### PR TITLE
adds BCH to coins using setting from trezor and bip44

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ tags
 *.pbi
 *.cout
 
+#CLion
+.idea/
+CMakeLists.txt
+cmake-build-debug/

--- a/b
+++ b/b
@@ -52,8 +52,12 @@ def compile_protocol_buffers():
     version = json.load(open('version.json', 'r'))
     tag = 'v%s.%s.%s' % (version['MAJOR_VERSION'], version['MINOR_VERSION'], version['PATCH_VERSION'])
 
+    print('../%s' % DEVICE_PROTOCOL)
+
     if not os.path.exists('../%s' % DEVICE_PROTOCOL):
-        local('git clone -b %s https://github.com/keepkey/%s.git ../%s' % (tag, DEVICE_PROTOCOL, DEVICE_PROTOCOL))
+        # TODO: uncomment and return to refer to keepkey repo
+        # local('git clone -b %s https://github.com/keepkey/%s.git ../%s' % (tag, DEVICE_PROTOCOL, DEVICE_PROTOCOL))
+        local('git clone -b %s https://github.com/afg419/%s.git ../%s' % ("1bccSpike", DEVICE_PROTOCOL, DEVICE_PROTOCOL))
 
     if not os.path.exists('interface/local'):
         os.mkdir('interface/local')

--- a/interface/public/messages.options
+++ b/interface/public/messages.options
@@ -2,7 +2,7 @@ Features.vendor				max_size:33
 Features.device_id			max_size:25
 Features.language			max_size:17
 Features.label				max_size:33
-Features.coins				max_count:8
+Features.coins				max_count:9
 Features.revision			max_size:20
 Features.bootloader_hash		max_size:32
 Features.policies			max_count:1

--- a/keepkey/local/baremetal/coins.c
+++ b/keepkey/local/baremetal/coins.c
@@ -28,15 +28,15 @@
 /* === Variables =========================================================== */
 
 const CoinType coins[COINS_COUNT] = {
-    {true, "Bitcoin",  true, "BTC",  true,   0, true,     100000, true,   5, true,  6, true, 10, true, "\x18" "Bitcoin Signed Message:\n", true, 0x80000000},
-    {true, "Testnet",  true, "TEST", true, 111, true,   10000000, true, 196, true,  3, true, 40, true, "\x18" "Bitcoin Signed Message:\n", true, 0x80000001},
-    {true, "Bcash",    true, "BCH",  true,   0, true,     500000, true,   5, false, 0, false, 0, true, "\x18" "BCCash Signed Message:\n",   true, 0x80000091},
-    {true, "Namecoin", true, "NMC",  true,  52, true,   10000000, true,   5, false, 0, false, 0, true, "\x19" "Namecoin Signed Message:\n", true, 0x80000007},
-    {true, "Litecoin", true, "LTC",  true,  48, true,    1000000, true,   5, false, 0, false, 0, true, "\x19" "Litecoin Signed Message:\n", true, 0x80000002},
-    {true, "Dogecoin", true, "DOGE", true,  30, true, 1000000000, true,  22, false, 0, false, 0, true, "\x19" "Dogecoin Signed Message:\n", true, 0x80000003},
-    {true, "Dash",     true, "DASH", true,  76, true,     100000, true,  16, false, 0, false, 0, true, "\x19" "DarkCoin Signed Message:\n", true, 0x80000005},
-    {true, ETHEREUM,   true, "ETH",  true,  NA, true,     100000, true,  NA, false, 0, false, 0, true, "\x19" "Ethereum Signed Message:\n", true, 0x8000003c},
-    {true, ETHEREUM_CLS, true, "ETC",  true, NA, true,   100000, true,  NA, false, 0, false, 0, true, "\x19" "Ethereum Signed Message:\n", true, 0x8000003d}
+    {true, "Bitcoin",  true, "BTC",  true,   0, true,     100000, true,   5, true,  6, true, 10, true, "\x18" "Bitcoin Signed Message:\n", true, 0x80000000, false, 0},
+    {true, "Testnet",  true, "TEST", true, 111, true,   10000000, true, 196, true,  3, true, 40, true, "\x18" "Bitcoin Signed Message:\n", true, 0x80000001, false, 0},
+    {true, "Bcash",    true, "BCH",  true,   0, true,     500000, true,   5, false, 0, false, 0, true, "\x18" "BCCash Signed Message:\n",   true, 0x80000091, true, 0},
+    {true, "Namecoin", true, "NMC",  true,  52, true,   10000000, true,   5, false, 0, false, 0, true, "\x19" "Namecoin Signed Message:\n", true, 0x80000007, false, 0},
+    {true, "Litecoin", true, "LTC",  true,  48, true,    1000000, true,   5, false, 0, false, 0, true, "\x19" "Litecoin Signed Message:\n", true, 0x80000002, false, 0},
+    {true, "Dogecoin", true, "DOGE", true,  30, true, 1000000000, true,  22, false, 0, false, 0, true, "\x19" "Dogecoin Signed Message:\n", true, 0x80000003, false, 0},
+    {true, "Dash",     true, "DASH", true,  76, true,     100000, true,  16, false, 0, false, 0, true, "\x19" "DarkCoin Signed Message:\n", true, 0x80000005, false, 0},
+    {true, ETHEREUM,   true, "ETH",  true,  NA, true,     100000, true,  NA, false, 0, false, 0, true, "\x19" "Ethereum Signed Message:\n", true, 0x8000003c, false, 0},
+    {true, ETHEREUM_CLS, true, "ETC",  true, NA, true,   100000, true,  NA, false, 0, false, 0, true, "\x19" "Ethereum Signed Message:\n", true, 0x8000003d, false, 0}
 };
 
 /* === Private Functions =================================================== */

--- a/keepkey/local/baremetal/coins.c
+++ b/keepkey/local/baremetal/coins.c
@@ -30,6 +30,7 @@
 const CoinType coins[COINS_COUNT] = {
     {true, "Bitcoin",  true, "BTC",  true,   0, true,     100000, true,   5, true,  6, true, 10, true, "\x18" "Bitcoin Signed Message:\n", true, 0x80000000},
     {true, "Testnet",  true, "TEST", true, 111, true,   10000000, true, 196, true,  3, true, 40, true, "\x18" "Bitcoin Signed Message:\n", true, 0x80000001},
+    {true, "Bcash",    true, "BCH",  true,   0, true,     500000, true,   5, false, 0, false, 0, true, "\x18" "BCCash Signed Message:\n",   true, 0x80000091},
     {true, "Namecoin", true, "NMC",  true,  52, true,   10000000, true,   5, false, 0, false, 0, true, "\x19" "Namecoin Signed Message:\n", true, 0x80000007},
     {true, "Litecoin", true, "LTC",  true,  48, true,    1000000, true,   5, false, 0, false, 0, true, "\x19" "Litecoin Signed Message:\n", true, 0x80000002},
     {true, "Dogecoin", true, "DOGE", true,  30, true, 1000000000, true,  22, false, 0, false, 0, true, "\x19" "Dogecoin Signed Message:\n", true, 0x80000003},

--- a/keepkey/local/baremetal/signing.c
+++ b/keepkey/local/baremetal/signing.c
@@ -38,6 +38,8 @@
 
 /* === Private Variables =================================================== */
 
+static uint8_t hash_prevouts[32], hash_sequence[32],hash_outputs[32];
+
 static uint32_t inputs_count;
 static uint32_t outputs_count;
 static const CoinType *coin;
@@ -49,7 +51,7 @@ static TxRequest resp;
 static TxInputType input;
 static TxOutputBinType bin_output;
 static TxStruct to, tp, ti;
-static SHA256_CTX tc[3];
+static SHA256_CTX tc;
 static uint8_t hash[32], hash_check[32], privkey[32], pubkey[33], sig[64];
 static uint64_t to_spend, spending, change_spend;
 static bool multisig_fp_set, multisig_fp_mismatch;
@@ -798,6 +800,7 @@ void signing_txack(TransactionType *tx)
 			}
 			return;
 		}
+
 		case STAGE_REQUEST_4_INPUT:
 			if (idx2 == 0) {
 				tx_init(&ti, inputs_count, outputs_count, version, lock_time, true);
@@ -876,14 +879,42 @@ void signing_txack(TransactionType *tx)
 					signing_abort();
 					return;
 				}
-				tx_hash_final(&ti, hash, false);
+
+				uint8_t sighash;
+				if(coin->has_forkid){
+					if (!compile_input_script_sig(&input)) {
+						fsm_sendFailure(FailureType_Failure_Other, ("Failed to compile input"));
+						signing_abort();
+						return;
+					}
+					if (!input.has_amount) {
+						fsm_sendFailure(FailureType_Failure_Other, ("SIGHASH_FORKID input without amount"));
+						signing_abort();
+						return;
+					}
+					if (input.amount > to_spend) {
+						fsm_sendFailure(FailureType_Failure_Other, ("Transaction has changed during signing"));
+						signing_abort();
+						return;
+					}
+					to_spend -= input.amount;
+
+					sighash = SIGHASH_ALL | SIGHASH_FORKID;
+					signing_hash_bip143(&input, sighash, coin->forkid, hash);
+				} else {
+					sighash = SIGHASH_ALL;
+					tx_hash_final(&ti, hash, false);
+				}
+
 				resp.has_serialized = true;
 				resp.serialized.has_signature_index = true;
 				resp.serialized.signature_index = idx1;
 				resp.serialized.has_signature = true;
 				resp.serialized.has_serialized_tx = true;
+
 				ecdsa_sign_digest(&secp256k1, privkey, hash, sig, 0);
 				resp.serialized.signature.size = ecdsa_sig_to_der(sig, resp.serialized.signature.bytes);
+
 				if (input.script_type == InputScriptType_SPENDMULTISIG) {
 					if (!input.has_multisig) {
 						fsm_sendFailure(FailureType_Failure_Other, "Multisig info not provided");
@@ -899,7 +930,7 @@ void signing_txack(TransactionType *tx)
 					}
 					memcpy(input.multisig.signatures[pubkey_idx].bytes, resp.serialized.signature.bytes, resp.serialized.signature.size);
 					input.multisig.signatures[pubkey_idx].size = resp.serialized.signature.size;
-					input.script_sig.size = serialize_script_multisig(&(input.multisig), 0, input.script_sig.bytes);
+					input.script_sig.size = serialize_script_multisig(&(input.multisig), sighash, input.script_sig.bytes);
 					if (input.script_sig.size == 0) {
 						fsm_sendFailure(FailureType_Failure_Other, "Failed to serialize multisig script");
 						signing_abort();
@@ -954,94 +985,94 @@ void signing_abort(void)
 	}
 }
 
-static void signing_hash_bip143(const TxInputType *txinput, uint8_t sighash, uint32_t forkid, uint8_t *hash) {
+void signing_hash_bip143(const TxInputType *txinput, uint8_t sighash, uint32_t forkid, uint8_t *hashX) {
 	uint32_t hash_type = (forkid << 8) | sighash;
-	sha256_Init(&tc[0]);
-	sha256_Update(&tc[0], (const uint8_t *)&version, 4);
-	sha256_Update(&tc[0], hash_prevouts, 32);
-	sha256_Update(&tc[0], hash_sequence, 32);
-	tx_prevout_hash(&tc[0], txinput);
-	tx_script_hash(&tc[0], txinput->script_sig.size, txinput->script_sig.bytes);
-	sha256_Update(&tc[0], (const uint8_t*) &txinput->amount, 8);
-	tx_sequence_hash(&tc[0], txinput);
-	sha256_Update(&tc[0], hash_outputs, 32);
-	sha256_Update(&tc[0], (const uint8_t*) &lock_time, 4);
-	sha256_Update(&tc[0], (const uint8_t*) &hash_type, 4);
-	sha256_Final(&tc[0], hash);
-	sha256_Raw(hash, 32, hash);
+	sha256_Init(&tc);
+	sha256_Update(&tc, (const uint8_t *)&version, 4);
+	sha256_Update(&tc, hash_prevouts, 32);
+	sha256_Update(&tc, hash_sequence, 32);
+	tx_prevout_hash(&tc, txinput);
+	tx_script_hash(&tc, txinput->script_sig.size, txinput->script_sig.bytes);
+	sha256_Update(&tc, (const uint8_t*) &txinput->amount, 8);
+	tx_sequence_hash(&tc, txinput);
+	sha256_Update(&tc, hash_outputs, 32);
+	sha256_Update(&tc, (const uint8_t*) &lock_time, 4);
+	sha256_Update(&tc, (const uint8_t*) &hash_type, 4);
+	sha256_Final(&tc, hashX);
+	sha256_Raw(hashX, 32, hashX);
 }
-
-static bool signing_sign_input(void) {
-	uint8_t hash[32];
-	sha256_Final(&tc[0], hash);
-	sha256_Raw(hash, 32, hash);
-	if (memcmp(hash, hash_check, 32) != 0) {
-		fsm_sendFailure(FailureType_Failure_Other, _("Transaction has changed during signing"));
-		signing_abort();
-		return false;
-	}
-
-	uint8_t sighash;
-	if (coin->has_forkid) {
-		if (!compile_input_script_sig(&input)) {
-			fsm_sendFailure(FailureType_Failure_Other, _("Failed to compile input"));
-			signing_abort();
-			return false;
-		}
-		if (!input.has_amount) {
-			fsm_sendFailure(FailureType_Failure_Other, _("SIGHASH_FORKID input without amount"));
-			signing_abort();
-			return false;
-		}
-		if (input.amount > to_spend) {
-			fsm_sendFailure(FailureType_Failure_Other, _("Transaction has changed during signing"));
-			signing_abort();
-			return false;
-		}
-		to_spend -= input.amount;
-
-		sighash = SIGHASH_ALL | SIGHASH_FORKID;
-		signing_hash_bip143(&input, sighash, coin->forkid, hash);
-	} else {
-		sighash = SIGHASH_ALL;
-		tx_hash_final(&ti, hash, false);
-	}
-
-	resp.has_serialized = true;
-	resp.serialized.has_signature_index = true;
-	resp.serialized.signature_index = idx1;
-	resp.serialized.has_signature = true;
-	resp.serialized.has_serialized_tx = true;
-	if (ecdsa_sign_digest(&secp256k1, privkey, hash, sig, NULL) != 0) {
-		fsm_sendFailure(FailureType_Failure_Other, _("Signing failed"));
-		signing_abort();
-		return false;
-	}
-	resp.serialized.signature.size = ecdsa_sig_to_der(sig, resp.serialized.signature.bytes);
-
-	if (input.has_multisig) {
-		// fill in the signature
-		int pubkey_idx = cryptoMultisigPubkeyIndex(&(input.multisig), pubkey);
-		if (pubkey_idx < 0) {
-			fsm_sendFailure(FailureType_Failure_Other, _("Pubkey not found in multisig script"));
-			signing_abort();
-			return false;
-		}
-		memcpy(input.multisig.signatures[pubkey_idx].bytes, resp.serialized.signature.bytes, resp.serialized.signature.size);
-		input.multisig.signatures[pubkey_idx].size = resp.serialized.signature.size;
-		input.script_sig.size = serialize_script_multisig(&(input.multisig), sighash, input.script_sig.bytes);
-		if (input.script_sig.size == 0) {
-			fsm_sendFailure(FailureType_Failure_Other, _("Failed to serialize multisig script"));
-			signing_abort();
-			return false;
-		}
-	} else { // SPENDADDRESS
-		input.script_sig.size = serialize_script_sig(resp.serialized.signature.bytes, resp.serialized.signature.size,
-													 pubkey, 33, 0, sighash);
-	}
-	resp.serialized.serialized_tx.size = tx_serialize_input(&to, &input, resp.serialized.serialized_tx.bytes);
-	return true;
-}
+//
+//static bool signing_sign_input(void) {
+//	uint8_t hash[32];
+//	sha256_Final(&tc[0], hash);
+//	sha256_Raw(hash, 32, hash);
+//	if (memcmp(hash, hash_check, 32) != 0) {
+//		fsm_sendFailure(FailureType_Failure_Other, ("Transaction has changed during signing"));
+//		signing_abort();
+//		return false;
+//	}
+//
+//	uint8_t sighash;
+//	if (coin->has_forkid) {
+//		if (!compile_input_script_sig(&input)) {
+//			fsm_sendFailure(FailureType_Failure_Other, ("Failed to compile input"));
+//			signing_abort();
+//			return false;
+//		}
+//		if (!input.has_amount) {
+//			fsm_sendFailure(FailureType_Failure_Other, ("SIGHASH_FORKID input without amount"));
+//			signing_abort();
+//			return false;
+//		}
+//		if (input.amount > to_spend) {
+//			fsm_sendFailure(FailureType_Failure_Other, ("Transaction has changed during signing"));
+//			signing_abort();
+//			return false;
+//		}
+//		to_spend -= input.amount;
+//
+//		sighash = SIGHASH_ALL | SIGHASH_FORKID;
+//		signing_hash_bip143(&input, sighash, coin->forkid, hash);
+//	} else {
+//		sighash = SIGHASH_ALL;
+//		tx_hash_final(&ti, hash, false);
+//	}
+//
+//	resp.has_serialized = true;
+//	resp.serialized.has_signature_index = true;
+//	resp.serialized.signature_index = idx1;
+//	resp.serialized.has_signature = true;
+//	resp.serialized.has_serialized_tx = true;
+//	if (ecdsa_sign_digest(&secp256k1, privkey, hash, sig, NULL) != 0) {
+//		fsm_sendFailure(FailureType_Failure_Other, ("Signing failed"));
+//		signing_abort();
+//		return false;
+//	}
+//	resp.serialized.signature.size = ecdsa_sig_to_der(sig, resp.serialized.signature.bytes);
+//
+//	if (input.has_multisig) {
+//		// fill in the signature
+//		int pubkey_idx = cryptoMultisigPubkeyIndex(&(input.multisig), pubkey);
+//		if (pubkey_idx < 0) {
+//			fsm_sendFailure(FailureType_Failure_Other, ("Pubkey not found in multisig script"));
+//			signing_abort();
+//			return false;
+//		}
+//		memcpy(input.multisig.signatures[pubkey_idx].bytes, resp.serialized.signature.bytes, resp.serialized.signature.size);
+//		input.multisig.signatures[pubkey_idx].size = resp.serialized.signature.size;
+//		input.script_sig.size = serialize_script_multisig(&(input.multisig), sighash, input.script_sig.bytes);
+//		if (input.script_sig.size == 0) {
+//			fsm_sendFailure(FailureType_Failure_Other, ("Failed to serialize multisig script"));
+//			signing_abort();
+//			return false;
+//		}
+//	} else { // SPENDADDRESS
+//		input.script_sig.size = serialize_script_sig(resp.serialized.signature.bytes, resp.serialized.signature.size,
+//													 pubkey, 33, 0, sighash);
+//	}
+//	resp.serialized.serialized_tx.size = tx_serialize_input(&to, &input, resp.serialized.serialized_tx.bytes);
+//	return true;
+//}
 
 bool compile_input_script_sig(TxInputType *tinput)
 {
@@ -1064,9 +1095,31 @@ bool compile_input_script_sig(TxInputType *tinput)
 	if (tinput->has_multisig) {
 		tinput->script_sig.size = compile_script_multisig(&(tinput->multisig), tinput->script_sig.bytes);
 	} else { // SPENDADDRESS
-		uint8_t hash[20];
-		ecdsa_get_pubkeyhash(node.public_key, hash);
-		tinput->script_sig.size = compile_script_sig(coin->address_type, hash, tinput->script_sig.bytes);
+		uint8_t hashX[20];
+		ecdsa_get_pubkeyhash(node.public_key, hashX);
+		tinput->script_sig.size = compile_script_sig(coin->address_type, hashX, tinput->script_sig.bytes);
 	}
 	return tinput->script_sig.size > 0;
+}
+
+uint32_t tx_prevout_hash(SHA256_CTX *ctx, const TxInputType *tinput)
+{
+	for (int i = 0; i < 32; i++) {
+		sha256_Update(ctx, &(tinput->prev_hash.bytes[31 - i]), 1);
+	}
+	sha256_Update(ctx, (const uint8_t *)&tinput->prev_index, 4);
+	return 36;
+}
+
+uint32_t tx_script_hash(SHA256_CTX *ctx, uint32_t size, const uint8_t *data)
+{
+	int r = ser_length_hash(ctx, size);
+	sha256_Update(ctx, data, size);
+	return r + size;
+}
+
+uint32_t tx_sequence_hash(SHA256_CTX *ctx, const TxInputType *tinput)
+{
+	sha256_Update(ctx, (const uint8_t *)&tinput->sequence, 4);
+	return 4;
 }

--- a/keepkey/local/baremetal/transaction.c
+++ b/keepkey/local/baremetal/transaction.c
@@ -263,18 +263,19 @@ uint32_t compile_script_multisig_hash(const MultisigRedeemScriptType *multisig, 
 	return 1;
 }
 
-uint32_t serialize_script_sig(const uint8_t *signature, uint32_t signature_len, const uint8_t *pubkey, uint32_t pubkey_len, uint8_t *out)
+uint32_t serialize_script_sig(const uint8_t *signature, uint32_t signature_len, const uint8_t *pubkey, uint32_t pubkey_len,
+							  uint8_t sighash, uint8_t *out)
 {
 	uint32_t r = 0;
 	r += op_push(signature_len + 1, out + r);
 	memcpy(out + r, signature, signature_len); r += signature_len;
-	out[r] = 0x01; r++;
+	out[r] = sighash; r++;
 	r += op_push(pubkey_len, out + r);
 	memcpy(out + r, pubkey, pubkey_len); r += pubkey_len;
 	return r;
 }
 
-uint32_t serialize_script_multisig(const MultisigRedeemScriptType *multisig, uint8_t *out)
+uint32_t serialize_script_multisig(const MultisigRedeemScriptType *multisig, uint8_t sighash, uint8_t *out)
 {
 	uint32_t i, r = 0;
 	out[r] = 0x00; r++;
@@ -284,7 +285,7 @@ uint32_t serialize_script_multisig(const MultisigRedeemScriptType *multisig, uin
 		}
 		r += op_push(multisig->signatures[i].size + 1, out + r);
 		memcpy(out + r, multisig->signatures[i].bytes, multisig->signatures[i].size); r += multisig->signatures[i].size;
-		out[r] = 0x01; r++;
+		out[r] = sighash; r++;
 	}
 	uint32_t script_len = compile_script_multisig(multisig, 0);
 	if (script_len == 0) {

--- a/keepkey/public/signing.h
+++ b/keepkey/public/signing.h
@@ -43,5 +43,11 @@ void signing_abort(void);
 void parse_raw_txack(uint8_t *msg, uint32_t msg_size);
 void signing_txack(TransactionType *tx);
 void send_fsm_co_error_message(int co_error);
+uint32_t tx_prevout_hash(SHA256_CTX *ctx, const TxInputType *input);
+uint32_t tx_script_hash(SHA256_CTX *ctx, uint32_t size, const uint8_t *data);
+uint32_t tx_sequence_hash(SHA256_CTX *ctx, const TxInputType *input);
+void signing_hash_bip143(const TxInputType *txinput, uint8_t sighash, uint32_t forkid, uint8_t *hash);
+bool compile_input_script_sig(TxInputType *tinput);
+
 
 #endif

--- a/keepkey/public/transaction.h
+++ b/keepkey/public/transaction.h
@@ -57,8 +57,9 @@ typedef struct {
 uint32_t compile_script_sig(uint8_t address_type, const uint8_t *pubkeyhash, uint8_t *out);
 uint32_t compile_script_multisig(const MultisigRedeemScriptType *multisig, uint8_t *out);
 uint32_t compile_script_multisig_hash(const MultisigRedeemScriptType *multisig, uint8_t *hash);
-uint32_t serialize_script_sig(const uint8_t *signature, uint32_t signature_len, const uint8_t *pubkey, uint32_t pubkey_len, uint8_t *out);
-uint32_t serialize_script_multisig(const MultisigRedeemScriptType *multisig, uint8_t *out);
+uint32_t serialize_script_sig(const uint8_t *signature, uint32_t signature_len, const uint8_t *pubkey, uint32_t pubkey_len,
+							  uint8_t sighash, uint8_t *out);
+uint32_t serialize_script_multisig(const MultisigRedeemScriptType *multisig, uint8_t sighash, uint8_t *out);
 int compile_output(const CoinType *coin, const HDNode *root, TxOutputType *in, TxOutputBinType *out, bool needs_confirm);
 uint32_t tx_serialize_input(TxStruct *tx, const TxInputType *input, uint8_t *out);
 uint32_t tx_serialize_output(TxStruct *tx, const TxOutputBinType *output, uint8_t *out);


### PR DESCRIPTION
In python-keepkey/helloworld.py this code:
 bip32_path = client.expand_path("44'/145'/0'/0/0")
    address = client.get_address('Bcash', bip32_path)
    print('Bitcoin Cash address:', address)

is executing appropriately with this PR accepted and uploaded to the device.