### PR TITLE
Fix some more errors found when building with clang.

### DIFF
--- a/libopencm3/include/libopencm3/cm3/scb.h
+++ b/libopencm3/include/libopencm3/cm3/scb.h
@@ -431,11 +431,11 @@ struct scb_exception_stack_frame {
 			      : [frameptr]"=r" (f));			\
 	} while (0)
 
-void scb_reset_system(void) __attribute__((noreturn, naked));
+void scb_reset_system(void) __attribute__((noreturn));
 
 /* Those defined only on ARMv7 and above */
 #if defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)
-void scb_reset_core(void) __attribute__((noreturn, naked));
+void scb_reset_core(void) __attribute__((noreturn));
 void scb_set_priority_grouping(uint32_t prigroup);
 #endif
 

--- a/libopencm3/lib/cm3/vector.c
+++ b/libopencm3/lib/cm3/vector.c
@@ -59,7 +59,7 @@ vector_table_t vector_table = {
 	}
 };
 
-void WEAK __attribute__ ((naked)) reset_handler(void)
+void WEAK reset_handler(void)
 {
 	volatile unsigned *src, *dest;
 	funcp_t *fp;

--- a/libopencm3/lib/cm3/vector.c
+++ b/libopencm3/lib/cm3/vector.c
@@ -32,7 +32,7 @@ extern funcp_t __preinit_array_start, __preinit_array_end;
 extern funcp_t __init_array_start, __init_array_end;
 extern funcp_t __fini_array_start, __fini_array_end;
 
-void main(void);
+int main(void);
 void blocking_handler(void);
 void null_handler(void);
 
@@ -86,7 +86,7 @@ void WEAK __attribute__ ((naked)) reset_handler(void)
 	pre_main();
 
 	/* Call the application's entry point. */
-	main();
+	(void)main();
 
 	/* Destructors. */
 	for (fp = &__fini_array_start; fp < &__fini_array_end; fp++) {

--- a/libopencm3/lib/stm32/common/timer_common_all.c
+++ b/libopencm3/lib/stm32/common/timer_common_all.c
@@ -101,7 +101,13 @@ to alternate function push-pull outputs where the PWM output will appear.
 #include <libopencm3/stm32/timer.h>
 #include <libopencm3/stm32/rcc.h>
 
-#define ADVANCED_TIMERS (defined(TIM1_BASE) || defined(TIM8_BASE))
+#if defined(TIM1_BASE)
+#define ADVANCED_TIMERS (1)
+#elif defined(TIM8_BASE)
+#define ADVANCED_TIMERS (1)
+#else
+#define ADVANCED_TIMERS (0)
+#endif
 
 #if defined(TIM8)
 #define TIMER_IS_ADVANCED(periph) ((periph == TIM1) || (periph == TIM8))

--- a/libopencm3/scripts/irq2nvic_h
+++ b/libopencm3/scripts/irq2nvic_h
@@ -79,12 +79,12 @@ template_vector_nvic_c = '''\
  */
 
 
-/** @defgroup CM3_nvic_isrpragmas_{partname_doxygen} User interrupt service routines (ISR) defaults for {partname_humanreadable}
-    @ingroup CM3_nvic_isrpragmas
+/** @defgroup CM3_nvic_isrdecls_{partname_doxygen} User interrupt service routines (ISR) defaults for {partname_humanreadable}
+    @ingroup CM3_nvic_isrdecls
 
     @{{*/
 
-{isrpragmas}
+{isrdecls}
 
 /**@}}*/
 
@@ -122,7 +122,7 @@ def convert(infile, outfile_nvic, outfile_vectornvic, outfile_cmsis):
 
     data['irqdefinitions'] = "\n".join('#define NVIC_%s_IRQ %d'%(v.upper(),int(k)) for (k,v) in irq2name)
     data['isrprototypes'] = "\n".join('void WEAK %s_isr(void);'%name.lower() for name in irqnames)
-    data['isrpragmas'] = "\n".join('#pragma weak %s_isr = blocking_handler'%name.lower() for name in irqnames)
+    data['isrdecls'] = "\n".join('void %s_isr(void) __attribute__((weak, alias("blocking_handler")));'%name.lower() for name in irqnames)
     data['vectortableinitialization'] = ', \\\n    '.join('[NVIC_%s_IRQ] = %s_isr'%(name.upper(), name.lower()) for name in irqnames)
     data['cmsisbends'] = "\n".join("#define %s_IRQHandler %s_isr"%(name.upper(), name.lower()) for name in irqnames)
 


### PR DESCRIPTION
Some of this is subtle differences in the way clang handles various extensions to the language, and other parts of it are fixes for stricter warnings (+ -Werror).

I've put these on a separate branch from my other -Werror fixes, since this code comes from a different project. Ideally, I'd like to upstream those changes to the libopencm3 community, but I've got several extremely hacky patches used to build this that I haven't posted, and I have yet to actually test any of this.

With this set of patches, those from the other pull request, and the unpublished hacky ones (which paper over s/arm-none-eabi-gcc/arm-none-eabi-clang/ sorts of differences), I've got everything built with my clang+newlib toolchain (pending an issue with lld's parsing of linker scripts, which I need to "phone a friend" about).

Again, this hasn't been tested, so please do so before merging this.