### PR TITLE
Fix UB in pin failure timeout printing

### DIFF
--- a/keepkey/local/baremetal/pin_sm.c
+++ b/keepkey/local/baremetal/pin_sm.c
@@ -298,12 +298,12 @@ bool pin_protect(char *prompt)
         {
             if(failed_cnts > 2)
             {
+                wait = (failed_cnts < 32) ? (1u << failed_cnts) : 0xFFFFFFFF;
+
                 /* snprintf: 36 + 10 (%u) + 1 (NULL) = 47 */
                 snprintf(warn_msg_fmt, MEDIUM_STR_BUF, "Previous PIN Failures: Wait %u Seconds",
-                         1u << failed_cnts);
+                         wait);
                 layout_warning(warn_msg_fmt);
-
-                wait = (failed_cnts < 32) ? (1u << failed_cnts) : 0xFFFFFFFF;
 
                 while(--wait > 0)
                 {


### PR DESCRIPTION
The Undefined Behavior happens when failed_cnts > 31. See C99/C11: 6.5.7p3.

Even though it'll take ~272 years to reach failed_cnts == 32, the compiler is
allowed to assume this cannot happen, and optimize to that effect leading to
Bad Things (TM). Better to avoid that entirely.

Also, added benefit: the time displayed is now correct once failed_cnts == 32, should anyone that patient live long enough to visit the year 2244.