### PR TITLE
BTG Support

### DIFF
--- a/keepkey/local/baremetal/coins.c
+++ b/keepkey/local/baremetal/coins.c
@@ -28,10 +28,13 @@
 
 /* === Variables =========================================================== */
 
+
+//Coin name, coin shortcut, address type p2pkh, max fee, address type p2sh, address type p2wpkh, address type p2wsh, signed message header, bip44_account_path, forkId
 const CoinType coins[COINS_COUNT] = {
         {true, "Bitcoin",     true, "BTC",  true,   0, true,     100000, true,   5, true,  6, true, 10, true,  "\x18" "Bitcoin Signed Message:\n",  true, 0x80000000, false, 0, true,   8, false, {0, {0}},                                          false, {0, {0}}},
         {true, "Testnet",     true, "TEST", true, 111, true,   10000000, true, 196, true,  3, true, 40, true,  "\x18" "Bitcoin Signed Message:\n",  true, 0x80000001, false, 0, true,   8, false, {0, {0}},                                          false, {0, {0}}},
         {true, "BitcoinCash", true, "BCH",  true,   0, true,     500000, true,   5, false, 0, false, 0, true,  "\x18" "Bitcoin Signed Message:\n",  true, 0x80000091, true,  0, true,   8, false, {0, {0}},                                          false, {0, {0}}},
+        {true, "Bitcoin Gold", true, "BTG",  true,   38, true,     500000, true,  23, false, 0, false, 0, true,  "\x18" "Bitcoin Signed Message:\n",  true, 0x8000009c, true,  79, true,   8, false, {0, {0}},                                          false, {0, {0}}},
         {true, "Namecoin",    true, "NMC",  true,  52, true,   10000000, true,   5, false, 0, false, 0, true,  "\x19" "Namecoin Signed Message:\n", true, 0x80000007, false, 0, true,   8, false, {0, {0}},                                          false, {0, {0}}},
         {true, "Litecoin",    true, "LTC",  true,  48, true,    1000000, true,   5, false, 0, false, 0, true,  "\x19" "Litecoin Signed Message:\n", true, 0x80000002, false, 0, true,   8, false, {0, {0}},                                          false, {0, {0}}},
         {true, "Dogecoin",    true, "DOGE", true,  30, true, 1000000000, true,  22, false, 0, false, 0, true,  "\x19" "Dogecoin Signed Message:\n", true, 0x80000003, false, 0, true,   8, false, {0, {0}},                                          false, {0, {0}}},


### PR DESCRIPTION
Hello KeepKey team!
I have added configuration for BTG. I am not able to test it because of the firmware signing that you do. 

- Mind that I included the BTG forkId (79), but I'm not sure if it is on the right place in the config.

Also mind that currently the device can be tested with BTG version of Electrum (called ElectrumG), you can check it from here - https://github.com/BTCGPU/electrum .

