### PR TITLE
Bootloader mode wipe_device also erases firmware

### DIFF
--- a/include/keepkey/board/bl_mpu.h
+++ b/include/keepkey/board/bl_mpu.h
@@ -19,6 +19,9 @@
 #ifndef __BL_MPU_H__
 #define __BL_MPU_H__
 
+#include "memory.h"
+
 void bl_flash_erase_word(Allocation group);
+void bl_flash_erase_sector(int sector);
 
 #endif

--- a/tools/bootloader/bl_mpu.c
+++ b/tools/bootloader/bl_mpu.c
@@ -17,6 +17,8 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "keepkey/board/bl_mpu.h"
+
 #ifndef EMULATOR
 #include <libopencm3/stm32/flash.h>
 #include <libopencm3/stm32/timer.h>
@@ -49,6 +51,21 @@ void bl_flash_erase_word(Allocation group)
     while(s->use != FLASH_INVALID)
     {
         if(s->use == group) {
+            bl_flash_erase_sector(s->sector);
+        }
+        ++s;
+    }
+#endif
+}
+
+
+// bootloader-only flash-erase that erases a given sector in 32bit chunks
+void bl_flash_erase_sector(int sector) {
+#ifndef EMULATOR
+    const FlashSector* s = flash_sector_map;
+    while(s->use != FLASH_INVALID)
+    {
+        if(s->sector == sector) {
 			// unlock the flash
 			flash_clear_status_flags();
 			flash_unlock();
@@ -64,6 +81,7 @@ void bl_flash_erase_word(Allocation group)
 			/* lock flash register */
 			FLASH_CR |= FLASH_CR_LOCK;
 			/* return flash status register */
+                        break;
         }
         ++s;
     }

--- a/tools/bootloader/main.c
+++ b/tools/bootloader/main.c
@@ -200,6 +200,7 @@ static bool isFirmwareUpdateMode(void)
     if (keepkey_button_down())
         return true;
 
+    // Firmware isn't there?
     if (!magic_ok())
         return true;
 

--- a/tools/bootloader/usb_flash.c
+++ b/tools/bootloader/usb_flash.c
@@ -530,17 +530,17 @@ void handler_wipe(WipeDevice *msg)
     /* Erase config data sectors  */
     for (uint32_t i = FLASH_STORAGE1; i <= FLASH_STORAGE3; i++) {
         bl_flash_erase_word(i);
-        layoutProgress("Erasing secrets", (i * 1000 / 9));
+        layoutProgress("Erasing Secrets", (i * 1000 / 8));
     }
 
     /* Erase application section */
     for (int i = 7; i <= 11; ++i) {
-        bl_flash_erase_word(i);
-        layoutProgress("Erasing firmware", ((i + 3 - 7 + 2) * 1000 / 9));
+        bl_flash_erase_sector(i);
+        layoutProgress("Erasing Firmware", ((i + 3 - 7 + 2) * 1000 / 8));
     }
 
     flash_lock();
-    layoutProgress("Erasing firmware", 1000);
+    layoutProgress("Erasing Firmware", 1000);
 
     layout_home();
     send_success("Device wiped");

--- a/tools/bootloader/usb_flash.c
+++ b/tools/bootloader/usb_flash.c
@@ -530,17 +530,17 @@ void handler_wipe(WipeDevice *msg)
     /* Erase config data sectors  */
     for (uint32_t i = FLASH_STORAGE1; i <= FLASH_STORAGE3; i++) {
         bl_flash_erase_word(i);
-        layoutProgress("Preparing for upgrade", (i * 1000 / 9));
+        layoutProgress("Erasing secrets", (i * 1000 / 9));
     }
 
     /* Erase application section */
     for (int i = 7; i <= 11; ++i) {
         bl_flash_erase_word(i);
-        layoutProgress("Preparing for upgrade", ((i + 3 - 7 + 2) * 1000 / 9));
+        layoutProgress("Erasing firmware", ((i + 3 - 7 + 2) * 1000 / 9));
     }
 
     flash_lock();
-    layoutProgress("Preparing for upgrade", 100);
+    layoutProgress("Erasing firmware", 1000);
 
     layout_home();
     send_success("Device wiped");


### PR DESCRIPTION
Similar behavior to how Trezor handles wipe device in bootloader mode