### PR TITLE
layout: erase the lock status before going to screensaver

### DIFF
--- a/lib/firmware/app_layout.c
+++ b/lib/firmware/app_layout.c
@@ -340,9 +340,7 @@ void layout_screen_test(void)
  */
 void layout_screensaver(void)
 {
-    draw_box_simple(layout_get_canvas(), 0x00, 0, 0,
-                    KEEPKEY_DISPLAY_WIDTH,
-                    KEEPKEY_DISPLAY_HEIGHT);
+    layout_clear();
 
     layout_add_animation(
         &layout_animate_images,

--- a/lib/firmware/home_sm.c
+++ b/lib/firmware/home_sm.c
@@ -84,8 +84,6 @@ void layoutHomeForced(void)
     home_state = AT_HOME;
 }
 
-
-
 /*
  * leave_home() - Leaves home screen
  *
@@ -139,6 +137,7 @@ void toggle_screensaver(void)
         case SCREENSAVER:
             if (idle_time < storage_getAutoLockDelayMs()) {
                 layout_home();
+                layoutLockedState();
                 home_state = AT_HOME;
             }
 


### PR DESCRIPTION
... so it doesn't show up partially on the screensaver page.