### PR TITLE
ROM Size Optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,14 @@ add_definitions(-DED25519_CUSTOMRANDOM=1)
 add_definitions(-DED25519_NO_INLINE_ASM)
 add_definitions(-DED25519_FORCE_32BIT=1)
 
+add_definitions(-DUSE_PRECOMPUTED_CP=0)
+
 add_definitions(-DUSE_ETHEREUM=1)
+add_definitions(-DUSE_KECCAK=1)
+add_definitions(-DUSE_GRAPHENE=0)
 add_definitions(-DUSE_CARDANO=0)
 add_definitions(-DUSE_MONERO=0)
+add_definitions(-DUSE_NEM=0)
 add_definitions(-DUSE_NANO=1)
 
 add_definitions(-DRAND_PLATFORM_INDEPENDENT=0)

--- a/include/keepkey/firmware/ethereum_tokens.h
+++ b/include/keepkey/firmware/ethereum_tokens.h
@@ -36,10 +36,10 @@ enum {
 #define TOKENS_COUNT ((int)TokenIndexLast-(int)TokenIndexFirst)
 
 typedef struct _TokenType {
-    uint8_t chain_id;
     const char * const address;
     const char * const ticker;
-    int decimals;
+    uint8_t chain_id;
+    uint8_t decimals;
 } TokenType;
 
 typedef struct _CoinType CoinType;

--- a/lib/firmware/ethereum_tokens.c
+++ b/lib/firmware/ethereum_tokens.c
@@ -6,7 +6,7 @@
 
 const TokenType tokens[] = {
 #define X(CHAIN_ID, CONTRACT_ADDR, TICKER, DECIMALS) \
-    { (CHAIN_ID), (CONTRACT_ADDR), (TICKER), (DECIMALS) },
+    { (CONTRACT_ADDR), (TICKER), (CHAIN_ID), (DECIMALS) },
 #include "keepkey/firmware/ethereum_tokens.def"
 };
 


### PR DESCRIPTION
Fixes some "easy wins" on #190, but of course we should do lots more.

This particular patch brings us down to 623k, which is below the current cap of 655k.