### PR TITLE
bootloader: display unofficial hash in chunks

### DIFF
--- a/include/keepkey/board/layout.h
+++ b/include/keepkey/board/layout.h
@@ -127,4 +127,5 @@ void layout_clear_animations(void);
 void layout_clear_static(void);
 
 void kk_strupr(char *str);
+void kk_strlwr(char *str);
 #endif

--- a/lib/board/layout.c
+++ b/lib/board/layout.c
@@ -268,6 +268,11 @@ void kk_strupr(char *str) {
         *str = toupper(*str);
 }
 
+void kk_strlwr(char *str) {
+    for ( ; *str; str++)
+        *str = tolower(*str);
+}
+
 /*
  * layout_standard_notification() - Display standard notification
  *

--- a/tools/bootloader/main.c
+++ b/tools/bootloader/main.c
@@ -271,6 +271,8 @@ static void boot(void)
         data2hex(flashed_firmware_hash + 20, 4, hash_str[5]);
         data2hex(flashed_firmware_hash + 24, 4, hash_str[6]);
         data2hex(flashed_firmware_hash + 28, 4, hash_str[7]);
+        for (int i = 0; i < 8; i++)
+            kk_strlwr(hash_str[i]);
         if (!confirm_without_button_request("Unofficial Firmware",
                                             "Are you willing to take the risk?\n"
                                             "%s %s %s %s\n"

--- a/tools/bootloader/main.c
+++ b/tools/bootloader/main.c
@@ -262,12 +262,21 @@ static void boot(void)
         uint8_t flashed_firmware_hash[SHA256_DIGEST_LENGTH];
         memzero(flashed_firmware_hash, sizeof(flashed_firmware_hash));
         memory_firmware_hash(flashed_firmware_hash);
-        char hash_str[2][2 * 16 + 1];
-        data2hex(flashed_firmware_hash,      16, hash_str[0]);
-        data2hex(flashed_firmware_hash + 16, 16, hash_str[1]);
+        char hash_str[8][2 * 4 + 1];
+        data2hex(flashed_firmware_hash,      4, hash_str[0]);
+        data2hex(flashed_firmware_hash +  4, 4, hash_str[1]);
+        data2hex(flashed_firmware_hash +  8, 4, hash_str[2]);
+        data2hex(flashed_firmware_hash + 12, 4, hash_str[3]);
+        data2hex(flashed_firmware_hash + 16, 4, hash_str[4]);
+        data2hex(flashed_firmware_hash + 20, 4, hash_str[5]);
+        data2hex(flashed_firmware_hash + 24, 4, hash_str[6]);
+        data2hex(flashed_firmware_hash + 28, 4, hash_str[7]);
         if (!confirm_without_button_request("Unofficial Firmware",
-                                            "Are you willing to take the risk?\n%s\n%s",
-                                            hash_str[0], hash_str[1])) {
+                                            "Are you willing to take the risk?\n"
+                                            "%s %s %s %s\n"
+                                            "%s %s %s %s",
+                                            hash_str[0], hash_str[1], hash_str[2], hash_str[3],
+                                            hash_str[4], hash_str[5], hash_str[6], hash_str[7])) {
             layout_simple_message("Boot Aborted");
             return;
         }

--- a/tools/bootloader/main.c
+++ b/tools/bootloader/main.c
@@ -262,23 +262,15 @@ static void boot(void)
         uint8_t flashed_firmware_hash[SHA256_DIGEST_LENGTH];
         memzero(flashed_firmware_hash, sizeof(flashed_firmware_hash));
         memory_firmware_hash(flashed_firmware_hash);
-        char hash_str[8][2 * 4 + 1];
-        data2hex(flashed_firmware_hash,      4, hash_str[0]);
-        data2hex(flashed_firmware_hash +  4, 4, hash_str[1]);
-        data2hex(flashed_firmware_hash +  8, 4, hash_str[2]);
-        data2hex(flashed_firmware_hash + 12, 4, hash_str[3]);
-        data2hex(flashed_firmware_hash + 16, 4, hash_str[4]);
-        data2hex(flashed_firmware_hash + 20, 4, hash_str[5]);
-        data2hex(flashed_firmware_hash + 24, 4, hash_str[6]);
-        data2hex(flashed_firmware_hash + 28, 4, hash_str[7]);
-        for (int i = 0; i < 8; i++)
-            kk_strlwr(hash_str[i]);
+        char hash_str[2 * 32 + 1];
+        data2hex(flashed_firmware_hash, 32, hash_str);
+        kk_strlwr(hash_str);
         if (!confirm_without_button_request("Unofficial Firmware",
                                             "Are you willing to take the risk?\n"
-                                            "%s %s %s %s\n"
-                                            "%s %s %s %s",
-                                            hash_str[0], hash_str[1], hash_str[2], hash_str[3],
-                                            hash_str[4], hash_str[5], hash_str[6], hash_str[7])) {
+                                            "%.8s %.8s %.8s %.8s\n"
+                                            "%.8s %.8s %.8s %.8s",
+                                            hash_str,      hash_str +  8, hash_str + 16, hash_str + 24,
+                                            hash_str + 32, hash_str + 40, hash_str + 48, hash_str + 56)) {
             layout_simple_message("Boot Aborted");
             return;
         }


### PR DESCRIPTION
This makes the hash easier to verify at a glance.