### PR TITLE
fix backwards logic in canDropPrivs()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.7.2)
 
 project(KeepKeyFirmware
 
-        VERSION 7.1.5
+        VERSION 7.1.6
 
         LANGUAGES C CXX ASM)
 

--- a/tools/firmware/keepkey_main.c
+++ b/tools/firmware/keepkey_main.c
@@ -95,7 +95,7 @@ static bool canDropPrivs(void) {
       // by this point already, and trying to drop privs *again* will cause a fault.
       bool sigPresent = sigindex1 >= 1 && sigindex1 <= BLK_v2_0_0_PUBKEYS;
       // delay before the security-critical branch instruction
-      return !fi_defense_delay(sigPresent);
+      return fi_defense_delay(sigPresent);
     }
   }
   __builtin_unreachable();


### PR DESCRIPTION
0527170 contained an extra `!` which, when using bootloader v2.0.0, breaks unsigned firmware and prevents signed builds from dropping their privs.

This error made it past our testing regime because it didn't trigger on our normal testing devices; props to @greatwolf for bringing it to our attention as #281.