### PR TITLE
fix isFirmwareUpdateMode()

### DIFF
--- a/tools/bootloader/main.c
+++ b/tools/bootloader/main.c
@@ -189,7 +189,7 @@ static bool isFirmwareUpdateMode(void) {
   // Check if the firmware wants us to boot into firmware update mode.
   // This is used to skip a hard reset after bootloader update, and drop the
   // user right back into the firmware update flow.
-  if ((FLASH_META_FLAGS & 1) == 1) return true;
+  if ((META_FLAGS & 1) == 1) return true;
 
   // If the firmware was signed with old signing keys, we also need to update.
   if (signed_firmware == KEY_EXPIRED) return true;


### PR DESCRIPTION
The macro [FLASH_META_FLAGS](https://github.com/keepkey/keepkey-firmware/blob/930d6ada7a15b3fd00bfef78ec855ae6fa7cc870/include/keepkey/board/memory.h#L139) is a pointer; it will always point to a 4-byte aligned location, and so this check will always be a no-op. [META_FLAGS](https://github.com/keepkey/keepkey-firmware/blob/930d6ada7a15b3fd00bfef78ec855ae6fa7cc870/include/keepkey/board/memory.h#L156) is the macro for the dereferenced version.

Of course, this neglects the fact that it's working fine already; I'm not entirely sure why!

Note that this check is repeated in [isUpdateRequired()](https://github.com/keepkey/keepkey-firmware/blob/930d6ada7a15b3fd00bfef78ec855ae6fa7cc870/tools/bootloader/usb_flash.c#L164) -- surely one of these must be wrong?