### PR TITLE
fix(zcash): update branch ID from Sapling to NU6

### DIFF
--- a/lib/firmware/signing.c
+++ b/lib/firmware/signing.c
@@ -624,7 +624,7 @@ void signing_init(const SignTx *msg, const CoinType *_coin,
         branch_id = 0x5BA81B19;  // Overwinter
         break;
       case 4:
-        branch_id = 0x76B809BB;  // Sapling
+        branch_id = 0xC8E71055;  // NU6
         break;
     }
   }


### PR DESCRIPTION
## Summary
- Updates Zcash branch ID constant from Sapling (`0x76B809BB`) to NU6 (`0xC8E71055`) in `lib/firmware/signing.c`
- Single-line change, zero new dependencies

## Test plan
- [ ] Build firmware with Zcash signing enabled
- [ ] Verify Zcash transactions use NU6 branch ID
- [ ] Confirm no regression on other UTXO chains