### PR TITLE
fix(zcash): update branch ID from Sapling to NU6

### DIFF
--- a/lib/firmware/signing.c
+++ b/lib/firmware/signing.c
@@ -624,7 +624,7 @@ void signing_init(const SignTx *msg, const CoinType *_coin,
         branch_id = 0x5BA81B19;  // Overwinter
         break;
       case 4:
-        branch_id = 0x76B809BB;  // Sapling
+        branch_id = 0xC8E71055;  // NU6
         break;
     }
   }


### PR DESCRIPTION
## Summary

Updates the Zcash consensus branch ID from Sapling (`0x76B809BB`) to NU6 (`0xC8E71055`) in `lib/firmware/signing.c:627`.

This is required for Zcash transactions to be valid on the current network. The Sapling branch ID is rejected by NU6 nodes.

## Changes

| File | Change |
|------|--------|
| `lib/firmware/signing.c` | 1 line: branch ID constant update |

**+1 / -1 LOC** — minimal, surgical change.

## Crypto dependencies

No new dependencies. Uses existing trezor-crypto primitives (unchanged).

## Test plan

- [ ] Build firmware (no compile errors)
- [ ] Sign a Zcash transaction — verify branch ID `0xC8E71055` in serialized tx
- [ ] Confirm no regression on BTC/LTC/other UTXO chains