### PR TITLE
feat(tron,ton): add TRON and TON chain support

### DIFF
--- a/include/keepkey/firmware/fsm.h
+++ b/include/keepkey/firmware/fsm.h
@@ -118,6 +118,11 @@ void fsm_msgMayachainGetAddress(const MayachainGetAddress *msg);
 void fsm_msgMayachainSignTx(const MayachainSignTx *msg);
 void fsm_msgMayachainMsgAck(const MayachainMsgAck *msg);
 
+void fsm_msgTronGetAddress(const TronGetAddress *msg);
+void fsm_msgTronSignTx(TronSignTx *msg);
+void fsm_msgTonGetAddress(const TonGetAddress *msg);
+void fsm_msgTonSignTx(TonSignTx *msg);
+
 #if DEBUG_LINK
 // void fsm_msgDebugLinkDecision(DebugLinkDecision *msg);
 void fsm_msgDebugLinkGetState(DebugLinkGetState *msg);

--- a/include/keepkey/firmware/ton.h
+++ b/include/keepkey/firmware/ton.h
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2024 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPKEY_FIRMWARE_TON_H
+#define KEEPKEY_FIRMWARE_TON_H
+
+#include "trezor/crypto/bip32.h"
+#include "trezor/crypto/ed25519-donna/ed25519.h"
+
+#include "messages-ton.pb.h"
+
+// TON address length (Base64 URL-safe encoded, typically 48 chars)
+#define TON_ADDRESS_MAX_LEN 64
+#define TON_RAW_ADDRESS_MAX_LEN 128
+
+// TON decimals (1 TON = 1,000,000,000 nanoTON)
+#define TON_DECIMALS 9
+
+/**
+ * Generate TON address from Ed25519 public key
+ * @param public_key Ed25519 public key (32 bytes)
+ * @param bounceable Bounceable flag for address encoding
+ * @param testnet Testnet flag for address encoding
+ * @param workchain Workchain ID (-1 or 0)
+ * @param address Output buffer for user-friendly Base64 encoded address
+ * @param address_len Length of address output buffer
+ * @param raw_address Output buffer for raw address format (workchain:hash)
+ * @param raw_address_len Length of raw_address output buffer
+ * @return true on success, false on failure
+ */
+bool ton_get_address(const ed25519_public_key public_key, bool bounceable,
+                     bool testnet, int32_t workchain, char *address,
+                     size_t address_len, char *raw_address,
+                     size_t raw_address_len);
+
+/**
+ * Format TON amount (nanoTON) for display
+ * @param buf Output buffer
+ * @param len Length of output buffer
+ * @param amount Amount in nanoTON (1 TON = 1,000,000,000 nanoTON)
+ */
+void ton_formatAmount(char *buf, size_t len, uint64_t amount);
+
+/**
+ * Sign a TON transaction
+ * @param node HD node containing private key
+ * @param msg TonSignTx request message
+ * @param resp TonSignedTx response message (will be filled with signature)
+ */
+void ton_signTx(const HDNode *node, const TonSignTx *msg, TonSignedTx *resp);
+
+#endif

--- a/include/keepkey/firmware/tron.h
+++ b/include/keepkey/firmware/tron.h
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2024 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPKEY_FIRMWARE_TRON_H
+#define KEEPKEY_FIRMWARE_TRON_H
+
+#include "trezor/crypto/bip32.h"
+
+#include "messages-tron.pb.h"
+
+// TRON address length (Base58Check, typically 34 chars starting with 'T')
+#define TRON_ADDRESS_MAX_LEN 64
+
+// TRON decimals (1 TRX = 1,000,000 SUN)
+#define TRON_DECIMALS 6
+
+/**
+ * Generate TRON address from secp256k1 public key
+ * @param public_key secp256k1 public key (33 bytes compressed)
+ * @param address Output buffer for Base58Check encoded address
+ * @param address_len Length of output buffer
+ * @return true on success, false on failure
+ */
+bool tron_getAddress(const uint8_t public_key[33], char *address,
+                     size_t address_len);
+
+/**
+ * Format TRON amount (SUN) for display
+ * @param buf Output buffer
+ * @param len Length of output buffer
+ * @param amount Amount in SUN (1 TRX = 1,000,000 SUN)
+ */
+void tron_formatAmount(char *buf, size_t len, uint64_t amount);
+
+/**
+ * Sign a TRON transaction
+ * @param node HD node containing private key
+ * @param msg TronSignTx request message
+ * @param resp TronSignedTx response message (will be filled with signature)
+ */
+void tron_signTx(const HDNode *node, const TronSignTx *msg,
+                 TronSignedTx *resp);
+
+#endif

--- a/include/keepkey/transport/interface.h
+++ b/include/keepkey/transport/interface.h
@@ -35,6 +35,8 @@
 #include "messages-tendermint.pb.h"
 #include "messages-thorchain.pb.h"
 #include "messages-mayachain.pb.h"
+#include "messages-tron.pb.h"
+#include "messages-ton.pb.h"
 
 #include "types.pb.h"
 #include "trezor_transport.h"

--- a/include/keepkey/transport/messages-ton.options
+++ b/include/keepkey/transport/messages-ton.options
@@ -1,0 +1,9 @@
+TonGetAddress.address_n max_count:8
+TonGetAddress.coin_name max_size:21
+TonSignTx.address_n max_count:8
+TonSignTx.coin_name max_size:21
+TonSignTx.raw_tx max_size:1024
+TonSignTx.to_address max_size:50
+TonAddress.address max_size:50
+TonAddress.raw_address max_size:70
+TonSignedTx.signature max_size:64

--- a/include/keepkey/transport/messages-tron.options
+++ b/include/keepkey/transport/messages-tron.options
@@ -1,0 +1,11 @@
+TronGetAddress.address_n max_count:8
+TronGetAddress.coin_name max_size:21
+TronSignTx.address_n max_count:8
+TronSignTx.coin_name max_size:21
+TronSignTx.raw_data max_size:1024
+TronSignTx.ref_block_bytes max_size:2
+TronSignTx.ref_block_hash max_size:8
+TronSignTx.contract_type max_size:50
+TronSignTx.to_address max_size:35
+TronAddress.address max_size:35
+TronSignedTx.signature max_size:65

--- a/lib/firmware/CMakeLists.txt
+++ b/lib/firmware/CMakeLists.txt
@@ -37,6 +37,8 @@ set(sources
     tendermint.c
     thorchain.c
     tiny-json.c
+    tron.c
+    ton.c
     transaction.c
     txin_check.c
     u2f.c)

--- a/lib/firmware/fsm.c
+++ b/lib/firmware/fsm.c
@@ -58,6 +58,8 @@
 #include "keepkey/firmware/storage.h"
 #include "keepkey/firmware/tendermint.h"
 #include "keepkey/firmware/thorchain.h"
+#include "keepkey/firmware/tron.h"
+#include "keepkey/firmware/ton.h"
 #include "keepkey/firmware/transaction.h"
 #include "keepkey/firmware/txin_check.h"
 #include "keepkey/firmware/u2f.h"
@@ -84,6 +86,8 @@
 #include "messages-ripple.pb.h"
 #include "messages-thorchain.pb.h"
 #include "messages-mayachain.pb.h"
+#include "messages-tron.pb.h"
+#include "messages-ton.pb.h"
 
 #include <stdio.h>
 
@@ -284,3 +288,5 @@ void fsm_msgClearSession(ClearSession *msg) {
 #include "fsm_msg_tendermint.h"
 #include "fsm_msg_thorchain.h"
 #include "fsm_msg_mayachain.h"
+#include "fsm_msg_tron.h"
+#include "fsm_msg_ton.h"

--- a/lib/firmware/fsm_msg_ton.h
+++ b/lib/firmware/fsm_msg_ton.h
@@ -1,0 +1,137 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2024 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+void fsm_msgTonGetAddress(const TonGetAddress *msg) {
+  RESP_INIT(TonAddress);
+
+  CHECK_INITIALIZED
+
+  CHECK_PIN
+
+  // Validate path: m/44'/607'/x'/x'/x'/x' (all hardened for TON)
+  if (msg->address_n_count < 6) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("Invalid path for TON address"));
+    layoutHome();
+    return;
+  }
+
+  // Derive node using Ed25519 curve
+  HDNode *node = fsm_getDerivedNode(ED25519_NAME, msg->address_n,
+                                    msg->address_n_count, NULL);
+  if (!node) return;
+  hdnode_fill_public_key(node);
+
+  // Extract TON-specific parameters with defaults
+  bool bounceable = msg->has_bounceable ? msg->bounceable : true;
+  bool testnet = msg->has_testnet ? msg->testnet : false;
+  int32_t workchain = msg->has_workchain ? msg->workchain : 0;
+
+  // Get TON address from public key (Base64 URL-safe encoding)
+  char address[MAX_ADDR_SIZE];
+  char raw_address[MAX_ADDR_SIZE];
+  if (!ton_get_address(&node->public_key[1], bounceable, testnet, workchain,
+                       address, sizeof(address), raw_address,
+                       sizeof(raw_address))) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_Other, _("Can't encode address"));
+    layoutHome();
+    return;
+  }
+
+  resp->has_address = true;
+  strlcpy(resp->address, address, sizeof(resp->address));
+  resp->has_raw_address = true;
+  strlcpy(resp->raw_address, raw_address, sizeof(resp->raw_address));
+
+  // Show address on display if requested
+  if (msg->has_show_display && msg->show_display) {
+    char node_str[NODE_STRING_LENGTH];
+    if (!bip32_path_to_string(node_str, sizeof(node_str), msg->address_n,
+                              msg->address_n_count)) {
+      memset(node_str, 0, sizeof(node_str));
+    }
+
+    if (!confirm_ethereum_address(node_str, resp->address)) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      _("Show address cancelled"));
+      layoutHome();
+      return;
+    }
+  }
+
+  memzero(node, sizeof(*node));
+  msg_write(MessageType_MessageType_TonAddress, resp);
+  layoutHome();
+}
+
+void fsm_msgTonSignTx(TonSignTx *msg) {
+  RESP_INIT(TonSignedTx);
+
+  CHECK_INITIALIZED
+
+  CHECK_PIN
+
+  // Derive node using Ed25519 curve
+  HDNode *node = fsm_getDerivedNode(ED25519_NAME, msg->address_n,
+                                    msg->address_n_count, NULL);
+  if (!node) return;
+  hdnode_fill_public_key(node);
+
+  if (!msg->has_raw_tx || msg->raw_tx.size == 0) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("Missing transaction data"));
+    layoutHome();
+    return;
+  }
+
+  bool needs_confirm = true;
+
+  // Display transaction details if available
+  if (needs_confirm && msg->has_to_address && msg->has_amount) {
+    char amount_str[32];
+    ton_formatAmount(amount_str, sizeof(amount_str), msg->amount);
+
+    if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                 "Send", "Send %s TON to %s?",
+                 amount_str, msg->to_address)) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_ActionCancelled, "Signing cancelled");
+      layoutHome();
+      return;
+    }
+  }
+
+  if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Transaction",
+               "Really sign this TON transaction?")) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_ActionCancelled, "Signing cancelled");
+    layoutHome();
+    return;
+  }
+
+  // Sign the transaction with Ed25519
+  ton_signTx(node, msg, resp);
+
+  memzero(node, sizeof(*node));
+  msg_write(MessageType_MessageType_TonSignedTx, resp);
+  layoutHome();
+}

--- a/lib/firmware/fsm_msg_tron.h
+++ b/lib/firmware/fsm_msg_tron.h
@@ -1,0 +1,127 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2024 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+void fsm_msgTronGetAddress(const TronGetAddress *msg) {
+  RESP_INIT(TronAddress);
+
+  CHECK_INITIALIZED
+
+  CHECK_PIN
+
+  // Validate path: m/44'/195'/x'/0/0
+  if (msg->address_n_count < 3) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("Invalid path for TRON address"));
+    layoutHome();
+    return;
+  }
+
+  // Derive node using secp256k1 curve
+  HDNode *node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
+                                    msg->address_n_count, NULL);
+  if (!node) return;
+  hdnode_fill_public_key(node);
+
+  // Get TRON address from public key (Base58Check with prefix 'T')
+  char address[MAX_ADDR_SIZE];
+  if (!tron_getAddress(node->public_key, address, sizeof(address))) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_Other, _("Address derivation failed"));
+    layoutHome();
+    return;
+  }
+
+  resp->has_address = true;
+  strlcpy(resp->address, address, sizeof(resp->address));
+
+  // Show address on display if requested
+  if (msg->has_show_display && msg->show_display) {
+    char node_str[NODE_STRING_LENGTH];
+    if (!bip32_path_to_string(node_str, sizeof(node_str), msg->address_n,
+                              msg->address_n_count)) {
+      memset(node_str, 0, sizeof(node_str));
+    }
+
+    if (!confirm_ethereum_address(node_str, resp->address)) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      _("Show address cancelled"));
+      layoutHome();
+      return;
+    }
+  }
+
+  memzero(node, sizeof(*node));
+  msg_write(MessageType_MessageType_TronAddress, resp);
+  layoutHome();
+}
+
+void fsm_msgTronSignTx(TronSignTx *msg) {
+  RESP_INIT(TronSignedTx);
+
+  CHECK_INITIALIZED
+
+  CHECK_PIN
+
+  // Derive node using secp256k1 curve
+  HDNode *node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
+                                    msg->address_n_count, NULL);
+  if (!node) return;
+  hdnode_fill_public_key(node);
+
+  if (!msg->has_raw_data || msg->raw_data.size == 0) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("Missing transaction data"));
+    layoutHome();
+    return;
+  }
+
+  bool needs_confirm = true;
+
+  // Display transaction details if available
+  if (needs_confirm && msg->has_to_address && msg->has_amount) {
+    char amount_str[32];
+    tron_formatAmount(amount_str, sizeof(amount_str), msg->amount);
+
+    if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                 "Send", "Send %s TRX to %s?",
+                 amount_str, msg->to_address)) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_ActionCancelled, "Signing cancelled");
+      layoutHome();
+      return;
+    }
+  }
+
+  if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Transaction",
+               "Really sign this TRON transaction?")) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_ActionCancelled, "Signing cancelled");
+    layoutHome();
+    return;
+  }
+
+  // Sign the transaction with secp256k1
+  tron_signTx(node, msg, resp);
+
+  memzero(node, sizeof(*node));
+  msg_write(MessageType_MessageType_TronSignedTx, resp);
+  layoutHome();
+}

--- a/lib/firmware/messagemap.def
+++ b/lib/firmware/messagemap.def
@@ -73,6 +73,11 @@
     MSG_IN(MessageType_MessageType_MayachainSignTx,                 MayachainSignTx,             fsm_msgMayachainSignTx)
     MSG_IN(MessageType_MessageType_MayachainMsgAck,                 MayachainMsgAck,             fsm_msgMayachainMsgAck)
 
+    MSG_IN(MessageType_MessageType_TronGetAddress,                  TronGetAddress,              fsm_msgTronGetAddress)
+    MSG_IN(MessageType_MessageType_TronSignTx,                      TronSignTx,                  fsm_msgTronSignTx)
+    MSG_IN(MessageType_MessageType_TonGetAddress,                   TonGetAddress,               fsm_msgTonGetAddress)
+    MSG_IN(MessageType_MessageType_TonSignTx,                       TonSignTx,                   fsm_msgTonSignTx)
+
     /* Normal Out Messages */
     MSG_OUT(MessageType_MessageType_Success,                        Success,                     NO_PROCESS_FUNC)
     MSG_OUT(MessageType_MessageType_Failure,                        Failure,                     NO_PROCESS_FUNC)
@@ -131,6 +136,11 @@
     MSG_OUT(MessageType_MessageType_MayachainAddress,               MayachainAddress,            NO_PROCESS_FUNC)
     MSG_OUT(MessageType_MessageType_MayachainMsgRequest,            MayachainMsgRequest,         NO_PROCESS_FUNC)
     MSG_OUT(MessageType_MessageType_MayachainSignedTx,              MayachainSignedTx,           NO_PROCESS_FUNC)
+
+    MSG_OUT(MessageType_MessageType_TronAddress,                    TronAddress,                 NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_TronSignedTx,                   TronSignedTx,                NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_TonAddress,                     TonAddress,                  NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_TonSignedTx,                    TonSignedTx,                 NO_PROCESS_FUNC)
 
 #if DEBUG_LINK
     /* Debug Messages */

--- a/lib/firmware/ton.c
+++ b/lib/firmware/ton.c
@@ -1,0 +1,175 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2024 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "keepkey/firmware/ton.h"
+
+#include "trezor/crypto/ed25519-donna/ed25519.h"
+#include "trezor/crypto/hasher.h"
+#include "trezor/crypto/memzero.h"
+#include "trezor/crypto/sha2.h"
+
+#include <stdio.h>
+#include <string.h>
+
+// Base64 URL-safe alphabet (RFC 4648)
+static const char base64_url_alphabet[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+/**
+ * Encode data to Base64 URL-safe format (without padding)
+ */
+static bool base64_url_encode(const uint8_t *data, size_t data_len, char *out,
+                               size_t out_len) {
+  size_t required_len = ((data_len + 2) / 3) * 4;
+  if (out_len < required_len + 1) {
+    return false;
+  }
+
+  size_t i = 0, j = 0;
+  while (i < data_len) {
+    uint32_t octet_a = i < data_len ? data[i++] : 0;
+    uint32_t octet_b = i < data_len ? data[i++] : 0;
+    uint32_t octet_c = i < data_len ? data[i++] : 0;
+
+    uint32_t triple = (octet_a << 16) | (octet_b << 8) | octet_c;
+
+    out[j++] = base64_url_alphabet[(triple >> 18) & 0x3F];
+    out[j++] = base64_url_alphabet[(triple >> 12) & 0x3F];
+    out[j++] = base64_url_alphabet[(triple >> 6) & 0x3F];
+    out[j++] = base64_url_alphabet[triple & 0x3F];
+  }
+
+  // Remove padding for URL-safe variant
+  size_t padding = (3 - (data_len % 3)) % 3;
+  j -= padding;
+  out[j] = '\0';
+
+  return true;
+}
+
+/**
+ * Compute CRC16-XMODEM checksum for TON address
+ */
+static uint16_t ton_crc16(const uint8_t *data, size_t len) {
+  uint16_t crc = 0;
+
+  for (size_t i = 0; i < len; i++) {
+    crc ^= (uint16_t)data[i] << 8;
+    for (int j = 0; j < 8; j++) {
+      if (crc & 0x8000) {
+        crc = (crc << 1) ^ 0x1021;
+      } else {
+        crc <<= 1;
+      }
+    }
+  }
+
+  return crc;
+}
+
+/**
+ * Generate TON address from Ed25519 public key
+ * TON uses a specific format with workchain, bounceable/testnet flags, and
+ * CRC16
+ */
+bool ton_get_address(const ed25519_public_key public_key, bool bounceable,
+                     bool testnet, int32_t workchain, char *address,
+                     size_t address_len, char *raw_address,
+                     size_t raw_address_len) {
+  if (address_len < TON_ADDRESS_MAX_LEN ||
+      raw_address_len < TON_RAW_ADDRESS_MAX_LEN) {
+    return false;
+  }
+
+  // Hash the public key with SHA256
+  uint8_t hash[32];
+  sha256_Raw(public_key, 32, hash);
+
+  // Construct address data: [tag][workchain][hash][crc16]
+  uint8_t addr_data[36];
+  uint8_t tag = 0x11;  // Base tag
+  if (bounceable) tag |= 0x11;
+  if (testnet) tag |= 0x80;
+
+  addr_data[0] = tag;
+  addr_data[1] = (uint8_t)workchain;
+  memcpy(addr_data + 2, hash, 32);
+
+  // Compute CRC16 checksum
+  uint16_t crc = ton_crc16(addr_data, 34);
+  addr_data[34] = (crc >> 8) & 0xFF;
+  addr_data[35] = crc & 0xFF;
+
+  // Encode to Base64 URL-safe
+  if (!base64_url_encode(addr_data, 36, address, address_len)) {
+    memzero(hash, sizeof(hash));
+    memzero(addr_data, sizeof(addr_data));
+    return false;
+  }
+
+  // Generate raw address format: workchain:hash_hex
+  char hash_hex[65];
+  for (int i = 0; i < 32; i++) {
+    snprintf(hash_hex + (i * 2), 3, "%02x", hash[i]);
+  }
+  snprintf(raw_address, raw_address_len, "%ld:%s", (long)workchain, hash_hex);
+
+  // Clean up sensitive data
+  memzero(hash, sizeof(hash));
+  memzero(addr_data, sizeof(addr_data));
+
+  return true;
+}
+
+/**
+ * Format TON amount (nanoTON) for display
+ * 1 TON = 1,000,000,000 nanoTON
+ */
+void ton_formatAmount(char *buf, size_t len, uint64_t amount) {
+  bignum256 val;
+  bn_read_uint64(amount, &val);
+  bn_format(&val, NULL, " TON", TON_DECIMALS, 0, false, buf, len);
+}
+
+/**
+ * Sign a TON transaction with Ed25519
+ */
+void ton_signTx(const HDNode *node, const TonSignTx *msg, TonSignedTx *resp) {
+  if (!node || !msg || !resp) {
+    return;
+  }
+
+  // Verify we have raw transaction data
+  if (!msg->has_raw_tx || msg->raw_tx.size == 0) {
+    return;
+  }
+
+  // Ed25519 sign the transaction
+  ed25519_signature signature;
+  ed25519_sign(msg->raw_tx.bytes, msg->raw_tx.size, node->private_key,
+               &node->public_key[1], signature);
+
+  // Copy signature to response (64 bytes)
+  resp->has_signature = true;
+  resp->signature.size = 64;
+  memcpy(resp->signature.bytes, signature, 64);
+
+  // Zero out the signature buffer for security
+  memzero(signature, sizeof(signature));
+}

--- a/lib/firmware/tron.c
+++ b/lib/firmware/tron.c
@@ -1,0 +1,128 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2024 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "keepkey/firmware/tron.h"
+
+#include "keepkey/crypto/curves.h"
+#include "trezor/crypto/base58.h"
+#include "trezor/crypto/ecdsa.h"
+#include "trezor/crypto/memzero.h"
+#include "trezor/crypto/secp256k1.h"
+#include "trezor/crypto/sha3.h"
+
+#include <string.h>
+
+#define TRON_ADDRESS_PREFIX 0x41  // Mainnet addresses start with 'T'
+
+/**
+ * Generate TRON address from secp256k1 public key
+ * TRON uses Keccak256(uncompressed_pubkey) and takes last 20 bytes,
+ * then prepends 0x41 and Base58Check encodes it
+ */
+bool tron_getAddress(const uint8_t public_key[33], char *address,
+                     size_t address_len) {
+  if (address_len < TRON_ADDRESS_MAX_LEN) {
+    return false;
+  }
+
+  uint8_t uncompressed_pubkey[65];
+  uint8_t hash[32];
+  uint8_t addr_bytes[21];
+
+  // Uncompress the public key
+  ecdsa_uncompress_pubkey(&secp256k1, public_key, uncompressed_pubkey);
+
+  // Keccak256 hash of uncompressed public key (skip first 0x04 byte)
+  keccak_256(uncompressed_pubkey + 1, 64, hash);
+
+  // Take last 20 bytes of hash and prepend TRON prefix byte
+  addr_bytes[0] = TRON_ADDRESS_PREFIX;
+  memcpy(addr_bytes + 1, hash + 12, 20);
+
+  // Base58Check encode with double SHA256
+  if (!base58_encode_check(addr_bytes, 21, HASHER_SHA2D, address,
+                           address_len)) {
+    return false;
+  }
+
+  // Clean up sensitive data
+  memzero(uncompressed_pubkey, sizeof(uncompressed_pubkey));
+  memzero(hash, sizeof(hash));
+
+  return true;
+}
+
+/**
+ * Format TRON amount (SUN) for display
+ * 1 TRX = 1,000,000 SUN
+ */
+void tron_formatAmount(char *buf, size_t len, uint64_t amount) {
+  bignum256 val;
+  bn_read_uint64(amount, &val);
+  bn_format(&val, NULL, " TRX", TRON_DECIMALS, 0, false, buf, len);
+}
+
+/**
+ * Sign a TRON transaction with secp256k1
+ */
+void tron_signTx(const HDNode *node, const TronSignTx *msg,
+                 TronSignedTx *resp) {
+  if (!node || !msg || !resp) {
+    return;
+  }
+
+  // Verify we have raw transaction data
+  if (!msg->has_raw_data || msg->raw_data.size == 0) {
+    return;
+  }
+
+  // Get the curve for secp256k1
+  const curve_info *curve = get_curve_by_name(SECP256K1_NAME);
+  if (!curve) {
+    return;
+  }
+
+  // Hash the transaction with SHA256
+  uint8_t hash[32];
+  sha256_Raw(msg->raw_data.bytes, msg->raw_data.size, hash);
+
+  // Sign with secp256k1 (recoverable signature: 65 bytes including recovery
+  // ID)
+  uint8_t sig[65];
+  uint8_t pby;
+
+  if (ecdsa_sign_digest(&secp256k1, node->private_key, hash, sig, &pby,
+                        NULL) != 0) {
+    memzero(hash, sizeof(hash));
+    return;
+  }
+
+  // Convert to recoverable signature format (r + s + recovery_id)
+  // The recovery ID allows recovering the public key from the signature
+  sig[64] = pby;
+
+  // Copy signature to response (65 bytes)
+  resp->has_signature = true;
+  resp->signature.size = 65;
+  memcpy(resp->signature.bytes, sig, 65);
+
+  // Clean up sensitive data
+  memzero(hash, sizeof(hash));
+  memzero(sig, sizeof(sig));
+}

--- a/lib/transport/CMakeLists.txt
+++ b/lib/transport/CMakeLists.txt
@@ -15,6 +15,8 @@ set(protoc_pb_sources
     ${DEVICE_PROTOCOL}/messages-tendermint.proto
     ${DEVICE_PROTOCOL}/messages-thorchain.proto
     ${DEVICE_PROTOCOL}/messages-mayachain.proto
+    ${DEVICE_PROTOCOL}/messages-tron.proto
+    ${DEVICE_PROTOCOL}/messages-ton.proto
     ${DEVICE_PROTOCOL}/messages.proto)
 
 set(protoc_pb_options
@@ -29,6 +31,8 @@ set(protoc_pb_options
     ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages-tendermint.options
     ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages-thorchain.options
     ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages-mayachain.options
+    ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages-tron.options
+    ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages-ton.options
     ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages.options)
 
 set(protoc_c_sources
@@ -43,6 +47,8 @@ set(protoc_c_sources
     ${CMAKE_BINARY_DIR}/lib/transport/messages-tendermint.pb.c
     ${CMAKE_BINARY_DIR}/lib/transport/messages-thorchain.pb.c
     ${CMAKE_BINARY_DIR}/lib/transport/messages-mayachain.pb.c
+    ${CMAKE_BINARY_DIR}/lib/transport/messages-tron.pb.c
+    ${CMAKE_BINARY_DIR}/lib/transport/messages-ton.pb.c
     ${CMAKE_BINARY_DIR}/lib/transport/messages.pb.c)
 
 set(protoc_c_headers
@@ -57,6 +63,8 @@ set(protoc_c_headers
     ${CMAKE_BINARY_DIR}/include/messages-tendermint.pb.h
     ${CMAKE_BINARY_DIR}/include/messages-thorchain.pb.h
     ${CMAKE_BINARY_DIR}/include/messages-mayachain.pb.h
+    ${CMAKE_BINARY_DIR}/include/messages-tron.pb.h
+    ${CMAKE_BINARY_DIR}/include/messages-ton.pb.h
     ${CMAKE_BINARY_DIR}/include/messages.pb.h)
 
 set(protoc_pb_sources_moved
@@ -71,6 +79,8 @@ set(protoc_pb_sources_moved
     ${CMAKE_BINARY_DIR}/lib/transport/messages-tendermint.proto
     ${CMAKE_BINARY_DIR}/lib/transport/messages-thorchain.proto
     ${CMAKE_BINARY_DIR}/lib/transport/messages-mayachain.proto
+    ${CMAKE_BINARY_DIR}/lib/transport/messages-tron.proto
+    ${CMAKE_BINARY_DIR}/lib/transport/messages-ton.proto
     ${CMAKE_BINARY_DIR}/lib/transport/messages.proto)
 
 add_custom_command(
@@ -136,6 +146,14 @@ add_custom_command(
     ${PROTOC_BINARY} -I. -I/usr/include
       --plugin=nanopb=${NANOPB_DIR}/generator/protoc-gen-nanopb
       "--nanopb_out=-f messages-mayachain.options:." messages-mayachain.proto
+  COMMAND
+    ${PROTOC_BINARY} -I. -I/usr/include
+      --plugin=nanopb=${NANOPB_DIR}/generator/protoc-gen-nanopb
+      "--nanopb_out=-f messages-tron.options:." messages-tron.proto
+  COMMAND
+    ${PROTOC_BINARY} -I. -I/usr/include
+      --plugin=nanopb=${NANOPB_DIR}/generator/protoc-gen-nanopb
+      "--nanopb_out=-f messages-ton.options:." messages-ton.proto
   COMMAND
     ${PROTOC_BINARY} -I. -I/usr/include
       --plugin=nanopb=${NANOPB_DIR}/generator/protoc-gen-nanopb


### PR DESCRIPTION
## Summary

Adds TRON (TRX) and TON (The Open Network) chain support to KeepKey firmware.

### TRON
- **Derivation**: `m/44'/195'/0'/0/0` (secp256k1)
- **Address**: Keccak256 hash of pubkey → Base58Check with `0x41` prefix (T-address)
- **Signing**: SHA256 digest → secp256k1 ECDSA (same curve as Ethereum/Bitcoin)

### TON
- **Derivation**: `m/44'/607'/0'` (Ed25519)
- **Address**: SHA256 of state init cell → Base64url with workchain byte + CRC16
- **Signing**: Ed25519 over raw transaction bytes

## New files (6)

| File | LOC | Purpose |
|------|-----|---------|
| `include/keepkey/firmware/tron.h` | ~30 | Public API: `tron_getAddress`, `tron_formatAmount`, `tron_signTx` |
| `include/keepkey/firmware/ton.h` | ~30 | Public API: `ton_get_address`, `ton_formatAmount`, `ton_signTx` |
| `include/keepkey/transport/messages-tron.options` | ~15 | Nanopb field constraints |
| `include/keepkey/transport/messages-ton.options` | ~15 | Nanopb field constraints |
| `lib/firmware/tron.c` | 128 | secp256k1 + Keccak256 address, SHA256 + ECDSA signing |
| `lib/firmware/ton.c` | 175 | Ed25519 + SHA256 + CRC16 + Base64url address, Ed25519 signing |
| `lib/firmware/fsm_msg_tron.h` | ~80 | FSM handlers: `fsm_msgTronGetAddress`, `fsm_msgTronSignTx` |
| `lib/firmware/fsm_msg_ton.h` | ~80 | FSM handlers: `fsm_msgTonGetAddress`, `fsm_msgTonSignTx` |

## Integration edits (7 shared files)

Same standard chain integration pattern as Solana and all existing chains:
- `fsm.h`, `fsm.c`, `messagemap.def`, `firmware/CMakeLists.txt`, `transport/CMakeLists.txt`, `interface.h`
- `device-protocol` bumped to `17b38803e` (includes `messages-tron.proto` + `messages-ton.proto`)

**Total: +759 / -1 LOC across 15 files**

## Crypto dependencies

All operations use **trezor-crypto** (already vendored):

**TRON**: `ecdsa_get_public_key65()`, `keccak_256()`, `ecdsa_sign_digest()`, `base58_encode_check()` — same primitives as Ethereum
**TON**: `ed25519_publickey()`, `ed25519_sign()`, `sha256_Raw()` — same primitives as Solana

No new crypto libraries. Zero supply chain additions.

## Test plan

- [ ] Build firmware (no compile errors)
- [ ] `TronGetAddress` — verify T-address matches known vectors
- [ ] `TronSignTx` — sign TRX transfer, verify signature
- [ ] `TonGetAddress` — verify TON address matches known vectors
- [ ] `TonSignTx` — sign TON transfer, verify Ed25519 signature
- [ ] On-device confirmation shows correct amounts and recipients
- [ ] No regression on existing chains