### PR TITLE
feat(policy): add blind signing policies, default disabled

### DIFF
--- a/include/keepkey/firmware/policy.h
+++ b/include/keepkey/firmware/policy.h
@@ -32,6 +32,8 @@ static const PolicyType policies[] = {
     {true, "Pin Caching", true, true},
     {true, "Experimental", true, false},
     {true, "AdvancedMode", true, false},
+    {true, "SolBlindSign", true, false},
+    {true, "EthBlindSign", true, false},
 };
 
 int run_policy_compile_output(const CoinType *coin, const HDNode *root,

--- a/lib/firmware/ethereum.c
+++ b/lib/firmware/ethereum.c
@@ -734,10 +734,19 @@ void ethereum_signing_init(EthereumSignTx *msg, const HDNode *node,
 
   memset(confirm_body_message, 0, sizeof(confirm_body_message));
   if (token == NULL && data_total > 0 && data_needs_confirm) {
+    // EthBlindSign policy: hard gate when disabled
+    if (!storage_isPolicyEnabled("EthBlindSign")) {
+      (void)review(ButtonRequestType_ButtonRequest_Other, "Blocked",
+                   "Blind signing is disabled. Enable "
+                   "'EthBlindSign' policy to allow.");
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      "Blind signing disabled by policy");
+      ethereum_signing_abort();
+      return;
+    }
+
     // KeepKey custom: warn the user that they're trying to do something
-    // that is potentially dangerous. People (generally) aren't great at
-    // parsing raw transaction data, and we can't effectively show them
-    // what they're about to do in the general case.
+    // that is potentially dangerous.
     if (!storage_isPolicyEnabled("AdvancedMode")) {
       (void)review(
           ButtonRequestType_ButtonRequest_Other, "Warning",


### PR DESCRIPTION
## Summary
- Add `EthBlindSign` and `SolBlindSign` policies to the policy table, both defaulting to **disabled**
- Add hard gate in `ethereum.c` — arbitrary contract data signing is blocked unless `EthBlindSign` is enabled on-device
- Users must explicitly enable via `ApplyPolicies` which requires on-device button confirmation + PIN

## Test plan
- [ ] Flash firmware, verify blind signing ETH contract data is rejected by default
- [ ] Enable `EthBlindSign` via ApplyPolicies, confirm device prompts for button + PIN
- [ ] After enabling, verify ETH contract data signing works
- [ ] Verify `SolBlindSign` policy is present and defaults to disabled (enforcement comes with Solana merge)