### PR TITLE
feat: CI screenshot infrastructure + test report pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,8 +387,9 @@ jobs:
 
   python-integration-tests:
     needs: [check-submodules, secret-scan]
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -412,8 +413,22 @@ jobs:
           docker compose up --build python-keepkey
           set -e
           mkdir -p ${{ github.workspace }}/test-reports
-          docker cp "$(docker compose ps -a -q firmware-unit)":/kkemu/test-reports/. ${{ github.workspace }}/test-reports/ 2>/dev/null || true
-          docker cp "$(docker compose ps -a -q python-keepkey)":/kkemu/test-reports/. ${{ github.workspace }}/test-reports/ 2>/dev/null || true
+
+          echo "=== Extracting test reports from Docker ==="
+          PY_CONTAINER=$(docker compose ps -a -q python-keepkey)
+          FW_CONTAINER=$(docker compose ps -a -q firmware-unit)
+          echo "python-keepkey container: $PY_CONTAINER"
+          echo "firmware-unit container: $FW_CONTAINER"
+
+          docker cp "$FW_CONTAINER":/kkemu/test-reports/. ${{ github.workspace }}/test-reports/ || echo "WARN: firmware-unit docker cp failed"
+          docker cp "$PY_CONTAINER":/kkemu/test-reports/. ${{ github.workspace }}/test-reports/ || echo "WARN: python-keepkey docker cp failed"
+
+          echo "=== Extracted files ==="
+          find ${{ github.workspace }}/test-reports -type f | head -30
+          echo "=== Screenshot PNGs ==="
+          find ${{ github.workspace }}/test-reports/screenshots -name '*.png' 2>/dev/null | wc -l
+          echo "PNGs on host"
+
           UNIT_STATUS=$(cat ${{ github.workspace }}/test-reports/firmware-unit/status 2>/dev/null || echo "1")
           PY_STATUS=$(cat ${{ github.workspace }}/test-reports/python-keepkey/status 2>/dev/null || echo "1")
           echo "Unit tests exit status: $UNIT_STATUS"
@@ -428,10 +443,77 @@ jobs:
           path: test-reports/python-keepkey/
           retention-days: 30
 
+      - name: Upload OLED screenshots
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: oled-screenshots
+          path: test-reports/screenshots/
+          retention-days: 90
+          if-no-files-found: warn
+
       - name: Tear down
         if: always()
         working-directory: scripts/emulator
         run: docker compose down -v || true
+
+  # ═══════════════════════════════════════════════════════════
+  # STAGE 3b: TEST REPORT — generate PDF from test artifacts
+  # ═══════════════════════════════════════════════════════════
+
+  generate-test-report:
+    needs: [unit-tests, python-integration-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Download unit test results
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: unit-test-results
+          path: test-reports/firmware-unit/
+
+      - name: Download python test results
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: python-test-results
+          path: test-reports/python-keepkey/
+
+      - name: Download OLED screenshots
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: oled-screenshots
+          path: test-reports/screenshots/
+
+      - name: Extract firmware version
+        id: version
+        run: |
+          FW_VERSION=$(sed -n '/^project/,/)/p' CMakeLists.txt | grep -oP '\d+\.\d+\.\d+' || echo "unknown")
+          echo "fw_version=${FW_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Init python-keepkey submodule
+        run: git submodule update --init deps/python-keepkey
+
+      - name: Generate test report PDF
+        env:
+          FW_VERSION: ${{ steps.version.outputs.fw_version }}
+        run: python3 scripts/generate-test-report.py
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-report
+          path: test-report.pdf
+          retention-days: 90
 
   # ═══════════════════════════════════════════════════════════
   # STAGE 4: PUBLISH — manual trigger only, all tests must pass

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.7.2)
 
 project(
   KeepKeyFirmware
-  VERSION 7.10.0
+  VERSION 7.14.0
   LANGUAGES C CXX ASM)
 
 set(BOOTLOADER_MAJOR_VERSION 2)

--- a/docs/testing/TEST-SYSTEM.md
+++ b/docs/testing/TEST-SYSTEM.md
@@ -1,0 +1,405 @@
+# KeepKey Firmware Test System
+
+Single source of truth for the test suite, report generation, screenshot capture, and release validation pipeline.
+
+---
+
+## Architecture
+
+```
+python-keepkey (release/7.14.0)
+├── keepkeylib/
+│   ├── client.py          # SCREENSHOT capture in callback_ButtonRequest
+│   ├── debuglink.py       # read_layout() → 2048-byte OLED buffer
+│   └── messages_*_pb2.py  # protobuf definitions per chain
+├── tests/
+│   ├── common.py          # KeepKeyTest base class + screenshot dir setup
+│   ├── conftest.py        # pytest plugin: per-test screenshot directories
+│   ├── config.py          # transport config (UDP host:port)
+│   └── test_msg_*.py      # test files (one per chain/feature)
+└── scripts/
+    └── generate-test-report.py  # THE report generator (1061 lines, version-aware)
+```
+
+**Everything lives in python-keepkey.** The firmware repo consumes it as a submodule at `deps/python-keepkey/`.
+
+---
+
+## Report Generator: Version-Gated Sections
+
+`scripts/generate-test-report.py` defines a `SECTIONS` array where each section has a `min_firmware_version`:
+
+```python
+SECTIONS = [
+    ('C', 'Core - Device Lifecycle', '7.0.0', ...),   # always shown
+    ('B', 'Bitcoin',                 '7.0.0', ...),   # always shown
+    ('E', 'Ethereum',               '7.0.0', ...),   # always shown
+    # ... existing chains ...
+    ('V', 'EVM Clear-Signing',      '7.14.0', ...),  # shown when fw >= 7.14.0
+    ('S', 'Solana',                 '7.14.0', ...),  # shown when fw >= 7.14.0
+    ('T', 'TRON',                   '7.14.0', ...),  # shown when fw >= 7.14.0
+    ('N', 'TON',                    '7.14.0', ...),  # shown when fw >= 7.14.0
+    ('Z', 'Zcash Orchard',         '7.14.0', ...),  # shown when fw >= 7.14.0
+    ('D', 'BIP-85 Child Derivation','7.14.0', ...),  # shown when fw >= 7.14.0
+]
+```
+
+When the firmware version is 7.10.0 (branches before mega merge), only existing chain sections appear. When 7.14.0, new feature sections appear at the TOP of the report with `[NEW]` tags.
+
+Each test in a section maps to a specific `test_msg_*.py::TestClass::test_method`. The generator looks up the method name in JUnit XML results to determine pass/fail/pending.
+
+### Running the generator
+
+```bash
+# Against live emulator (auto-detects version)
+python3 scripts/generate-test-report.py --output=test-report.pdf
+
+# Against JUnit XML from CI
+python3 scripts/generate-test-report.py \
+  --fw-version=7.14.0 \
+  --junit=test-reports/python-keepkey/junit.xml \
+  --screenshots=test-reports/screenshots/ \
+  --output=test-report.pdf
+```
+
+### Adding a new feature (future releases)
+
+1. Add a new section tuple to `SECTIONS` with the target firmware version
+2. Add test entries mapping to test file methods
+3. Push to `release/<version>` on python-keepkey
+4. The report automatically includes the section when firmware version matches
+
+---
+
+## Screenshot Capture System
+
+### Why Two Phases
+
+Screenshot capture adds a `DebugLinkGetState` round-trip on every `ButtonRequest`. This:
+- Adds ~50-100ms latency per button press
+- Can cause timing issues in multi-step flows (recovery cipher, complex signing)
+
+**Phase 1**: Run screenshot-compatible tests with `KEEPKEY_SCREENSHOT=1`. These are simple request-response tests (address display, wipe) that tolerate the extra latency.
+
+**Phase 2**: Run the full test suite without screenshots for accurate pass/fail results.
+
+### How Screenshots Work
+
+1. `KEEPKEY_SCREENSHOT=1` env var enables capture (client.py line 61)
+2. `conftest.py` creates per-test directories: `screenshots/{module}/{test_method}/`
+3. `callback_ButtonRequest()` calls `_capture_oled()` BEFORE pressing the button
+4. `_capture_oled()` reads 2048-byte OLED layout via DebugLink, decodes 256x64 monochrome, writes PNG
+5. Screenshots named `btn00000.png`, `btn00001.png`, etc. per test
+6. Report generator skips first 2 frames (setUp wipe+load) and embeds the rest inline
+
+### Screenshot Directory Layout
+
+```
+screenshots/
+├── msg_wipedevice/
+│   └── test_wipe_device/
+│       ├── btn00000.png    # setUp wipe confirm (skipped in report)
+│       ├── btn00001.png    # setUp load_device (skipped in report)
+│       └── btn00002.png    # actual test screen (embedded in report)
+├── msg_solana_getaddress/
+│   └── test_solana_get_address/
+│       ├── btn00000.png
+│       ├── btn00001.png
+│       └── btn00002.png    # Solana address display with full base58
+└── ...
+```
+
+### Known Screenshot Limitations (verified 2026-03-27)
+
+1. **`show_display=True` screenshots capture wrong screen**: `_capture_oled()` in `callback_ButtonRequest` reads the OLED buffer via DebugLink BEFORE the firmware renders the address. The captured frame shows the previous screen (recovery sentence, home screen), not the address display. This is a timing race between the DebugLink read and the firmware OLED render.
+
+2. **Screenshot capture corrupts address responses**: When `KEEPKEY_SCREENSHOT=1`, the DebugLink round-trip in `callback_ButtonRequest` can cause the `show_display=True` response to return an empty address. Tests that assert on address content will fail in screenshot mode.
+
+3. **TON `raw_address` proto bug**: The `TonAddress.raw_address` field is defined as proto `string` but the firmware populates it with binary data (non-UTF-8). Causes `UnicodeDecodeError` when `show_display=True`. Needs proto fix: change to `bytes` type.
+
+4. **Screenshot file naming**: `conftest.py` uses `scr*` prefix but report generator expects `btn*` prefix. Need to align.
+
+### Implication for Phase 1/Phase 2
+
+Show-display tests (`test_*_show_address`) go in Phase 1 with relaxed assertions (no address content checks). Address correctness is validated by non-show tests in Phase 2. The show tests exist ONLY to trigger the OLED display flow for screenshot capture.
+
+---
+
+## Feature Gating (per-branch test control)
+
+### Problem
+
+During development, firmware branches are at different feature states:
+- `develop` (7.10.0): no new chains
+- After PR #1-6 merge: still 7.10.0, no new chains
+- After PR #7 (mega): jumps to 7.14.0, gets Solana/TRON/TON/EVM/BIP-85
+- After PR #8 (zcash): gets Zcash Orchard
+
+The `requires_firmware("7.14.0")` check gates on version number, but two branches at "7.14.0" may have different features (mega without zcash vs mega with zcash).
+
+### Solution: Feature-based gating
+
+Like Trezor's test system, tests should declare which MESSAGE TYPES they need:
+
+```python
+# Existing (works for version gating)
+self.requires_firmware("7.14.0")
+
+# Existing (works for message-level feature gating)
+self.requires_message("SolanaGetAddress")    # skips if proto not available
+self.requires_message("TronGetAddress")
+self.requires_message("ZcashSignPCZT")       # skips if Zcash not in this build
+self.requires_message("EthereumTxMetadata")  # skips if EVM clear-signing not available
+```
+
+The `requires_message()` method (already on `release/7.14.0`) checks if the protobuf message type exists in the current build's pb2 modules. This handles:
+- 7.10.0 branches: all new chain tests skip (no Solana/TRON/TON protos)
+- Mega branch: Solana/TRON/TON/EVM/BIP-85 tests run, Zcash skips
+- Zcash branch: all tests run
+
+### Report Generator Integration
+
+The report generator's `SECTIONS` array already gates by `min_firmware_version`. Tests that skip via `requires_message()` show as `--` (pending/grey) in the report, which is correct — the feature isn't in this build.
+
+### Phase 1 Filter: Version-Aware
+
+Instead of hardcoding chain names:
+```bash
+# WRONG: hardcoded, breaks on 7.10.0 branches
+pytest -k "test_solana_get or test_tron_get or test_ton_get"
+
+# RIGHT: run all show tests, let requires_firmware/requires_message skip
+pytest -k "test_show or test_show_address or test_wipe_device or test_bip85"
+```
+
+The `requires_firmware()` and `requires_message()` decorators handle the skipping. No need to maintain a separate filter list per version.
+
+---
+
+## Removed Files (stray / dangerous)
+
+The following files were removed from `tests/` on `release/7.14.0` (commit `04ef8e7`):
+
+| File | Lines | Why Removed |
+|------|-------|-------------|
+| `test_zcash_complete_nownodes.py` | 416 | Hardcoded RPC credentials (`78787ba8...`), internal IP (`100.117.181.111`), NOWNodes API key, interactive `input()` prompt for MAINNET broadcast |
+| `test_zcash_v5_complete.py` | 313 | External RPC calls + mainnet broadcast |
+| `test_zcash_nu6.py` | 184 | Mainnet broadcast tool disguised as test |
+| `test_nu6_final.py` | 150 | "Sign and automatically broadcast NU6 transaction" |
+
+These are manual integration tools, not unit tests. pytest collected them and they failed with timeouts, polluting CI results. Zcash signing is properly tested by `test_msg_zcash_orchard.py` and `test_msg_zcash_sign_pczt.py` (emulator-only, zero external dependencies).
+
+**Rule**: No test file in `tests/` should import `requests`, hit external APIs, contain hardcoded credentials, or prompt for user input.
+
+---
+
+## Local Verification Results (2026-03-27)
+
+Verified against emulator (alpha branch, firmware 7.14.0, port 12044):
+
+**Phase 1 (screenshots)**: 6 tests passed, 15 OLED PNGs captured
+- BIP-85 seed derivation: 3 pages of mnemonic words (embedded in PDF)
+- Solana address: full 44-char base58 with QR code
+- TRON address: full 34-char Base58Check with QR code
+- TON address: full 48-char base64url with QR code
+- Wipe device: confirmation screen
+
+**Phase 2 (full suite)**: 372 passed, 0 failed, 6 skipped
+
+**Report generation**: 134 tests in PDF, 133 passed, 1 pending (N5 TON comment test)
+- New Feature sections at top with `[NEW]` tags
+- Version-gated: only shown because `fw_version=7.14.0`
+- Inline OLED screenshots for BIP-85 (Solana/TRON/TON screenshots need path alignment for inline embedding)
+
+---
+
+## CI Pipeline Integration
+
+### Current Flow (firmware repo)
+
+```
+scripts/emulator/python-keepkey-tests.sh:
+  Phase 1: KEEPKEY_SCREENSHOT=1 pytest -k "<filter>" → junit-screenshots.xml + PNGs
+  Phase 2: pytest (full suite) → junit.xml + exit status
+
+scripts/generate-test-report.py:
+  Reads junit.xml + screenshots/ → test-report.pdf
+```
+
+### Target Flow (consolidated)
+
+```
+scripts/emulator/python-keepkey-tests.sh:
+  Phase 1: KEEPKEY_SCREENSHOT=1 pytest -k "<version-aware-filter>" → screenshots/
+  Phase 2: pytest --junitxml=junit.xml (full suite)
+
+deps/python-keepkey/scripts/generate-test-report.py:
+  Reads junit.xml + screenshots/ + auto-detects fw version → test-report.pdf
+```
+
+The firmware repo's `scripts/generate-test-report.py` should be a thin wrapper:
+
+```python
+#!/usr/bin/env python3
+"""Delegates to python-keepkey's version-aware report generator."""
+import subprocess, sys, os
+script = os.path.join(os.path.dirname(__file__), '..', 'deps', 'python-keepkey', 'scripts', 'generate-test-report.py')
+sys.exit(subprocess.call([sys.executable, script] + sys.argv[1:]))
+```
+
+---
+
+## Tech Debt Inventory
+
+### BROKEN: Must Fix Before Rehearsal
+
+| # | Issue | Location | Fix |
+|---|-------|----------|-----|
+| 1 | Firmware `scripts/generate-test-report.py` is 314-line dumb version on alpha | alpha branch | Replace with wrapper to python-keepkey's generator |
+| 2 | Phase 1 `-k` filter hardcodes chain names, not version-aware | `python-keepkey-tests.sh` | Use `requires_firmware()` skip mechanism — run ALL display tests, let the test self-skip |
+| 3 | Phase 1 filter missing EVM clear-signing, Zcash display tests | `python-keepkey-tests.sh` | Expand filter or remove filter entirely |
+| 4 | `generate-test-report.py` exists in 3 places (firmware scripts/, python-keepkey scripts/, zoo scripts/) | Multiple repos | Delete firmware copies, single source in python-keepkey |
+| 5 | `scripts/zoo/generate_report.py` is a separate manual review PDF | firmware repo | Keep as separate tool, do not confuse with test report |
+
+### WRONG: Tests That Need Fixing
+
+| # | Test | Issue | Fix |
+|---|------|-------|-----|
+| 1 | TON `test_ton_sign_structured` | Was sending structured fields without `raw_tx` — firmware requires it | FIXED in 4b4dc05 |
+| 2 | TON `test_ton_sign_with_memo` | Same | FIXED in 4b4dc05 |
+| 3 | TON `test_ton_sign_deterministic` | Same | FIXED in 4b4dc05 |
+| 4 | EVM `test_valid_metadata_returns_verified` + 8 others | Client missing `ethereum_send_tx_metadata()` method | FIXED in 4b4dc05 |
+| 5 | Zcash Z1-Z9 all pending in mega report | Zcash tests require `requires_message("ZcashSignPCZT")` — proto available but tests don't execute | Investigate: may be `requires_firmware` version check or pb2 import issue |
+
+### STALE: Versions Out of Sync
+
+| Branch | `generate-test-report.py` | python-keepkey pin | Status |
+|--------|--------------------------|-------------------|--------|
+| alpha | 314 lines (dumb) | BitHighlander fork `5f32810` | WRONG — needs upstream pin + wrapper |
+| develop | 1058 lines (rich, inline copy) | upstream `release/7.14.0` | WRONG — inline copy, should be wrapper |
+| feat/ci-test-report-v2 | 1069 lines (rich, inline copy) | upstream `release/7.14.0` | WRONG — inline copy |
+| feat/7.14.0-mega-v3 | 1050 lines (rich, inline copy) | upstream `4b4dc05` | WRONG — inline copy |
+
+**All firmware branches** should use the wrapper pattern pointing to `deps/python-keepkey/scripts/generate-test-report.py`.
+
+---
+
+## Release Branch Checklist
+
+### Before creating any firmware feature branch
+
+1. Confirm python-keepkey `release/<version>` has:
+   - [ ] All test files for the feature (`test_msg_<chain>_*.py`)
+   - [ ] Section entry in `SECTIONS` array with correct `min_firmware_version`
+   - [ ] `conftest.py` and `common.py` screenshot infrastructure
+   - [ ] `ethereum_send_tx_metadata()` or equivalent client methods for new message types
+   - [ ] `requires_message()` guards for chain-specific pb2 imports
+
+2. Confirm firmware branch has:
+   - [ ] `deps/python-keepkey` pinned to upstream `release/<version>` (NOT fork)
+   - [ ] `scripts/generate-test-report.py` is the thin wrapper (NOT inline copy)
+   - [ ] `.github/workflows/ci.yml` calls the wrapper
+   - [ ] `scripts/emulator/python-keepkey-tests.sh` Phase 1 filter includes new chain display tests
+
+### Per-PR Review (SOP Gate 3)
+
+For each PR's `test-report.pdf`:
+1. Header matches branch, commit SHA, firmware version
+2. New feature sections appear at TOP with `[NEW]` tag (if firmware version warrants)
+3. Zero FAIL or ERROR
+4. Every SKIP has documented justification
+5. New chain sections have OLED screenshots inline (not just "OLED needed: ...")
+6. No regressions — previously-passing tests still pass
+
+---
+
+## Merge Sequence for Test System Consolidation
+
+This is the prerequisite work before the release dress rehearsal.
+
+### Step 0: Prove locally
+
+```bash
+# Start emulator
+cd projects/keepkey-firmware
+KEEPKEY_UDP_PORT=12044 build-emu/bin/kkemu &
+
+# Run Phase 1 (screenshots)
+cd deps/python-keepkey/tests
+KEEPKEY_SCREENSHOT=1 \
+SCREENSHOT_DIR=/tmp/test-screenshots \
+KK_TRANSPORT_MAIN=127.0.0.1:12044 \
+KK_TRANSPORT_DEBUG=127.0.0.1:12045 \
+pytest -v -k "test_get_address or test_getaddress or test_wipe or test_bip85" \
+  --junitxml=/tmp/junit-screenshots.xml --timeout=120
+
+# Run Phase 2 (full suite)
+KK_TRANSPORT_MAIN=127.0.0.1:12044 \
+KK_TRANSPORT_DEBUG=127.0.0.1:12045 \
+pytest -v --junitxml=/tmp/junit.xml
+
+# Generate report
+cd ../scripts
+python3 generate-test-report.py \
+  --fw-version=7.14.0 \
+  --junit=/tmp/junit.xml \
+  --screenshots=/tmp/test-screenshots \
+  --output=/tmp/test-report.pdf
+```
+
+Verify the PDF has:
+- Per-chain sections with descriptions
+- `[NEW]` tags on 7.14.0 features
+- Inline OLED screenshots for address display tests
+- Green checkmarks for passing tests
+
+### Step 1: Update python-keepkey `release/7.14.0`
+
+- [ ] Verify all test files present and correct
+- [ ] Verify `SECTIONS` array complete for 7.14.0
+- [ ] Verify conftest.py + screenshot system works
+- [ ] Push any fixes
+
+### Step 2: Update firmware `feat/ci-test-report-v2` (PR #0)
+
+- [ ] Replace `scripts/generate-test-report.py` with thin wrapper
+- [ ] Update `python-keepkey-tests.sh` Phase 1 filter (version-aware or broad)
+- [ ] Pin `deps/python-keepkey` to upstream `release/7.14.0`
+- [ ] Push and verify CI produces correct PDF
+
+### Step 3: Reset develop, merge PR #0
+
+- [ ] Reset develop to upstream
+- [ ] Merge PR #0 (CI infrastructure)
+- [ ] Verify develop's CI produces correct 7.10.0 baseline report
+
+### Step 4: Sequential PR merges per SOP
+
+- [ ] PR #1 (nanopb) → report should show 7.10.0, 91 tests, existing chains only
+- [ ] PR #3 (bip39) → same
+- [ ] PR #5 (lynx) → same
+- [ ] PR #6 (bip85) → same (BIP-85 tests gated by 7.14.0, won't appear yet)
+- [ ] PR #7 (mega) → report jumps to 7.14.0, new sections appear, screenshots required
+- [ ] PR #8 (zcash) → Zcash section tests execute
+
+### Step 5: Verify each PDF
+
+Each PR's `test-report.pdf` is downloaded and reviewed:
+- Pre-mega PRs: 91 tests, existing chains, no `[NEW]` sections
+- Mega PR: 134 tests, `[NEW]` sections at top, inline OLED screenshots
+- Zcash PR: Zcash section tests execute (no longer `--` pending)
+
+---
+
+## File Reference
+
+| File | Location | Purpose | Owner |
+|------|----------|---------|-------|
+| `generate-test-report.py` | `python-keepkey/scripts/` | THE report generator (1061 lines) | python-keepkey `release/7.14.0` |
+| `conftest.py` | `python-keepkey/tests/` | pytest screenshot directory plugin | python-keepkey `release/7.14.0` |
+| `common.py` | `python-keepkey/tests/` | KeepKeyTest base + screenshot setup | python-keepkey `release/7.14.0` |
+| `client.py` | `python-keepkey/keepkeylib/` | SCREENSHOT capture + ButtonRequest hook | python-keepkey `release/7.14.0` |
+| `debuglink.py` | `python-keepkey/keepkeylib/` | `read_layout()` OLED buffer read | python-keepkey `release/7.14.0` |
+| `python-keepkey-tests.sh` | firmware `scripts/emulator/` | CI test runner (Phase 1 + Phase 2) | firmware repo |
+| `ci.yml` | firmware `.github/workflows/` | CI pipeline definition | firmware repo |
+| `generate_report.py` | firmware `scripts/zoo/` | Manual review PDF (separate from test report) | firmware repo |

--- a/include/keepkey/transport/messages.options
+++ b/include/keepkey/transport/messages.options
@@ -109,7 +109,7 @@ ApplyPolicies.policy			max_count:16
 FirmwareUpload.payload_hash  max_size:32
 FirmwareUpload.payload			max_size:0
 
-DebugLinkState.layout			max_size:1024
+DebugLinkState.layout			max_size:2048
 DebugLinkState.pin			max_size:10
 DebugLinkState.matrix			max_size:10
 DebugLinkState.mnemonic			max_size:241

--- a/lib/firmware/fsm_msg_debug.h
+++ b/lib/firmware/fsm_msg_debug.h
@@ -46,6 +46,35 @@ void fsm_msgDebugLinkGetState(DebugLinkGetState* msg) {
   resp->storage_hash.size =
       memory_storage_hash(resp->storage_hash.bytes, storage_getLocation());
 
+  /* Render pending animations ONLY if the animation queue is active.
+   * Static layouts (warning screens, address displays) write directly
+   * to the canvas — calling animate() unconditionally overwrites them
+   * with stale animation frames. Only run animations when queued. */
+  if (is_animating()) {
+    force_animation_start();
+    animate();
+  }
+  display_refresh();
+
+  /* Pack 256x64 grayscale canvas into 1bpp layout for screenshot capture.
+   * Each byte in layout holds 8 vertical pixels (LSB = top).
+   * Total: 256 columns x (64/8) rows = 2048 bytes. */
+  {
+    Canvas *c = display_canvas();
+    if (c && c->buffer) {
+      resp->has_layout = true;
+      resp->layout.size = 2048;
+      memset(resp->layout.bytes, 0, 2048);
+      for (int x = 0; x < 256; x++) {
+        for (int y = 0; y < 64; y++) {
+          if (c->buffer[y * 256 + x] > 0) {
+            resp->layout.bytes[x + (y / 8) * 256] |= (1 << (y % 8));
+          }
+        }
+      }
+    }
+  }
+
   msg_debug_write(MessageType_MessageType_DebugLinkState, resp);
 }
 

--- a/scripts/emulator/Dockerfile
+++ b/scripts/emulator/Dockerfile
@@ -3,11 +3,13 @@ FROM kktech/firmware:v15
 WORKDIR /kkemu
 COPY ./ /kkemu
 
+ARG coinsupport=""
 RUN cmake -C ./cmake/caches/emulator.cmake . \
     -DCMAKE_BUILD_TYPE=Debug \
     -DCMAKE_C_COMPILER=clang \
     -DCMAKE_CXX_COMPILER=clang++ \
     -DCMAKE_BUILD_TYPE=Debug \
+    ${coinsupport} \
     -DCMAKE_COLOR_MAKEFILE=ON
 
 RUN make -j

--- a/scripts/emulator/bridge.py
+++ b/scripts/emulator/bridge.py
@@ -20,6 +20,10 @@ ds.connect(debug)
 
 app = Flask(__name__)
 
+@app.route('/health')
+def health():
+    return Response('ok', status=200)
+
 @app.route('/exchange/<string:kind>', methods=['GET', 'POST'])
 def exchange(kind):
 

--- a/scripts/emulator/docker-compose-zoo.yml
+++ b/scripts/emulator/docker-compose-zoo.yml
@@ -1,0 +1,39 @@
+version: '3'
+services:
+  kkemu:
+    image: kktech/kkemu:zoo
+    build:
+      context: '../../'
+      dockerfile: 'scripts/emulator/Dockerfile'
+    networks:
+      - zoo-net
+    ports:
+      - "127.0.0.1:11044:11044/udp"
+      - "127.0.0.1:11045:11045/udp"
+    restart: unless-stopped
+
+  zoo-runner:
+    build:
+      context: '../../'
+      dockerfile: 'scripts/emulator/python-keepkey.Dockerfile'
+    volumes:
+      # Mount test scripts + zoo capture scripts from host (editable without rebuild)
+      - ../../deps/python-keepkey:/kkemu/deps/python-keepkey:ro
+      - ../../scripts/zoo:/kkemu/scripts/zoo:ro
+      # Output dir for screenshots (writable)
+      - ../../zoo-output/screenshots:/output:rw
+    environment:
+      - KK_TRANSPORT_MAIN=kkemu:11044
+      - KK_TRANSPORT_DEBUG=kkemu:11045
+      # ZOO_FLOW: run a single flow (e.g. recovery-cipher, btc-send)
+      # ZOO_MNEMONIC: custom mnemonic for recovery flows
+      # ZOO_ARGS: raw CLI args (overrides ZOO_FLOW/ZOO_MNEMONIC)
+    networks:
+      - zoo-net
+    depends_on:
+      - kkemu
+    entrypoint: ["/bin/sh", "-c", "pip3 install Pillow >/dev/null 2>&1 && python3 /kkemu/scripts/zoo/capture_screenshots.py --output=/output ${ZOO_FLOW:+--flow=$ZOO_FLOW} ${ZOO_MNEMONIC:+--mnemonic=\"$ZOO_MNEMONIC\"} $ZOO_ARGS"]
+
+networks:
+  zoo-net:
+    external: false

--- a/scripts/emulator/docker-compose.yml
+++ b/scripts/emulator/docker-compose.yml
@@ -11,6 +11,12 @@ services:
       - "127.0.0.1:11044:11044/udp"
       - "127.0.0.1:11045:11045/udp"
       - "127.0.0.1:5000:5000"
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:5000/health')\" || exit 1"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
   python-keepkey:
     build:
       context: '../../'
@@ -20,7 +26,8 @@ services:
     networks:
       - local-net
     depends_on:
-      - kkemu
+      kkemu:
+        condition: service_healthy
   firmware-unit:
     build:
       context: '../../'
@@ -31,7 +38,8 @@ services:
     networks:
       - local-net
     depends_on:
-      - kkemu
+      kkemu:
+        condition: service_healthy
 networks:
   local-net:
     external: false

--- a/scripts/emulator/python-keepkey-tests.sh
+++ b/scripts/emulator/python-keepkey-tests.sh
@@ -1,6 +1,82 @@
 #!/bin/sh
+set -e
 
 mkdir -p /kkemu/test-reports/python-keepkey
+mkdir -p /kkemu/test-reports/screenshots
+
+# Wait for emulator
+echo "=== Waiting for emulator ==="
+for i in $(seq 1 20); do
+  if echo -n "PINGPING" | nc -u -w1 kkemu 11044 2>/dev/null | grep -q PONG; then
+    echo "Emulator ready (attempt $i)"
+    break
+  fi
+  echo "  attempt $i/20..."
+  sleep 2
+done
+
 cd deps/python-keepkey/tests
-KK_TRANSPORT_MAIN=kkemu:11044 KK_TRANSPORT_DEBUG=kkemu:11045 pytest -v --junitxml=/kkemu/test-reports/python-keepkey/junit.xml
-echo "$?" > /kkemu/test-reports/python-keepkey/status
+
+# Diagnostic: verify SCREENSHOT flag reaches Python
+echo "=== Pre-flight diagnostic ==="
+KEEPKEY_SCREENSHOT=1 python3 -c "
+import os, sys
+sys.path.insert(0, '..')
+print('KEEPKEY_SCREENSHOT env:', os.environ.get('KEEPKEY_SCREENSHOT', 'NOT SET'))
+from keepkeylib.client import SCREENSHOT
+print('SCREENSHOT global:', SCREENSHOT)
+# Check if _capture_oled has debug logging
+import inspect
+from keepkeylib.client import DebugLinkMixin
+src = inspect.getsource(DebugLinkMixin._capture_oled)
+has_debug = '[SCREENSHOT]' in src
+print('_capture_oled has debug logging:', has_debug)
+print('_capture_oled first 200 chars:', repr(src[:200]))
+" 2>&1
+echo "=== End diagnostic ==="
+
+# Phase 1: Screenshot captures driven by report SECTIONS (single source of truth)
+#
+# generate-test-report.py --screenshot-filter reads SECTIONS and emits a pytest -k
+# expression for every test with non-empty screenshot expectations. Adding screenshots
+# to a test in SECTIONS automatically includes it here — no manual filter maintenance.
+echo "=== Phase 1: Report-driven screenshot capture ==="
+# Auto-detect firmware version from emulator, fall back to env or 7.14.0
+SCREENSHOT_FILTER=$(python3 ../scripts/generate-test-report.py --screenshot-filter ${FW_VERSION:+--fw-version=$FW_VERSION} 2>/dev/null)
+if [ -z "$SCREENSHOT_FILTER" ]; then
+    echo "WARNING: --screenshot-filter returned empty, falling back to full suite"
+    SCREENSHOT_FILTER="test_"
+fi
+echo "Filter: $SCREENSHOT_FILTER"
+KEEPKEY_SCREENSHOT=1 \
+SCREENSHOT_DIR=/kkemu/test-reports/screenshots \
+KK_TRANSPORT_MAIN=kkemu:11044 \
+KK_TRANSPORT_DEBUG=kkemu:11045 \
+pytest -v --tb=short \
+  -k "$SCREENSHOT_FILTER" \
+  --junitxml=/kkemu/test-reports/python-keepkey/junit-screenshots.xml \
+  -s 2>&1 || true
+# pytest exit code is NOT the gate — screenshot count below is.
+# Tests for features not yet merged (gated by requires_firmware/requires_message)
+# may fail or skip here; the real check is: did screenshots get captured?
+
+# Gate: fail fast if screenshots broken
+echo "=== Screenshot results ==="
+find /kkemu/test-reports/screenshots -name '*.png' -ls 2>/dev/null || echo "NO SCREENSHOTS"
+SCREENSHOT_COUNT=$(find /kkemu/test-reports/screenshots -name '*.png' 2>/dev/null | wc -l)
+echo "Total PNGs: $SCREENSHOT_COUNT"
+if [ "$SCREENSHOT_COUNT" -eq 0 ]; then
+    echo "FATAL: KEEPKEY_SCREENSHOT=1 but 0 PNGs captured. Screenshot pipeline is broken."
+    echo "1" > /kkemu/test-reports/python-keepkey/status
+    exit 1
+fi
+
+# Phase 2: Full suite (no screenshots) — non-blocking for JUnit collection.
+# Tests for features not yet merged will fail here; the generate-test-report
+# step uses JUnit XML to mark them FAILED/PENDING in the PDF.
+# Phase 1 (screenshot filter) is the hard gate; Phase 2 is informational.
+echo "=== Phase 2: Full test suite ==="
+KK_TRANSPORT_MAIN=kkemu:11044 \
+KK_TRANSPORT_DEBUG=kkemu:11045 \
+pytest -v --junitxml=/kkemu/test-reports/python-keepkey/junit.xml || true
+echo "0" > /kkemu/test-reports/python-keepkey/status

--- a/scripts/emulator/python-keepkey-tests.sh
+++ b/scripts/emulator/python-keepkey-tests.sh
@@ -71,12 +71,24 @@ if [ "$SCREENSHOT_COUNT" -eq 0 ]; then
     exit 1
 fi
 
-# Phase 2: Full suite (no screenshots) — non-blocking for JUnit collection.
-# Tests for features not yet merged will fail here; the generate-test-report
-# step uses JUnit XML to mark them FAILED/PENDING in the PDF.
-# Phase 1 (screenshot filter) is the hard gate; Phase 2 is informational.
+# Phase 2: Full test suite — SECTIONS is the source of truth.
+# pytest may exit non-zero (some tests fail before gating kicks in),
+# so we capture the JUnit XML regardless, then validate against SECTIONS.
+# Tests that skip via requires_message/requires_firmware are OK.
+# Tests that fail or are missing from JUnit = CI failure.
 echo "=== Phase 2: Full test suite ==="
 KK_TRANSPORT_MAIN=kkemu:11044 \
 KK_TRANSPORT_DEBUG=kkemu:11045 \
 pytest -v --junitxml=/kkemu/test-reports/python-keepkey/junit.xml || true
-echo "0" > /kkemu/test-reports/python-keepkey/status
+
+echo "=== Phase 2: Validate results against SECTIONS ==="
+python3 ../scripts/generate-test-report.py \
+  --validate-junit \
+  --junit=/kkemu/test-reports/python-keepkey/junit.xml \
+  ${FW_VERSION:+--fw-version=$FW_VERSION}
+VALIDATE_RC=$?
+echo "$VALIDATE_RC" > /kkemu/test-reports/python-keepkey/status
+if [ "$VALIDATE_RC" -ne 0 ]; then
+    echo "SECTIONS validation failed — see above for failing tests"
+    exit 1
+fi

--- a/scripts/generate-test-report.py
+++ b/scripts/generate-test-report.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""
+CI trigger for test report generation.
+
+The actual report generator lives in deps/python-keepkey/scripts/generate-test-report.py
+(stdlib-only PDF writer with SECTIONS as single source of truth for test catalog,
+screenshot filter, and report layout).
+
+This script finds the JUnit XML + screenshots from CI artifacts and calls through.
+"""
+import os
+import sys
+import glob
+import subprocess
+
+REPORT_GENERATOR = os.path.join(
+    os.path.dirname(__file__), '..', 'deps', 'python-keepkey', 'scripts', 'generate-test-report.py'
+)
+
+def main():
+    if not os.path.exists(REPORT_GENERATOR):
+        print("ERROR: %s not found — is the python-keepkey submodule initialized?" % REPORT_GENERATOR,
+              file=sys.stderr)
+        sys.exit(1)
+
+    # Collect JUnit XMLs from CI artifacts
+    junit_files = (
+        glob.glob('test-reports/python-keepkey/junit*.xml') +
+        glob.glob('test-reports/firmware-unit/*.xml')
+    )
+
+    # Merge multiple JUnit XMLs into one for the report generator
+    merged = 'test-reports/junit-merged.xml'
+    if junit_files:
+        import xml.etree.ElementTree as ET
+        root = ET.Element('testsuites')
+        for jf in junit_files:
+            try:
+                tree = ET.parse(jf)
+                for suite in tree.iter('testsuite'):
+                    root.append(suite)
+            except ET.ParseError:
+                print("WARN: skipping malformed %s" % jf, file=sys.stderr)
+        ET.ElementTree(root).write(merged, xml_declaration=True, encoding='unicode')
+        print("Merged %d JUnit files -> %s" % (len(junit_files), merged))
+    else:
+        print("WARN: no JUnit XML files found", file=sys.stderr)
+        merged = None
+
+    # Find screenshots directory
+    screenshot_dir = 'test-reports/screenshots'
+    if not os.path.isdir(screenshot_dir):
+        screenshot_dir = None
+
+    # Build command
+    cmd = [sys.executable, REPORT_GENERATOR, '--output=test-report.pdf']
+    if merged:
+        cmd.append('--junit=%s' % merged)
+    if screenshot_dir:
+        cmd.append('--screenshots=%s' % screenshot_dir)
+    fw_version = os.environ.get('FW_VERSION')
+    if fw_version:
+        cmd.append('--fw-version=%s' % fw_version)
+
+    print("Running: %s" % ' '.join(cmd))
+    result = subprocess.run(cmd)
+
+    # Don't exit non-zero -- let the report be uploaded even with partial results
+    if result.returncode != 0:
+        print("WARN: report generator exited %d" % result.returncode, file=sys.stderr)
+
+    if os.path.exists('test-report.pdf'):
+        size = os.path.getsize('test-report.pdf')
+        print("Generated test-report.pdf (%d bytes)" % size)
+    else:
+        print("ERROR: test-report.pdf not created", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/zoo/capture_screenshots.py
+++ b/scripts/zoo/capture_screenshots.py
@@ -1,0 +1,534 @@
+#!/usr/bin/env python3
+"""
+capture_screenshots.py — Orchestrates KeepKey emulator screenshot capture.
+
+Connects to a running emulator via UDP, executes transaction flows,
+and captures the OLED display at each confirmation screen.
+
+Usage:
+  python3 capture_screenshots.py --output=/output [--flow=btc-send]
+  python3 capture_screenshots.py --output=/output --flow=recovery-cipher
+  python3 capture_screenshots.py --output=/output --flow=recovery-cipher --mnemonic="zoo zoo ... wrong"
+
+Requires: emulator running on KK_TRANSPORT_MAIN / KK_TRANSPORT_DEBUG
+"""
+import os
+import sys
+import argparse
+import time
+import json
+
+# Add python-keepkey to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'deps', 'python-keepkey'))
+
+from keepkeylib.client import KeepKeyDebuglinkClient
+from keepkeylib.transport_udp import UDPTransport
+from keepkeylib import messages_pb2 as proto
+from keepkeylib import messages_ethereum_pb2 as eth_proto
+from keepkeylib import messages_solana_pb2 as sol_proto
+from keepkeylib import messages_tron_pb2 as tron_proto
+from keepkeylib import messages_ton_pb2 as ton_proto
+from keepkeylib import messages_zcash_pb2 as zec_proto
+from screenshot import capture_screenshot
+
+
+def make_client():
+    """Create a DebugLink client connected to the emulator."""
+    main_host = os.environ.get('KK_TRANSPORT_MAIN', '127.0.0.1:11044')
+    debug_host = os.environ.get('KK_TRANSPORT_DEBUG', '127.0.0.1:11045')
+
+    transport = UDPTransport(main_host)
+    client = KeepKeyDebuglinkClient(transport)
+    debug_transport = UDPTransport(debug_host)
+    client.set_debuglink(debug_transport)
+    # Disable auto-confirm so we control capture timing
+    client.auto_button = False
+    return client
+
+
+def reset_device(client, mnemonic='all ' * 11 + 'all'):
+    """Wipe and load a known mnemonic for deterministic screenshots."""
+    client.auto_button = True  # auto-confirm for setup
+    client.wipe_device()
+    client.load_device_by_mnemonic(
+        mnemonic=mnemonic.strip(),
+        pin='',
+        passphrase_protection=False,
+        label='KeepKey Zoo',
+        language='english',
+    )
+    client.auto_button = False  # back to manual for captures
+
+
+def capture(client, output_dir, name):
+    """Capture current OLED state to output_dir/name.png."""
+    path = os.path.join(output_dir, name)
+    ok = capture_screenshot(client.debug, path, scale=3)
+    if ok:
+        fsize = os.path.getsize(path)
+        status = 'OK' if fsize > 400 else 'BLANK?'
+        print(f"    [{status}] {name} ({fsize}B)")
+    return ok
+
+
+def capture_with_meta(client, output_dir, name, meta):
+    """Capture OLED + save metadata JSON sidecar."""
+    ok = capture(client, output_dir, name)
+    if ok and meta:
+        json_path = os.path.join(output_dir, name.replace('.png', '.json'))
+        with open(json_path, 'w') as f:
+            json.dump(meta, f, indent=2)
+    return ok
+
+
+def send_and_capture(client, msg, output_dir, screen_name):
+    """Send msg, wait for ButtonRequest, capture OLED, then confirm.
+
+    Core pattern: send -> ButtonRequest (screen displayed) -> capture -> press -> advance.
+    """
+    ret = client.call_raw(msg)
+    while isinstance(ret, proto.ButtonRequest):
+        time.sleep(0.15)  # animation flush
+        capture(client, output_dir, screen_name)
+        client.debug.press_yes()
+        ret = client.call_raw(proto.ButtonAck())
+    return ret
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Flow: BTC Send
+# ═══════════════════════════════════════════════════════════════════════
+
+def flow_btc_send(client, out):
+    """Bitcoin send flow — address display."""
+    from keepkeylib import tx_api
+    client.set_tx_api(tx_api.TxApiBitcoin)
+    reset_device(client)
+
+    print("  [btc-send] Get address (show on device)...")
+    send_and_capture(client, proto.GetAddress(
+        address_n=[44 | 0x80000000, 0 | 0x80000000, 0 | 0x80000000, 0, 0],
+        coin_name='Bitcoin',
+        show_display=True,
+    ), out, '01-btc-get-address.png')
+
+
+def flow_btc_sign(client, out):
+    """Bitcoin sign transaction — confirm output + fee screens."""
+    from keepkeylib import tx_api
+    client.set_tx_api(tx_api.TxApiBitcoin)
+    reset_device(client)
+
+    print("  [btc-sign] Sign transaction...")
+    # Use a simple 1-in-1-out tx
+    inp1 = proto.TxInputType(
+        address_n=[44 | 0x80000000, 0 | 0x80000000, 0 | 0x80000000, 0, 0],
+        prev_hash=bytes.fromhex('d5f65ee80147b4bcc70b75e4bbf2d7382021b871bd8867ef8fa525ef50864882'),
+        prev_index=0,
+        amount=390000,
+    )
+    out1 = proto.TxOutputType(
+        address='1MJ2tj2ThBE62pXbBSwVDT1Gn72SKPkLhD',
+        amount=380000,
+        script_type=proto.OutputScriptType.Value('PAYTOADDRESS'),
+    )
+
+    try:
+        (signatures, serialized_tx) = client.sign_tx('Bitcoin', [inp1], [out1])
+        # Screenshots captured during the sign flow via DebugLink auto-confirm
+    except Exception as e:
+        print(f"    sign_tx raised: {e}")
+
+    capture(client, out, '02-btc-confirm-output.png')
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Flow: ETH Send
+# ═══════════════════════════════════════════════════════════════════════
+
+def flow_eth_send(client, out):
+    """Ethereum send flow — address display."""
+    reset_device(client)
+
+    print("  [eth-send] Get ETH address...")
+    send_and_capture(client, eth_proto.EthereumGetAddress(
+        address_n=[44 | 0x80000000, 60 | 0x80000000, 0 | 0x80000000, 0, 0],
+        show_display=True,
+    ), out, '01-eth-get-address.png')
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Flow: Solana
+# ═══════════════════════════════════════════════════════════════════════
+
+def flow_solana_address(client, out):
+    """Solana get address — full 44-char base58."""
+    reset_device(client)
+
+    print("  [solana] Get Solana address...")
+    try:
+        send_and_capture(client, sol_proto.SolanaGetAddress(
+            address_n=[44 | 0x80000000, 501 | 0x80000000, 0 | 0x80000000],
+            show_display=True,
+        ), out, '01-sol-get-address.png')
+    except Exception as e:
+        print(f"    solana not available: {e}")
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Flow: Recovery Cipher (character-by-character seed entry)
+# ═══════════════════════════════════════════════════════════════════════
+
+def flow_recovery_cipher(client, out, mnemonic=None, word_count=12, with_pin=False):
+    """Recovery cipher flow — captures every screen of character-by-character
+    seed phrase entry. This is the major UX bottleneck for users.
+
+    Captures:
+      - Initial "reminder" / instructions screen
+      - First cipher grid (scrambled alphabet)
+      - Character entry progression (each keystroke updates the grid)
+      - Auto-complete events (word matched from partial input)
+      - Word boundary transitions (space between words)
+      - Final confirmation / success screen
+
+    Each screenshot gets a JSON sidecar with metadata:
+      - cipher: the 26-char scrambled alphabet mapping
+      - word_index: which word (0-based)
+      - char_index: which character within the word
+      - typed_so_far: characters entered for current word
+      - auto_completed: the word if auto-complete triggered
+      - phase: 'pin' | 'reminder' | 'cipher_grid' | 'char_entry' | 'auto_complete' | 'word_space' | 'done'
+    """
+
+    if mnemonic is None:
+        mnemonic = 'all ' * 11 + 'all'
+    mnemonic = mnemonic.strip()
+    mnemonic_words = mnemonic.split()
+
+    if word_count is None:
+        word_count = len(mnemonic_words)
+
+    print(f"  [recovery-cipher] {word_count}-word recovery, {len(mnemonic_words)} words to enter")
+    print(f"  [recovery-cipher] First 3 words: {' '.join(mnemonic_words[:3])}...")
+
+    # Step 1: Wipe the device so it's uninitialized
+    client.wipe_device()
+
+    step = 1
+
+    # Step 2: Start recovery
+    ret = client.call_raw(proto.RecoveryDevice(
+        word_count=word_count,
+        passphrase_protection=False,
+        pin_protection=with_pin,
+        label='KeepKey Zoo Recovery',
+        language='english',
+        enforce_wordlist=True,
+        use_character_cipher=True,
+    ))
+
+    # Step 3: Handle optional PIN entry
+    if with_pin and isinstance(ret, proto.PinMatrixRequest):
+        capture_with_meta(client, out, f'{step:02d}-pin-entry-1.png', {
+            'phase': 'pin', 'step': 'first_pin_entry',
+        })
+        step += 1
+
+        pin_encoded = client.debug.encode_pin('135246')
+        ret = client.call_raw(proto.PinMatrixAck(pin=pin_encoded))
+
+        if isinstance(ret, proto.PinMatrixRequest):
+            capture_with_meta(client, out, f'{step:02d}-pin-entry-2.png', {
+                'phase': 'pin', 'step': 'confirm_pin_entry',
+            })
+            step += 1
+            pin_encoded = client.debug.encode_pin('135246')
+            ret = client.call_raw(proto.PinMatrixAck(pin=pin_encoded))
+
+    # Step 4: Reminder / instructions screen (ButtonRequest)
+    if isinstance(ret, proto.ButtonRequest):
+        capture_with_meta(client, out, f'{step:02d}-recovery-reminder.png', {
+            'phase': 'reminder',
+            'description': 'Instructions screen before cipher entry begins',
+        })
+        step += 1
+        client.debug.press_yes()
+        ret = client.call_raw(proto.ButtonAck())
+
+    # Step 5: Character-by-character cipher entry
+    total_chars = 0
+    total_auto_completes = 0
+    recovery_log = []
+
+    for word_idx, word in enumerate(mnemonic_words):
+        word_chars_entered = []
+        print(f"    Word {word_idx + 1}/{len(mnemonic_words)}: '{word}'")
+
+        for char_idx, character in enumerate(word):
+            if not isinstance(ret, proto.CharacterRequest):
+                print(f"    WARNING: Expected CharacterRequest, got {ret.__class__.__name__}")
+                capture_with_meta(client, out, f'{step:02d}-unexpected-{ret.__class__.__name__}.png', {
+                    'phase': 'error',
+                    'expected': 'CharacterRequest',
+                    'got': ret.__class__.__name__,
+                    'word_index': word_idx,
+                    'char_index': char_idx,
+                })
+                step += 1
+                break
+
+            # Read cipher + layout in one DebugLink call (avoids 3 round-trips)
+            recovery_state = client.debug.read_recovery_state()
+            cipher = recovery_state['cipher']
+
+            # Capture the cipher grid screen BEFORE sending character
+            is_first_char = (char_idx == 0)
+            capture_name = f'{step:02d}-w{word_idx + 1:02d}-c{char_idx + 1:02d}-cipher'
+            if is_first_char:
+                capture_name += '-initial'
+            capture_name += '.png'
+
+            meta = {
+                'phase': 'cipher_grid' if is_first_char else 'char_entry',
+                'word_index': word_idx,
+                'word': word,
+                'char_index': char_idx,
+                'target_char': character,
+                'typed_so_far': ''.join(word_chars_entered),
+                'cipher': cipher if isinstance(cipher, str) else cipher.decode('ascii', errors='replace'),
+                'cipher_mapping': {chr(97 + i): (cipher[i] if isinstance(cipher[i], str) else chr(cipher[i]))
+                                   for i in range(min(26, len(cipher)))},
+            }
+            capture_with_meta(client, out, capture_name, meta)
+            step += 1
+            total_chars += 1
+
+            # Encode and send the character through the cipher
+            encoded_character = cipher[ord(character) - 97]
+            ret = client.call_raw(proto.CharacterAck(character=encoded_character))
+            word_chars_entered.append(character)
+
+            # Check for auto-complete (single call)
+            auto_completed = client.debug.read_recovery_auto_completed_word()
+
+            if word == auto_completed:
+                total_auto_completes += 1
+                print(f"      Auto-completed '{word}' after {len(word_chars_entered)} chars")
+
+                # Capture the auto-complete screen
+                capture_with_meta(client, out, f'{step:02d}-w{word_idx + 1:02d}-auto-complete.png', {
+                    'phase': 'auto_complete',
+                    'word_index': word_idx,
+                    'word': word,
+                    'chars_needed': len(word_chars_entered),
+                    'total_chars_in_word': len(word),
+                })
+                step += 1
+
+                recovery_log.append({
+                    'word': word,
+                    'chars_typed': len(word_chars_entered),
+                    'auto_completed': True,
+                })
+
+                # Send space to move to next word (except last)
+                if word_idx < len(mnemonic_words) - 1:
+                    capture_with_meta(client, out, f'{step:02d}-w{word_idx + 1:02d}-word-space.png', {
+                        'phase': 'word_space',
+                        'word_index': word_idx,
+                        'completed_word': word,
+                        'next_word_index': word_idx + 1,
+                    })
+                    step += 1
+                    ret = client.call_raw(proto.CharacterAck(character=' '))
+                break
+        else:
+            # Word was fully typed without auto-complete
+            recovery_log.append({
+                'word': word,
+                'chars_typed': len(word),
+                'auto_completed': False,
+            })
+            # Send space to move to next word (except last)
+            if word_idx < len(mnemonic_words) - 1:
+                if isinstance(ret, proto.CharacterRequest):
+                    ret = client.call_raw(proto.CharacterAck(character=' '))
+
+    # Step 6: Final CharacterAck(done=True)
+    if isinstance(ret, proto.CharacterRequest):
+        capture_with_meta(client, out, f'{step:02d}-final-before-done.png', {
+            'phase': 'done',
+            'description': 'Final screen before submitting recovery',
+            'total_chars_typed': total_chars,
+            'total_auto_completes': total_auto_completes,
+        })
+        step += 1
+        ret = client.call_raw(proto.CharacterAck(done=True))
+
+    # Step 7: Capture the result
+    if isinstance(ret, proto.Success):
+        print(f"    Recovery SUCCESS: {ret.message}")
+        capture_with_meta(client, out, f'{step:02d}-recovery-success.png', {
+            'phase': 'success',
+            'message': ret.message,
+            'total_screenshots': step,
+            'total_chars_typed': total_chars,
+            'total_auto_completes': total_auto_completes,
+        })
+    elif isinstance(ret, proto.Failure):
+        print(f"    Recovery FAILED: {ret.message}")
+        capture_with_meta(client, out, f'{step:02d}-recovery-failure.png', {
+            'phase': 'failure',
+            'message': ret.message,
+        })
+    else:
+        print(f"    Unexpected response: {ret.__class__.__name__}")
+        capture_with_meta(client, out, f'{step:02d}-recovery-unexpected.png', {
+            'phase': 'error',
+            'response_type': ret.__class__.__name__,
+        })
+
+    step += 1
+
+    # Write summary log
+    summary = {
+        'flow': 'recovery-cipher',
+        'word_count': word_count,
+        'total_screenshots': step - 1,
+        'total_chars_typed': total_chars,
+        'total_auto_completes': total_auto_completes,
+        'with_pin': with_pin,
+        'words': recovery_log,
+    }
+    summary_path = os.path.join(out, 'summary.json')
+    with open(summary_path, 'w') as f:
+        json.dump(summary, f, indent=2)
+    print(f"    -> summary.json ({step - 1} screenshots, {total_chars} chars, {total_auto_completes} auto-completes)")
+
+
+def flow_recovery_cipher_with_pin(client, out, mnemonic=None):
+    """Recovery cipher with PIN — tests the full PIN + cipher flow."""
+    flow_recovery_cipher(client, out, mnemonic=mnemonic, with_pin=True)
+
+
+def flow_recovery_cipher_24(client, out):
+    """Recovery cipher with 24-word mnemonic."""
+    mnemonic_24 = 'dignity pass list indicate nasty swamp pool script soccer toe leaf photo multiply desk host tomato cradle drill spread actor shine dismiss champion exotic'
+    flow_recovery_cipher(client, out, mnemonic=mnemonic_24, word_count=24)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Flow: TRON
+# ═══════════════════════════════════════════════════════════════════════
+
+def flow_tron_send(client, out):
+    """TRON address display."""
+    reset_device(client)
+
+    print("  [tron] Get TRON address...")
+    try:
+        send_and_capture(client, tron_proto.TronGetAddress(
+            address_n=[44 | 0x80000000, 195 | 0x80000000, 0 | 0x80000000, 0, 0],
+            show_display=True,
+        ), out, '01-tron-get-address.png')
+    except Exception as e:
+        print(f"    tron not available: {e}")
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Flow: TON
+# ═══════════════════════════════════════════════════════════════════════
+
+def flow_ton_send(client, out):
+    """TON address display."""
+    reset_device(client)
+
+    print("  [ton] Get TON address...")
+    try:
+        send_and_capture(client, ton_proto.TonGetAddress(
+            address_n=[44 | 0x80000000, 607 | 0x80000000, 0 | 0x80000000],
+            show_display=True,
+        ), out, '01-ton-get-address.png')
+    except Exception as e:
+        print(f"    ton sign not available: {e}")
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Flow: Zcash Orchard
+# ═══════════════════════════════════════════════════════════════════════
+
+def flow_zcash_fvk(client, out):
+    """Zcash Orchard Full Viewing Key derivation."""
+    reset_device(client)
+
+    print("  [zcash] Get Orchard FVK...")
+    try:
+        send_and_capture(client, zec_proto.ZcashGetOrchardFVK(
+            address_n=[32 | 0x80000000, 133 | 0x80000000, 0 | 0x80000000],
+        ), out, '01-zcash-orchard-fvk.png')
+    except Exception as e:
+        print(f"    zcash fvk not available: {e}")
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Flow Registry
+# ═══════════════════════════════════════════════════════════════════════
+
+FLOWS = {
+    'btc-send': flow_btc_send,
+    'btc-sign': flow_btc_sign,
+    'eth-send': flow_eth_send,
+    'solana-address': flow_solana_address,
+    'tron-send': flow_tron_send,
+    'ton-send': flow_ton_send,
+    'zcash-fvk': flow_zcash_fvk,
+    'recovery-cipher': flow_recovery_cipher,
+    'recovery-cipher-pin': flow_recovery_cipher_with_pin,
+    'recovery-cipher-24': flow_recovery_cipher_24,
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description='KeepKey Zoo Screenshot Capture')
+    parser.add_argument('--output', default='zoo-output/screenshots', help='Output directory')
+    parser.add_argument('--flow', default=None, help='Run single flow (default: all)')
+    parser.add_argument('--mnemonic', default=None, help='Custom mnemonic for recovery flows')
+    parser.add_argument('--list-flows', action='store_true', help='List available flows')
+    args = parser.parse_args()
+
+    if args.list_flows:
+        print("\nAvailable flows:")
+        for name, func in FLOWS.items():
+            doc = (func.__doc__ or '').split('\n')[0].strip()
+            print(f"  {name:25s} {doc}")
+        print()
+        return
+
+    print("\nKeepKey Zoo — Screenshot Capture\n")
+
+    client = make_client()
+
+    flows_to_run = {args.flow: FLOWS[args.flow]} if args.flow else FLOWS
+
+    for name, func in flows_to_run.items():
+        flow_dir = os.path.join(args.output, name)
+        os.makedirs(flow_dir, exist_ok=True)
+        print(f"  Flow: {name}")
+        try:
+            # Pass mnemonic to recovery flows that accept it
+            if args.mnemonic and name.startswith('recovery-cipher') and name != 'recovery-cipher-24':
+                func(client, flow_dir, mnemonic=args.mnemonic)
+            else:
+                func(client, flow_dir)
+        except Exception as e:
+            import traceback
+            print(f"    ERROR: {e}")
+            traceback.print_exc()
+        print()
+
+    print(f"  Screenshots: {args.output}/")
+    print("  Done.\n")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/zoo/generate_report.py
+++ b/scripts/zoo/generate_report.py
@@ -1,0 +1,571 @@
+#!/usr/bin/env python3
+"""
+generate_report.py — Firmware review PDF from real KeepKey emulator screenshots.
+
+Generates a human-readable firmware release document with:
+  - Executive summary of firmware capabilities
+  - Per-chain sections with real OLED captures + security context
+  - Feature highlights (what changed, why it matters)
+  - Recovery cipher UX walkthrough
+
+Usage:
+  python3 generate_report.py \
+    --screenshots /tmp/zoo-test \
+    --output artifacts/firmware-review.pdf \
+    --version "7.14.0"
+"""
+import os
+import sys
+import json
+import argparse
+import glob
+from datetime import datetime
+
+from fpdf import FPDF
+from PIL import Image, ImageDraw
+
+
+def safe(text):
+    """Strip non-latin1 chars for PDF core fonts."""
+    return str(text).encode('latin-1', errors='replace').decode('latin-1')
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Report content — what goes on each page
+# ═══════════════════════════════════════════════════════════════════════
+
+CHAIN_SECTIONS = [
+    {
+        'id': 'btc',
+        'title': 'Bitcoin (BTC)',
+        'accent': (247, 147, 26),
+        'security': 'CRITICAL',
+        'screenshots': ['btc-address.png', 'btc-segwit.png'],
+        'what': 'Full address display with QR code. Supports legacy (P2PKH), SegWit (P2SH-P2WPKH), and native SegWit (bech32) address types.',
+        'why': 'Address verification on the device screen is the primary defense against clipboard hijacking malware. The QR code enables air-gapped verification with a phone camera.',
+        'details': [
+            'Legacy, SegWit, and native SegWit addresses supported',
+            'QR code rendered on device for mobile verification',
+            'Full address shown - no truncation',
+            'Account and address index displayed',
+        ],
+    },
+    {
+        'id': 'eth',
+        'title': 'Ethereum (ETH)',
+        'accent': (98, 126, 234),
+        'security': 'CRITICAL',
+        'screenshots': ['eth-address.png'],
+        'what': 'Full 42-character hex address display. Supports EIP-155 chain ID for all EVM networks (Polygon, Arbitrum, Optimism, Avalanche, BSC, Base).',
+        'why': 'ETH addresses lack built-in checksums. The device screen is the only reliable verification point. Chain ID display prevents cross-network sends.',
+        'details': [
+            'Full 0x-prefixed address (42 chars)',
+            'EIP-155 chain ID for multi-chain EVM support',
+            'Same derivation path m/44\'/60\'/0\'/0/0 for all EVM chains',
+            'Gas price and limit shown during signing',
+        ],
+    },
+    {
+        'id': 'solana',
+        'title': 'Solana (SOL)',
+        'accent': (20, 241, 149),
+        'security': 'CRITICAL',
+        'new': True,
+        'screenshots': ['solana-address.png'],
+        'what': 'Full 44-character base58 address display. Native SOL transfers, SPL token transfers, and unknown program instruction handling with clear-signing.',
+        'why': 'Solana base58 addresses are 32-44 characters. Middle-truncation (XXXX...XXXX) was a spoofing vector in older firmware -- attackers could craft keys with matching prefix+suffix. Full display eliminates this.',
+        'details': [
+            'Full 44-character base58 address (no truncation)',
+            'Native SOL and SPL token transfer parsing',
+            'Unknown programs show full program ID for verification',
+            'Transaction instruction count displayed',
+        ],
+    },
+    {
+        'id': 'cosmos',
+        'title': 'Cosmos (ATOM)',
+        'accent': (100, 100, 200),
+        'security': 'HIGH',
+        'screenshots': ['cosmos-address.png'],
+        'what': 'Cosmos bech32 address display with full address verification. Supports MsgSend with amount, recipient, and memo.',
+        'why': 'Cosmos addresses use bech32 encoding with chain-specific prefixes. Full display ensures the user verifies the correct chain and address.',
+        'details': [
+            'Full bech32 address with cosmos1... prefix',
+            'Amount, recipient, memo shown during signing',
+            'QR code for mobile verification',
+        ],
+    },
+    {
+        'id': 'thorchain',
+        'title': 'THORChain (RUNE)',
+        'accent': (35, 220, 200),
+        'security': 'HIGH',
+        'screenshots': ['thorchain-address.png'],
+        'what': 'THORChain address display and swap transaction signing with full memo verification.',
+        'why': 'THORChain swap memos control the entire swap operation. Memo manipulation can redirect funds to an attacker address. Full memo display is essential.',
+        'details': [
+            'Full thor1... bech32 address',
+            'Swap memo shown in full during signing',
+            'Amount and fee verification',
+        ],
+    },
+    {
+        'id': 'maya',
+        'title': 'Maya Protocol (CACAO)',
+        'accent': (60, 180, 220),
+        'security': 'HIGH',
+        'screenshots': ['maya-address.png'],
+        'what': 'Maya Protocol address display and cross-chain swap signing.',
+        'why': 'Maya is a THORChain fork -- same memo-based swap architecture requires full memo verification.',
+        'details': [
+            'Full maya1... bech32 address',
+            'Cross-chain swap memo verification',
+        ],
+    },
+    {
+        'id': 'osmosis',
+        'title': 'Osmosis (OSMO)',
+        'accent': (180, 80, 220),
+        'security': 'HIGH',
+        'screenshots': ['osmosis-address.png'],
+        'what': 'Osmosis address display with IBC transfer and LP operation support.',
+        'why': 'Osmosis IBC transfers cross chain boundaries. Full address and memo verification prevents fund loss to wrong chains.',
+        'details': [
+            'Full osmo1... bech32 address',
+            'IBC transfer memo support',
+        ],
+    },
+    {
+        'id': 'xrp',
+        'title': 'Ripple (XRP)',
+        'accent': (35, 160, 230),
+        'security': 'HIGH',
+        'screenshots': ['xrp-address.png'],
+        'what': 'XRP address display with destination tag support.',
+        'why': 'XRP destination tags route funds to specific accounts on exchanges. Missing or wrong tags cause permanent fund loss.',
+        'details': [
+            'Full r... address display',
+            'Destination tag shown when present',
+            'Amount in drops converted to XRP',
+        ],
+    },
+    {
+        'id': 'ltc',
+        'title': 'Litecoin (LTC)',
+        'accent': (190, 190, 190),
+        'security': 'HIGH',
+        'screenshots': ['ltc-address.png'],
+        'what': 'Litecoin address display with legacy and SegWit support.',
+        'why': 'Same UTXO model as Bitcoin. Full address verification prevents address substitution attacks.',
+        'details': ['Full L.../M.../ltc1... address with QR code'],
+    },
+    {
+        'id': 'bch',
+        'title': 'Bitcoin Cash (BCH)',
+        'accent': (140, 200, 60),
+        'security': 'HIGH',
+        'screenshots': ['bch-address.png'],
+        'what': 'Bitcoin Cash CashAddr format display.',
+        'why': 'BCH and BTC share similar address formats. Device shows the coin name to prevent cross-chain sends.',
+        'details': ['CashAddr format with coin identification'],
+    },
+    {
+        'id': 'doge',
+        'title': 'Dogecoin (DOGE)',
+        'accent': (200, 180, 50),
+        'security': 'HIGH',
+        'screenshots': ['doge-address.png'],
+        'what': 'Dogecoin address display with full verification.',
+        'why': 'UTXO chain with Bitcoin-derived address format. Device verification prevents address swaps.',
+        'details': ['Full D... address with QR code'],
+    },
+    {
+        'id': 'dash',
+        'title': 'Dash (DASH)',
+        'accent': (0, 140, 230),
+        'security': 'HIGH',
+        'screenshots': ['dash-address.png'],
+        'what': 'Dash address display.',
+        'why': 'UTXO chain requiring device-side address verification.',
+        'details': ['Full X... address with QR code'],
+    },
+]
+
+FEATURE_SECTIONS = [
+    {
+        'id': 'recovery-cipher',
+        'title': 'Recovery Cipher (Seed Entry)',
+        'accent': (20, 241, 149),
+        'security': 'CRITICAL',
+        'new_in_release': True,
+        'screenshots': {
+            'dir': 'recovery-cipher-v10',
+            'picks': ['01-recovery-reminder.png', '02-w01-c01-cipher-initial.png',
+                       '07-w02-c01-cipher-initial.png', '63-w12-c01-cipher-initial.png',
+                       '68-recovery-success.png'],
+        },
+        'what': 'Character-by-character seed phrase entry using a scrambled cipher grid. Previous completed word now displayed below current word progress (new in 7.14.0).',
+        'why': 'The cipher grid reshuffles after every keystroke, preventing keylogger and screen-watching attacks. The new previous-word display (e.g. "11: anger") helps users track their position without losing context during the tedious 12/24 word entry process.',
+        'highlights': [
+            'NEW: Previous completed word shown below current progress',
+            'Full auto-completed BIP39 word displayed (not truncated)',
+            'Cipher grid reshuffles every character entry',
+            'Auto-complete after 3-4 chars when unique BIP39 match found',
+            'Per-word BIP39 validation rejects invalid words immediately',
+        ],
+    },
+]
+
+SECURITY_COLORS = {
+    'CRITICAL': (220, 50, 50),
+    'HIGH': (240, 160, 20),
+    'MEDIUM': (240, 190, 30),
+}
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# PDF Builder
+# ═══════════════════════════════════════════════════════════════════════
+
+class FirmwareReport(FPDF):
+
+    def __init__(self, version='7.14.0'):
+        super().__init__(orientation='P', unit='mm', format='letter')
+        self.fw_version = version
+        self.set_auto_page_break(auto=True, margin=15)
+
+    def header(self):
+        if self.page_no() <= 1:
+            return
+        self.set_font('Helvetica', '', 7)
+        self.set_text_color(140, 140, 140)
+        self.cell(0, 4, safe(f'KeepKey Firmware {self.fw_version} - Screen Review'), align='L')
+        self.ln(6)
+
+    def footer(self):
+        self.set_y(-10)
+        self.set_font('Helvetica', '', 7)
+        self.set_text_color(160, 160, 160)
+        self.cell(0, 4, f'Page {self.page_no()}', align='C')
+
+    def _badge(self, x, y, text, color):
+        self.set_fill_color(*color)
+        w = self.get_string_width(text) + 6
+        self.rect(x, y, w, 5, 'F')
+        self.set_xy(x + 3, y + 0.5)
+        self.set_font('Helvetica', 'B', 7)
+        self.set_text_color(255, 255, 255)
+        self.cell(0, 4, text)
+
+    def _section_header(self, title, accent, security=None, is_new=False):
+        self.set_fill_color(18, 18, 26)
+        self.rect(0, self.get_y(), 216, 12, 'F')
+        self.set_fill_color(*accent)
+        self.rect(0, self.get_y() + 12, 216, 0.6, 'F')
+        self.set_xy(10, self.get_y() + 2)
+        self.set_font('Helvetica', 'B', 12)
+        self.set_text_color(255, 255, 255)
+        self.cell(0, 8, safe(title))
+        if is_new:
+            self._badge(self.get_string_width(title) + 16, self.get_y() + 3, 'NEW', (20, 180, 80))
+        if security:
+            sc = SECURITY_COLORS.get(security, (100, 100, 100))
+            self.set_xy(180, self.get_y())
+            self.set_font('Helvetica', 'B', 8)
+            self.set_text_color(*sc)
+            self.cell(0, 8, security)
+        self.set_y(self.get_y() + 15)
+
+    def _embed_screenshot(self, path, caption=None):
+        """Embed a real emulator screenshot with device bezel."""
+        if not os.path.exists(path):
+            return
+        try:
+            img = Image.open(path)
+            # Add black bezel
+            pw, ph = img.width + 16, img.height + 12
+            bezel = Image.new('RGB', (pw, ph), (0, 0, 0))
+            bezel.paste(img, (8, 6))
+            draw = ImageDraw.Draw(bezel)
+            draw.rectangle([0, 0, pw - 1, ph - 1], outline=(80, 80, 80))
+
+            tmp = path + '.tmp.png'
+            bezel.save(tmp)
+
+            w_mm = 140
+            h_mm = w_mm * ph / pw
+            if h_mm > 50:
+                h_mm = 50
+                w_mm = h_mm * pw / ph
+
+            x = (216 - w_mm) / 2  # center
+            self.image(tmp, x=x, y=self.get_y(), w=w_mm)
+            self.set_y(self.get_y() + h_mm + 2)
+            os.remove(tmp)
+
+            if caption:
+                self.set_font('Helvetica', 'I', 7)
+                self.set_text_color(120, 120, 120)
+                self.cell(0, 4, safe(caption), align='C')
+                self.ln(5)
+        except Exception as e:
+            self.set_font('Helvetica', '', 8)
+            self.set_text_color(200, 50, 50)
+            self.cell(0, 4, f'[image error: {e}]')
+            self.ln(5)
+
+    # ── Pages ─────────────────────────────────────────────────────────
+
+    def add_title_page(self, chain_count, feature_count, screenshot_count):
+        self.add_page()
+
+        # Header
+        self.set_fill_color(18, 18, 26)
+        self.rect(0, 0, 216, 40, 'F')
+        self.set_fill_color(20, 241, 149)
+        self.rect(0, 40, 216, 1.2, 'F')
+
+        self.set_xy(14, 8)
+        self.set_font('Helvetica', 'B', 24)
+        self.set_text_color(255, 255, 255)
+        self.cell(0, 10, 'KeepKey Firmware')
+
+        self.set_xy(14, 22)
+        self.set_font('Helvetica', 'B', 14)
+        self.set_text_color(20, 241, 149)
+        self.cell(0, 10, safe(f'v{self.fw_version} Screen Review'))
+
+        self.set_xy(160, 10)
+        self.set_font('Helvetica', '', 9)
+        self.set_text_color(160, 160, 160)
+        self.cell(0, 5, datetime.now().strftime('%Y-%m-%d'))
+
+        # Summary box
+        y = 50
+        self.set_xy(14, y)
+        self.set_font('Helvetica', 'B', 11)
+        self.set_text_color(40, 40, 40)
+        self.cell(0, 7, 'About This Report')
+        y += 9
+        self.set_xy(14, y)
+        self.set_font('Helvetica', '', 9)
+        self.set_text_color(60, 60, 60)
+        self.multi_cell(185, 5, safe(
+            'This document presents real screenshots captured from the KeepKey firmware emulator '
+            'via DebugLink. Every image is a pixel-accurate rendering of what users see on the '
+            '256x64 OLED display during address verification, transaction signing, and device management. '
+            'No synthetic mockups -- all screens are captured from running firmware.'
+        ))
+        y = self.get_y() + 6
+
+        # Stats
+        self.set_xy(14, y)
+        self.set_font('Helvetica', 'B', 11)
+        self.cell(0, 7, 'Coverage')
+        y += 9
+        stats = [
+            (f'{chain_count} chains', 'Address display verified'),
+            (f'{feature_count} features', 'Security-critical flows documented'),
+            (f'{screenshot_count} screenshots', 'Real emulator captures (not mockups)'),
+        ]
+        for val, desc in stats:
+            self.set_xy(18, y)
+            self.set_font('Helvetica', 'B', 9)
+            self.set_text_color(20, 140, 80)
+            self.cell(30, 5, val)
+            self.set_font('Helvetica', '', 9)
+            self.set_text_color(80, 80, 80)
+            self.cell(0, 5, desc)
+            y += 6
+
+    def add_chain_page(self, section, screenshots_dir):
+        self.add_page()
+        self._section_header(
+            section['title'], section['accent'],
+            section.get('security'), section.get('new', False))
+
+        y = self.get_y()
+
+        # What it shows
+        self.set_xy(10, y)
+        self.set_font('Helvetica', 'B', 9)
+        self.set_text_color(40, 40, 40)
+        self.cell(0, 5, 'What The User Sees')
+        self.ln(6)
+        self.set_x(10)
+        self.set_font('Helvetica', '', 9)
+        self.set_text_color(60, 60, 60)
+        self.multi_cell(192, 5, safe(section['what']))
+        self.ln(2)
+
+        # Screenshots
+        for fname in section.get('screenshots', []):
+            path = os.path.join(screenshots_dir, fname)
+            self._embed_screenshot(path, fname.replace('.png', '').replace('-', ' '))
+
+        # Why it matters
+        self.set_x(10)
+        self.set_font('Helvetica', 'B', 9)
+        self.set_text_color(40, 40, 40)
+        self.cell(0, 5, 'Why This Matters')
+        self.ln(6)
+        self.set_x(10)
+        self.set_font('Helvetica', '', 9)
+        self.set_text_color(60, 60, 60)
+        self.multi_cell(192, 5, safe(section['why']))
+        self.ln(3)
+
+        # Details
+        if section.get('details'):
+            self.set_x(10)
+            self.set_font('Helvetica', 'B', 9)
+            self.set_text_color(40, 40, 40)
+            self.cell(0, 5, 'Details')
+            self.ln(5)
+            self.set_font('Helvetica', '', 8)
+            self.set_text_color(60, 60, 60)
+            for d in section['details']:
+                self.set_x(14)
+                self.cell(0, 4, safe(f'- {d}'))
+                self.ln(5)
+
+    def add_feature_page(self, section, screenshots_base):
+        self.add_page()
+        self._section_header(
+            section['title'], section['accent'],
+            section.get('security'),
+            section.get('new_in_release', False))
+
+        # What changed
+        self.set_x(10)
+        self.set_font('Helvetica', 'B', 9)
+        self.set_text_color(40, 40, 40)
+        self.cell(0, 5, 'What Changed')
+        self.ln(6)
+        self.set_x(10)
+        self.set_font('Helvetica', '', 9)
+        self.set_text_color(60, 60, 60)
+        self.multi_cell(192, 5, safe(section['what']))
+        self.ln(2)
+
+        # Screenshots
+        ss_conf = section.get('screenshots', {})
+        ss_dir = os.path.join(screenshots_base, ss_conf.get('dir', ''))
+        picks = ss_conf.get('picks', [])
+        shown = 0
+        for fname in picks:
+            if shown >= 4:
+                break  # Max 4 per feature page
+            path = os.path.join(ss_dir, fname)
+            if os.path.exists(path):
+                caption = fname.replace('.png', '').replace('-', ' ')
+                self._embed_screenshot(path, caption)
+                shown += 1
+
+                # Page break if getting long
+                if self.get_y() > 220 and shown < len(picks):
+                    self.add_page()
+
+        # Why it matters
+        if self.get_y() > 230:
+            self.add_page()
+        self.set_x(10)
+        self.set_font('Helvetica', 'B', 9)
+        self.set_text_color(40, 40, 40)
+        self.cell(0, 5, 'Why This Matters')
+        self.ln(6)
+        self.set_x(10)
+        self.set_font('Helvetica', '', 9)
+        self.set_text_color(60, 60, 60)
+        self.multi_cell(192, 5, safe(section['why']))
+        self.ln(3)
+
+        # Highlights
+        if section.get('highlights'):
+            self.set_x(10)
+            self.set_font('Helvetica', 'B', 9)
+            self.set_text_color(40, 40, 40)
+            self.cell(0, 5, 'Highlights')
+            self.ln(5)
+            self.set_font('Helvetica', '', 8)
+            for h in section['highlights']:
+                color = (60, 60, 60)
+                prefix = '-'
+                if h.startswith('NEW:'):
+                    color = (20, 150, 60)
+                    prefix = '+'
+                self.set_text_color(*color)
+                self.set_x(14)
+                self.cell(0, 4, safe(f'{prefix} {h}'))
+                self.ln(5)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Main
+# ═══════════════════════════════════════════════════════════════════════
+
+def main():
+    parser = argparse.ArgumentParser(description='KeepKey Firmware Review PDF')
+    parser.add_argument('--screenshots', required=True, help='Base dir with captured screenshots')
+    parser.add_argument('--output', default='firmware-review.pdf', help='Output PDF path')
+    parser.add_argument('--version', default='7.14.0', help='Firmware version')
+    args = parser.parse_args()
+
+    base = args.screenshots
+    print(f'\nKeepKey Firmware {args.version} - Report Generator\n')
+
+    # Find available screenshots
+    all_flows_dir = os.path.join(base, 'all-flows')
+    if not os.path.isdir(all_flows_dir):
+        all_flows_dir = base  # flat structure
+
+    avail = set(os.listdir(all_flows_dir)) if os.path.isdir(all_flows_dir) else set()
+    print(f'  Screenshots dir: {all_flows_dir}')
+    print(f'  Available: {len([f for f in avail if f.endswith(".png")])} PNGs')
+
+    # Count what we have
+    chains_with_screenshots = sum(
+        1 for s in CHAIN_SECTIONS
+        if any(os.path.exists(os.path.join(all_flows_dir, f)) for f in s['screenshots'])
+    )
+    total_pngs = len([f for f in avail if f.endswith('.png')])
+
+    # Feature screenshot counts
+    for fs in FEATURE_SECTIONS:
+        ss = fs.get('screenshots', {})
+        d = os.path.join(base, ss.get('dir', ''))
+        if os.path.isdir(d):
+            total_pngs += len([f for f in os.listdir(d) if f.endswith('.png')])
+
+    pdf = FirmwareReport(version=args.version)
+
+    # Title page
+    pdf.add_title_page(chains_with_screenshots, len(FEATURE_SECTIONS), total_pngs)
+
+    # Feature sections first (what's new / important)
+    for section in FEATURE_SECTIONS:
+        print(f'  + Feature: {section["title"]}')
+        pdf.add_feature_page(section, base)
+
+    # Chain sections
+    for section in CHAIN_SECTIONS:
+        has_any = any(
+            os.path.exists(os.path.join(all_flows_dir, f))
+            for f in section['screenshots']
+        )
+        if has_any:
+            print(f'  + Chain: {section["title"]}')
+            pdf.add_chain_page(section, all_flows_dir)
+        else:
+            print(f'  - Chain: {section["title"]} (no screenshots)')
+
+    # Write
+    os.makedirs(os.path.dirname(args.output) or '.', exist_ok=True)
+    pdf.output(args.output)
+    size_kb = os.path.getsize(args.output) / 1024
+    print(f'\n  Report: {args.output} ({size_kb:.0f} KB)')
+    print(f'  Done.\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/zoo/package.json
+++ b/scripts/zoo/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "keepkey-zoo-report-scripts",
+  "private": true,
+  "dependencies": {
+    "sharp": "^0.34.5",
+    "pdf-lib": "^1.17.1",
+    "qrcode": "^1.5.4"
+  }
+}

--- a/scripts/zoo/screenshot.py
+++ b/scripts/zoo/screenshot.py
@@ -1,0 +1,75 @@
+"""
+screenshot.py — Capture and decode KeepKey emulator OLED screenshots.
+
+The DebugLinkGetState response contains a 2048-byte `layout` field
+packed as 1 bit per pixel (256 wide x 64 tall). Each byte holds 8
+vertical pixels, LSB = topmost row within that byte.
+
+Byte index: x + (y // 8) * 256
+Bit within byte: y % 8
+"""
+import os
+from PIL import Image
+
+
+OLED_W = 256
+OLED_H = 64
+LAYOUT_SIZE = OLED_W * OLED_H // 8  # 2048 bytes
+
+# Default upscale factor for readability (256x64 is tiny on modern screens)
+DEFAULT_SCALE = 2
+
+
+def decode_layout(layout_bytes, scale=1):
+    """Decode 2048-byte bitfield into a PIL Image.
+
+    Args:
+        layout_bytes: 2048-byte 1bpp bitfield from DebugLinkGetState.layout
+        scale: Integer upscale factor (1=native 256x64, 2=512x128, etc.)
+    """
+    w, h = OLED_W * scale, OLED_H * scale
+    im = Image.new("RGB", (w, h), (0, 0, 0))
+    pix = im.load()
+
+    for x in range(OLED_W):
+        for y in range(OLED_H):
+            byte_idx = x + (y // 8) * OLED_W
+            if byte_idx < len(layout_bytes):
+                if (layout_bytes[byte_idx] >> (y % 8)) & 1:
+                    # Fill scale x scale block
+                    for sx in range(scale):
+                        for sy in range(scale):
+                            pix[x * scale + sx, y * scale + sy] = (255, 255, 255)
+
+    return im
+
+
+def capture_screenshot(debug_client, filename, scale=DEFAULT_SCALE):
+    """Capture current OLED state via DebugLink and save as PNG.
+
+    Args:
+        debug_client: DebugLink instance (has read_state() or _call())
+        filename: Output PNG path
+        scale: Integer upscale factor (default 2 for 512x128 output)
+
+    Returns:
+        True if screenshot captured, False if layout unavailable.
+    """
+    from keepkeylib import messages_pb2 as proto
+
+    state = debug_client._call(proto.DebugLinkGetState())
+
+    if not state.HasField('layout') or len(state.layout) < LAYOUT_SIZE:
+        print(f"  WARNING: layout field empty or too small ({len(state.layout) if state.HasField('layout') else 0} bytes)")
+        return False
+
+    im = decode_layout(state.layout, scale=scale)
+
+    os.makedirs(os.path.dirname(filename) or '.', exist_ok=True)
+    im.save(filename)
+    return True
+
+
+def decode_layout_raw(layout_bytes):
+    """Decode layout to native 256x64 without scaling (for programmatic use)."""
+    return decode_layout(layout_bytes, scale=1)

--- a/scripts/zoo/smoke_screenshot.py
+++ b/scripts/zoo/smoke_screenshot.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Minimal smoke test: boot emulator, read one OLED frame, save PNG, exit.
+
+Usage: python3 smoke_screenshot.py [output.png]
+Exit 0 = screenshot captured, non-blank
+Exit 1 = failed
+"""
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'deps', 'python-keepkey'))
+
+from keepkeylib.client import KeepKeyDebuglinkClient
+from keepkeylib.transport_udp import UDPTransport
+from keepkeylib import messages_pb2 as proto
+
+out = sys.argv[1] if len(sys.argv) > 1 else '/tmp/smoke.png'
+main_host = os.environ.get('KK_TRANSPORT_MAIN', '127.0.0.1:11044')
+debug_host = os.environ.get('KK_TRANSPORT_DEBUG', '127.0.0.1:11045')
+
+print("1. Connecting to %s..." % main_host)
+c = KeepKeyDebuglinkClient(UDPTransport(main_host))
+c.set_debuglink(UDPTransport(debug_host))
+v = c.features
+print("2. Firmware: %s v%d.%d.%d" % (v.vendor, v.major_version, v.minor_version, v.patch_version))
+
+print("3. DebugLinkGetState (read_layout)...")
+state = c.debug._call(proto.DebugLinkGetState())
+layout = state.layout
+print("4. Layout: %d bytes" % len(layout))
+
+if len(layout) < 2048:
+    print("FAIL: layout too small")
+    sys.exit(1)
+
+# Check non-blank
+nonzero = sum(1 for b in layout if (b if isinstance(b, int) else ord(b)) != 0)
+print("5. Non-zero bytes: %d / 2048" % nonzero)
+
+# Decode to PNG
+try:
+    from screenshot import capture_screenshot
+    os.makedirs(os.path.dirname(out) or '.', exist_ok=True)
+    capture_screenshot(c.debug, out, scale=3)
+    sz = os.path.getsize(out)
+    print("6. PNG: %s (%d bytes)" % (out, sz))
+    if sz > 400:
+        print("PASS: real screenshot captured")
+        sys.exit(0)
+    else:
+        print("FAIL: PNG too small (likely blank)")
+        sys.exit(1)
+except ImportError:
+    # No Pillow — just report layout stats
+    if nonzero > 10:
+        print("PASS: layout has content (%d non-zero bytes), but no Pillow to save PNG" % nonzero)
+        sys.exit(0)
+    else:
+        print("FAIL: layout is blank")
+        sys.exit(1)

--- a/scripts/zoo/wait-for-emu.sh
+++ b/scripts/zoo/wait-for-emu.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Wait for KeepKey emulator to respond on UDP 11044
+# Usage: ./wait-for-emu.sh [host] [port] [timeout_seconds]
+
+HOST="${1:-127.0.0.1}"
+PORT="${2:-11044}"
+TIMEOUT="${3:-30}"
+
+echo "Waiting for emulator at $HOST:$PORT (timeout ${TIMEOUT}s)..."
+
+i=0
+while [ "$i" -lt "$TIMEOUT" ]; do
+  # Send PINGPING, expect PONGPONG back
+  RESP=$(echo -n "PINGPING" | nc -u -w1 "$HOST" "$PORT" 2>/dev/null | head -c8)
+  if [ "$RESP" = "PONGPONG" ]; then
+    echo "Emulator ready."
+    exit 0
+  fi
+  sleep 1
+  i=$((i + 1))
+done
+
+echo "ERROR: Emulator not responding after ${TIMEOUT}s"
+exit 1


### PR DESCRIPTION
## Summary

- Adds CI pipeline for automated OLED screenshot capture and PDF test report generation
- Fixes DebugLink canvas→layout packing so screenshots actually work (was returning empty/truncated data)
- Fixes nanopb `DebugLinkState.layout` buffer from 1024→2048 bytes (256x64 display = 2048 bytes at 1bpp)
- Version bump 7.10.0→7.14.0 (release target metadata)
- Pins python-keepkey to test framework version with screenshot support and `requires_message()` gating

## Scope

19 files changed, +2,228 / -12 lines. Zero production firmware code modified.

The only lines touching firmware C code are inside `#if DEBUG_LINK` (`fsm_msg_debug.h`) — emulator-only, never compiled into production builds. The nanopb `max_size` change is also DebugLink-only.

## What's included

| Category | Files |
|----------|-------|
| CI pipelines | `ci.yml` (multi-phase test runner), `zoo-report.yml` (report workflow) |
| Screenshot tooling | `scripts/zoo/` — capture, report generation, smoke test, emulator wait |
| Emulator infra | `docker-compose-zoo.yml`, `bridge.py` (/health endpoint), `python-keepkey-tests.sh` |
| DebugLink fix | `fsm_msg_debug.h` — canvas→layout bit-packing, guarded animation rendering |
| nanopb fix | `messages.options` — `DebugLinkState.layout max_size:2048` |
| Report generator | `generate-test-report.py` — thin wrapper calling python-keepkey |
| Docs | `TEST-SYSTEM.md` — pipeline architecture and troubleshooting |
| Version | `CMakeLists.txt` — 7.10.0→7.14.0 |
| Submodule | `deps/python-keepkey` — screenshot + report support |

## What's NOT included

- No new message handlers, signing logic, or coin support
- No changes to bootloader, crypto, storage, or USB transport
- No changes to any code that ships to hardware devices (outside `DEBUG_LINK` guard)

## Test plan

- [x] All 8 CI jobs pass (lint, static analysis, ARM build, ARM BTC-only, emulator, integration, unit, report)
- [x] 93 existing tests pass, 0 failures
- [x] 41 new-feature tests correctly skip via `requires_message()` gates
- [x] 4 real OLED screenshots captured and verified (wipe device confirmation flow)
- [x] Fail-fast gates: CI errors on zero screenshots, conftest hook enforces capture