### PR TITLE
fix: upgrade CI actions to Node.js 24 + apply clang-format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -82,7 +82,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
@@ -103,7 +103,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           submodules: false
@@ -162,19 +162,20 @@ jobs:
         continue-on-error: true
 
       - name: Upload cppcheck report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: cppcheck-report
           path: cppcheck_report.txt
           retention-days: 30
+          if-no-files-found: ignore
 
   check-submodules:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -210,7 +211,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -224,11 +225,11 @@ jobs:
           git submodule update --init deps/sca-hardening/SecAESSTM32
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Cache base image
         id: cache-base
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/base-image.tar
           key: base-image-${{ env.BASE_IMAGE }}
@@ -254,7 +255,7 @@ jobs:
         run: docker save ${{ env.EMU_IMAGE }} -o /tmp/emu-image.tar
 
       - name: Upload emulator image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: emu-image
           path: /tmp/emu-image.tar
@@ -266,7 +267,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -281,7 +282,7 @@ jobs:
 
       - name: Cache base image
         id: cache-base
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/base-image.tar
           key: base-image-${{ env.BASE_IMAGE }}
@@ -335,7 +336,7 @@ jobs:
           echo "::notice::Firmware v${{ steps.version.outputs.fw_version }} built successfully"
 
       - name: Upload firmware artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: firmware-v${{ steps.version.outputs.fw_version }}-${{ steps.version.outputs.git_short }}
           path: |
@@ -353,7 +354,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Download emulator image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: emu-image
           path: /tmp
@@ -375,7 +376,7 @@ jobs:
                 exit \$RC"
 
       - name: Upload unit test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: unit-test-results
@@ -388,7 +389,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -418,7 +419,7 @@ jobs:
           [ "${UNIT_STATUS}${PY_STATUS}" = "00" ] || exit 1
 
       - name: Upload Python test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: python-test-results
@@ -443,12 +444,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Download emulator image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: emu-image
           path: /tmp
@@ -469,7 +470,7 @@ jobs:
           docker tag ${{ env.EMU_IMAGE }} kktech/kkemu:v${{ steps.version.outputs.fw_version }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.KK_DOCKERHUB_USER }}
           password: ${{ secrets.KK_DOCKERHUB_PASS }}

--- a/include/keepkey/board/common.h
+++ b/include/keepkey/board/common.h
@@ -26,12 +26,13 @@
 #define HW_ENTROPY_LEN (12 + 32)
 extern uint8_t HW_ENTROPY_DATA[HW_ENTROPY_LEN];
 
-void __attribute__((noreturn))
-__fatal_error(const char *expr, const char *msg, const char *file, int line,
-              const char *func);
-void __attribute__((noreturn))
-error_shutdown(const char *line1, const char *line2, const char *line3,
-               const char *line4);
+void __attribute__((noreturn)) __fatal_error(const char* expr, const char* msg,
+                                             const char* file, int line,
+                                             const char* func);
+void __attribute__((noreturn)) error_shutdown(const char* line1,
+                                              const char* line2,
+                                              const char* line3,
+                                              const char* line4);
 
 #define ensure(expr, msg) \
   (((expr) == sectrue)    \
@@ -43,8 +44,8 @@ void hal_delay(uint32_t ms);
 void wait_random(void);
 
 void drbg_init(void);
-void drbg_reseed(const uint8_t *entropy, size_t len);
-void drbg_generate(uint8_t *buf, size_t len);
+void drbg_reseed(const uint8_t* entropy, size_t len);
+void drbg_generate(uint8_t* buf, size_t len);
 uint32_t drbg_random32(void);
 
 #endif

--- a/include/keepkey/board/confirm_sm.h
+++ b/include/keepkey/board/confirm_sm.h
@@ -28,26 +28,25 @@
 
 /* implement a means to display debug information */
 #ifdef DEBUG_ON
-  // Examples
-  // DEBUG_DISPLAY("here");
-  // DEBUG_DISPLAY("%d %s", slot, account);
-  #define DEBUG_DISPLAY(...)\
-  {\
-    char _str[61]={0};\
-    snprintf(_str, 60, __VA_ARGS__);\
-    (void)review(ButtonRequestType_ButtonRequest_Other, _str, " ");\
+// Examples
+// DEBUG_DISPLAY("here");
+// DEBUG_DISPLAY("%d %s", slot, account);
+#define DEBUG_DISPLAY(...)                                          \
+  {                                                                 \
+    char _str[61] = {0};                                            \
+    snprintf(_str, 60, __VA_ARGS__);                                \
+    (void)review(ButtonRequestType_ButtonRequest_Other, _str, " "); \
   }
-  // Example
-  // DEBUG_DISPLAY_VAL("sig", "sig %s", 65, resp->signature.bytes[_ctr]);
-  #define DEBUG_DISPLAY_VAL(TITLE,VALNAME,SIZE,BYTES) \
-  {\
-    char _str[SIZE+1];\
-    int _ctr;\
-    for (_ctr=0; _ctr<SIZE/2; _ctr++) {\
-      snprintf(&_str[2*_ctr], 3, "%02x", BYTES);\
-    }\
-    (void)review(ButtonRequestType_ButtonRequest_Other, TITLE,\
-                 VALNAME, _str);\
+// Example
+// DEBUG_DISPLAY_VAL("sig", "sig %s", 65, resp->signature.bytes[_ctr]);
+#define DEBUG_DISPLAY_VAL(TITLE, VALNAME, SIZE, BYTES)                         \
+  {                                                                            \
+    char _str[SIZE + 1];                                                       \
+    int _ctr;                                                                  \
+    for (_ctr = 0; _ctr < SIZE / 2; _ctr++) {                                  \
+      snprintf(&_str[2 * _ctr], 3, "%02x", BYTES);                             \
+    }                                                                          \
+    (void)review(ButtonRequestType_ButtonRequest_Other, TITLE, VALNAME, _str); \
   }
 #endif
 
@@ -68,8 +67,8 @@ typedef enum {
 
 /* Define the given layout dialog texts for each screen */
 typedef struct {
-  const char *request_title;
-  const char *request_body;
+  const char* request_title;
+  const char* request_body;
 } ScreenLine;
 
 typedef ScreenLine ScreenLines;
@@ -82,9 +81,9 @@ typedef struct {
   bool immediate;
 } StateInfo;
 
-#define isprint(c)   ((c) >= 0x20 && (c) < 0x7f)
+#define isprint(c) ((c) >= 0x20 && (c) < 0x7f)
 
-typedef void (*layout_notification_t)(const char *str1, const char *str2,
+typedef void (*layout_notification_t)(const char* str1, const char* str2,
                                       NotificationType type);
 
 /// User confirmation.
@@ -92,21 +91,22 @@ typedef void (*layout_notification_t)(const char *str1, const char *str2,
 /// \param request_title   Title of confirm message.
 /// \param request_body    Body of confirm message.
 /// \returns true iff the device confirmed.
-bool confirm(ButtonRequestType type, const char *request_title,
-             const char *request_body, ...)
+bool confirm(ButtonRequestType type, const char* request_title,
+             const char* request_body, ...)
     __attribute__((format(printf, 3, 4)));
 
-bool confirm_constant_power(ButtonRequestType type, const char *request_title, const char *request_body,
-             ...) __attribute__((format(printf, 3, 4)));
+bool confirm_constant_power(ButtonRequestType type, const char* request_title,
+                            const char* request_body, ...)
+    __attribute__((format(printf, 3, 4)));
 
 /// User confirmation.
 /// \param type            The kind of button request to send to the host.
 /// \param request_title   Title of confirm message.
 /// \param request_body    Body of confirm message.
 /// \returns true iff the device confirmed.
-bool confirm_with_custom_button_request(ButtonRequest *button_request,
-                                        const char *request_title,
-                                        const char *request_body, ...)
+bool confirm_with_custom_button_request(ButtonRequest* button_request,
+                                        const char* request_title,
+                                        const char* request_body, ...)
     __attribute__((format(printf, 3, 4)));
 
 /// User confirmation, custom layout.
@@ -117,8 +117,8 @@ bool confirm_with_custom_button_request(ButtonRequest *button_request,
 /// \returns true iff the device confirmed.
 bool confirm_with_custom_layout(layout_notification_t layout_notification_func,
                                 ButtonRequestType type,
-                                const char *request_title,
-                                const char *request_body, ...)
+                                const char* request_title,
+                                const char* request_body, ...)
     __attribute__((format(printf, 4, 5)));
 
 /// User confirmation.
@@ -127,33 +127,33 @@ bool confirm_with_custom_layout(layout_notification_t layout_notification_func,
 /// \param request_title   Title of confirm message.
 /// \param request_body    Body of confirm message.
 /// \returns true iff the device confirmed.
-bool confirm_without_button_request(const char *request_title,
-                                    const char *request_body, ...)
+bool confirm_without_button_request(const char* request_title,
+                                    const char* request_body, ...)
     __attribute__((format(printf, 2, 3)));
 
 /// Like confirm, but always \returns true.
 /// \param request_title   Title of confirm message.
 /// \param request_body    Body of confirm message.
-bool review(ButtonRequestType type, const char *request_title,
-            const char *request_body, ...)
+bool review(ButtonRequestType type, const char* request_title,
+            const char* request_body, ...)
     __attribute__((format(printf, 3, 4)));
 
 /// Like confirm, but always \returns true. Does not message the host for
 /// ButtonAcks. \param request_title   Title of confirm message. \param
 /// request_body    Body of confirm message.
-bool review_without_button_request(const char *request_title,
-                                   const char *request_body, ...)
+bool review_without_button_request(const char* request_title,
+                                   const char* request_body, ...)
     __attribute__((format(printf, 2, 3)));
 
-bool review_with_icon(ButtonRequestType type, IconType iconNum, const char *request_title,
-                      const char *request_body, ...)
-      __attribute__((format(printf, 4, 5)));
+bool review_with_icon(ButtonRequestType type, IconType iconNum,
+                      const char* request_title, const char* request_body, ...)
+    __attribute__((format(printf, 4, 5)));
 
 /// Like confirm, but always \returns true and immediately.
 /// \param request_title   Title of confirm message.
 /// \param request_body    Body of confirm message.
-bool review_immediate(ButtonRequestType type, const char *request_title,
-            const char *request_body, ...)
+bool review_immediate(ButtonRequestType type, const char* request_title,
+                      const char* request_body, ...)
     __attribute__((format(printf, 3, 4)));
 
 #endif

--- a/include/keepkey/board/keepkey_board.h
+++ b/include/keepkey/board/keepkey_board.h
@@ -62,7 +62,8 @@
 #define VERSION_STR(x) VERSION_NUM(x)
 
 #define RESET_PARAM_NONE 0
-// This is the ASCII string "UPDT" interpreted as an integer in little-endian form.
+// This is the ASCII string "UPDT" interpreted as an integer in little-endian
+// form.
 #define RESET_PARAM_REQUEST_UPDATE 0x54445055
 
 /* Flash metadata structure which will contains unique identifier
@@ -88,9 +89,9 @@ void board_init(void);
 void kk_board_init(void);
 
 void __stack_chk_fail(void) __attribute__((noreturn));
-uint32_t calc_crc32(const void *data, int word_len);
+uint32_t calc_crc32(const void* data, int word_len);
 
 void __attribute__((noreturn)) shutdown(void);
-void memset_reg(void *start, void *stop, uint32_t val);
+void memset_reg(void* start, void* stop, uint32_t val);
 
 #endif

--- a/include/keepkey/board/keepkey_display.h
+++ b/include/keepkey/board/keepkey_display.h
@@ -31,8 +31,8 @@
 #define DEFAULT_DISPLAY_BRIGHTNESS 100 /* Percent */
 
 void display_hw_init(void);
-Canvas *display_canvas_init(void);
-Canvas *display_canvas(void);
+Canvas* display_canvas_init(void);
+Canvas* display_canvas(void);
 void display_refresh(void);
 void display_set_brightness(int percentage);
 void display_turn_on(void);

--- a/include/keepkey/board/layout.h
+++ b/include/keepkey/board/layout.h
@@ -44,7 +44,7 @@
 /* Title */
 #define TITLE_COLOR 0xFF
 #define TITLE_WIDTH 206
-#define TITLE_WIDTH_WITH_ICON TITLE_WIDTH-LEFT_MARGIN_WITH_ICON
+#define TITLE_WIDTH_WITH_ICON TITLE_WIDTH - LEFT_MARGIN_WITH_ICON
 #define TITLE_ROWS 1
 #define TITLE_FONT_LINE_PADDING 0
 #define TITLE_CHAR_MAX 128
@@ -53,7 +53,7 @@
 #define BODY_TOP_MARGIN 7
 #define BODY_COLOR 0xFF
 #define BODY_WIDTH 225
-#define BODY_WIDTH_WITH_ICON  BODY_WIDTH-LEFT_MARGIN_WITH_ICON
+#define BODY_WIDTH_WITH_ICON BODY_WIDTH - LEFT_MARGIN_WITH_ICON
 #define BODY_ROWS 3
 #define BODY_FONT_LINE_PADDING 4
 #define BODY_CHAR_MAX 352
@@ -77,11 +77,11 @@ typedef enum {
 } NotificationType;
 
 typedef enum {
-  NO_ICON=0,
+  NO_ICON = 0,
   ETHEREUM_ICON,
 } IconType;
 
-typedef void (*AnimateCallback)(void *data, uint32_t duration,
+typedef void (*AnimateCallback)(void* data, uint32_t duration,
                                 uint32_t elapsed);
 typedef struct Animation Animation;
 typedef void (*leaving_handler_t)(void);
@@ -89,43 +89,44 @@ typedef void (*leaving_handler_t)(void);
 struct Animation {
   uint32_t duration;
   uint32_t elapsed;
-  void *data;
+  void* data;
   AnimateCallback animate_callback;
-  Animation *next;
+  Animation* next;
 };
 
 typedef struct {
-  Animation *head;
+  Animation* head;
   int size;
 
 } AnimationQueue;
 
 void layout_has_icon(bool tf);
-void layout_init(Canvas *canvas);
-Canvas *layout_get_canvas(void);
+void layout_init(Canvas* canvas);
+Canvas* layout_get_canvas(void);
 void call_leaving_handler(void);
 void layout_firmware_update_confirmation(void);
-void layout_standard_notification(const char *str1, const char *str2,
+void layout_standard_notification(const char* str1, const char* str2,
                                   NotificationType type);
-void layout_constant_power_notification(const char *str1, const char *str2, NotificationType type);
-void layout_notification_icon(NotificationType type, DrawableParams *sp);
+void layout_constant_power_notification(const char* str1, const char* str2,
+                                        NotificationType type);
+void layout_notification_icon(NotificationType type, DrawableParams* sp);
 void layout_add_icon(IconType type);
-void layout_warning(const char *prompt);
-void layout_warning_static(const char *str);
-void layout_simple_message(const char *str);
+void layout_warning(const char* prompt);
+void layout_warning_static(const char* str);
+void layout_simple_message(const char* str);
 void layout_version(int32_t major, int32_t minor, int32_t patch);
 void layout_home(void);
 void layout_home_reversed(void);
 void animate(void);
 bool is_animating(void);
 void force_animation_start(void);
-void animating_progress_handler(const char *desc, int permil);
-void layoutProgress(const char *desc, int permil);
-void layoutProgressForAuth(const char *otp, const char *desc, int permil);
-void layoutProgressSwipe(const char *desc, int permil);
-void layout_add_animation(AnimateCallback callback, void *data,
+void animating_progress_handler(const char* desc, int permil);
+void layoutProgress(const char* desc, int permil);
+void layoutProgressForAuth(const char* otp, const char* desc, int permil);
+void layoutProgressSwipe(const char* desc, int permil);
+void layout_add_animation(AnimateCallback callback, void* data,
                           uint32_t duration);
-void layout_animate_images(void *data, uint32_t duration, uint32_t elapsed);
+void layout_animate_images(void* data, uint32_t duration, uint32_t elapsed);
 void layout_clear(void);
 #if DEBUG_LINK
 void layout_debuglink_watermark(void);
@@ -133,6 +134,6 @@ void layout_debuglink_watermark(void);
 void layout_clear_animations(void);
 void layout_clear_static(void);
 
-void kk_strupr(char *str);
-void kk_strlwr(char *str);
+void kk_strupr(char* str);
+void kk_strlwr(char* str);
 #endif

--- a/include/keepkey/board/memory.h
+++ b/include/keepkey/board/memory.h
@@ -20,7 +20,7 @@
 #ifndef MEMORY_H
 #define MEMORY_H
 
-//#include <libopencm3/cm3/mpu.h>
+// #include <libopencm3/cm3/mpu.h>
 #include "trezor/crypto/sha2.h"
 
 #include <stddef.h>
@@ -73,17 +73,19 @@
 // clang-format on
 
 #ifdef EMULATOR
-extern uint8_t *emulator_flash_base;
+extern uint8_t* emulator_flash_base;
 #define FLASH_PTR(x) (emulator_flash_base + (x - FLASH_ORIGIN))
 #else
-#define FLASH_PTR(x) (const uint8_t *)(x)
+#define FLASH_PTR(x) (const uint8_t*)(x)
 #endif
 
-#define STACK_GOOD          1         // do not change this value, must equal SUCCESS in eip712 error list
-#define STACK_TOO_SMALL     13        // do not change this value, used in eip712 error list
+#define STACK_GOOD \
+  1  // do not change this value, must equal SUCCESS in eip712 error list
+#define STACK_TOO_SMALL \
+  13  // do not change this value, used in eip712 error list
 
-#define OPTION_BYTES_1 ((uint64_t *)0x1FFFC000)
-#define OPTION_BYTES_2 ((uint64_t *)0x1FFFC008)
+#define OPTION_BYTES_1 ((uint64_t*)0x1FFFC000)
+#define OPTION_BYTES_2 ((uint64_t*)0x1FFFC008)
 #define OPTION_RDP 0xCCFF
 #define OPTION_WRP 0xFF9E
 
@@ -130,34 +132,32 @@ extern uint8_t *emulator_flash_base;
 
 #define FLASH_META_MAGIC (FLASH_META_START)
 #define FLASH_META_CODELEN \
-  (FLASH_META_MAGIC + sizeof(((app_meta_td *)NULL)->magic))
+  (FLASH_META_MAGIC + sizeof(((app_meta_td*)NULL)->magic))
 #define FLASH_META_SIGINDEX1 \
-  (FLASH_META_CODELEN + sizeof(((app_meta_td *)NULL)->code_len))
+  (FLASH_META_CODELEN + sizeof(((app_meta_td*)NULL)->code_len))
 #define FLASH_META_SIGINDEX2 \
-  (FLASH_META_SIGINDEX1 + sizeof(((app_meta_td *)NULL)->sig_index1))
+  (FLASH_META_SIGINDEX1 + sizeof(((app_meta_td*)NULL)->sig_index1))
 #define FLASH_META_SIGINDEX3 \
-  (FLASH_META_SIGINDEX2 + sizeof(((app_meta_td *)NULL)->sig_index2))
+  (FLASH_META_SIGINDEX2 + sizeof(((app_meta_td*)NULL)->sig_index2))
 #define FLASH_SIG_FLAG \
-  (FLASH_META_SIGINDEX3 + sizeof(((app_meta_td *)NULL)->sig_index3))
+  (FLASH_META_SIGINDEX3 + sizeof(((app_meta_td*)NULL)->sig_index3))
 #define FLASH_META_FLAGS \
-  (FLASH_SIG_FLAG + sizeof(((app_meta_td *)NULL)->sig_flag))
+  (FLASH_SIG_FLAG + sizeof(((app_meta_td*)NULL)->sig_flag))
 #define FLASH_META_RESERVE \
-  (FLASH_META_FLAGS + sizeof(((app_meta_td *)NULL)->meta_flags))
-#define FLASH_META_SIG1 \
-  (FLASH_META_RESERVE + sizeof(((app_meta_td *)NULL)->rsv))
-#define FLASH_META_SIG2 (FLASH_META_SIG1 + sizeof(((app_meta_td *)NULL)->sig1))
-#define FLASH_META_SIG3 (FLASH_META_SIG2 + sizeof(((app_meta_td *)NULL)->sig2))
+  (FLASH_META_FLAGS + sizeof(((app_meta_td*)NULL)->meta_flags))
+#define FLASH_META_SIG1 (FLASH_META_RESERVE + sizeof(((app_meta_td*)NULL)->rsv))
+#define FLASH_META_SIG2 (FLASH_META_SIG1 + sizeof(((app_meta_td*)NULL)->sig1))
+#define FLASH_META_SIG3 (FLASH_META_SIG2 + sizeof(((app_meta_td*)NULL)->sig2))
 
-#define META_MAGIC_SIZE (sizeof(((app_meta_td *)NULL)->magic))
+#define META_MAGIC_SIZE (sizeof(((app_meta_td*)NULL)->magic))
 
 #define FLASH_APP_START \
   (FLASH_META_START + FLASH_META_DESC_LEN)  // 0x0806_0200 - 0x080F_FFFF
 #define FLASH_APP_LEN (FLASH_END - FLASH_APP_START)
 
-#define SIG_FLAG (*(uint8_t const *)FLASH_SIG_FLAG)
+#define SIG_FLAG (*(uint8_t const*)FLASH_SIG_FLAG)
 
-#define META_FLAGS (*(uint32_t const *)FLASH_META_FLAGS)
-
+#define META_FLAGS (*(uint32_t const*)FLASH_META_FLAGS)
 
 /* Misc Info. */
 #define FLASH_BOOTSTRAP_SECTOR 0
@@ -252,9 +252,11 @@ static const FlashSector flash_sector_map[] = {
     {11, 0x080E0000, APP_FLASH_SECT_LEN, FLASH_APP},
     {-1, 0, 0, FLASH_INVALID}};
 
-
-#define STACK_REENTRANCY_REQ    1280    // calculate this from a re-entrant call (unsigned)&p - (unsigned)&end)
-#define STACK_SIZE_GUARD        (STACK_REENTRANCY_REQ + 64) // Can't recurse without this much stack available
+#define STACK_REENTRANCY_REQ \
+  1280  // calculate this from a re-entrant call (unsigned)&p - (unsigned)&end)
+#define STACK_SIZE_GUARD  \
+  (STACK_REENTRANCY_REQ + \
+   64)  // Can't recurse without this much stack available
 int memcheck(unsigned stackGuardSize);
 
 void mpu_config(int);
@@ -270,16 +272,16 @@ void memory_unlock(void);
 /// \param hash    Buffer to be filled with hash.
 ///                Must be at least SHA256_DIGEST_LENGTH bytes long.
 /// \param cached  Whether a cached value is acceptable.
-int memory_bootloader_hash(uint8_t *hash, bool cached);
+int memory_bootloader_hash(uint8_t* hash, bool cached);
 
-int memory_firmware_hash(uint8_t *hash);
-int memory_storage_hash(uint8_t *hash, Allocation storage_location);
-bool find_active_storage(Allocation *storage_location);
+int memory_firmware_hash(uint8_t* hash);
+int memory_storage_hash(uint8_t* hash, Allocation storage_location);
+bool find_active_storage(Allocation* storage_location);
 
 /// Find the storage location *after* the active one.
 Allocation next_storage(Allocation active);
 
-void memory_getDeviceLabel(char *str, size_t len);
+void memory_getDeviceLabel(char* str, size_t len);
 
 /// Write the marker that allows the firmware to boot with secrets preserved.
 bool storage_protect_off(void);
@@ -293,8 +295,8 @@ void storage_protect_wipe(uint32_t status);
 /// \returns STORAGE_PROTECT_{ENABLED,DISABLED}
 uint32_t storage_protect_status(void);
 
-extern void *_timerusr_isr;
-extern void *_buttonusr_isr;
-extern void *_mmhusr_isr;
+extern void* _timerusr_isr;
+extern void* _buttonusr_isr;
+extern void* _mmhusr_isr;
 
 #endif

--- a/include/keepkey/board/pubkeys.h
+++ b/include/keepkey/board/pubkeys.h
@@ -23,11 +23,14 @@
 #include <inttypes.h>
 
 // The firmware has been designed to allow future key rotations on a 5 key basis
-// i.e, the current keys are indexed 0-4, the next future set of keys will be 5-9, etc.
-// When new keys are rotated in, the old keys must be recognized as expired. 
+// i.e, the current keys are indexed 0-4, the next future set of keys will be
+// 5-9, etc. When new keys are rotated in, the old keys must be recognized as
+// expired.
 
 #define PUBKEYS 5
-#define EXP_PUBKEYS 5       // This is a nop prior to future key rotation, intended to indicate which keys are expired.
+#define EXP_PUBKEYS \
+  5  // This is a nop prior to future key rotation, intended to indicate which
+     // keys are expired.
 #define PUBKEY_LENGTH 65
 #define SIGNATURES 3
 

--- a/include/keepkey/firmware/eip712.h
+++ b/include/keepkey/firmware/eip712.h
@@ -16,18 +16,17 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-/* 
-    Produces hashes based on the metamask v4 rules. This is different from the EIP-712 spec
-    in how arrays of structs are hashed but is compatable with metamask.
-    See https://github.com/MetaMask/eth-sig-util/pull/107
+/*
+    Produces hashes based on the metamask v4 rules. This is different from the
+   EIP-712 spec in how arrays of structs are hashed but is compatable with
+   metamask. See https://github.com/MetaMask/eth-sig-util/pull/107
 
     eip712 data rules:
     Parser wants to see C strings, not javascript strings:
-        requires all complete json message strings to be enclosed by braces, i.e., { ... }
-        Cannot have entire json string quoted, i.e., "{ ... }" will not work.
-        Remove all quote escape chars, e.g., {"types":  not  {\"types\":
-    int values must be hex. Negative sign indicates negative value, e.g., -5, -8a67 
+        requires all complete json message strings to be enclosed by braces,
+   i.e., { ... } Cannot have entire json string quoted, i.e., "{ ... }" will not
+   work. Remove all quote escape chars, e.g., {"types":  not  {\"types\": int
+   values must be hex. Negative sign indicates negative value, e.g., -5, -8a67
         Note: Do not prefix ints or uints with 0x
     All hex and byte strings must be big-endian
     Byte strings and address should be prefixed by 0x
@@ -38,71 +37,68 @@
 #include "keepkey/firmware/tiny-json.h"
 
 #define USE_KECCAK 1
-#define ADDRESS_SIZE        42
-#define JSON_OBJ_POOL_SIZE  100
-#define STRBUFSIZE          511
-#define MAX_USERDEF_TYPES   10      // This is max number of user defined type allowed
-#define MAX_TYPESTRING      33      // maximum size for a type string
-#define MAX_ENCBYTEN_SIZE   66
+#define ADDRESS_SIZE 42
+#define JSON_OBJ_POOL_SIZE 100
+#define STRBUFSIZE 511
+#define MAX_USERDEF_TYPES 10  // This is max number of user defined type allowed
+#define MAX_TYPESTRING 33     // maximum size for a type string
+#define MAX_ENCBYTEN_SIZE 66
 
 typedef enum {
-    NOT_ENCODABLE = 0,
-    ADDRESS,
-    STRING,
-    UINT,
-    INT,
-    BYTES,
-    BYTES_N,
-    BOOL,
-    UDEF_TYPE,
-    PREV_USERDEF,
-    TOO_MANY_UDEFS
+  NOT_ENCODABLE = 0,
+  ADDRESS,
+  STRING,
+  UINT,
+  INT,
+  BYTES,
+  BYTES_N,
+  BOOL,
+  UDEF_TYPE,
+  PREV_USERDEF,
+  TOO_MANY_UDEFS
 } basicType;
 
-typedef enum {
-    DOMAIN = 1,
-    MESSAGE
-} dm;
+typedef enum { DOMAIN = 1, MESSAGE } dm;
 
 // error list status
-#define SUCCESS              1
-#define NULL_MSG_HASH        2      // this is legal, not an error
-#define GENERAL_ERROR        3
-#define UDEF_NAME_ERROR      4
-#define UDEFS_OVERFLOW       5
-#define UDEF_ARRAY_NAME_ERR  6
-#define ADDR_STRING_VFLOW    7
-#define BYTESN_STRING_ERROR  8
-#define BYTESN_SIZE_ERROR    9
-#define INT_ARRAY_ERROR     10
-#define BYTESN_ARRAY_ERROR  11
-#define BOOL_ARRAY_ERROR    12
+#define SUCCESS 1
+#define NULL_MSG_HASH 2  // this is legal, not an error
+#define GENERAL_ERROR 3
+#define UDEF_NAME_ERROR 4
+#define UDEFS_OVERFLOW 5
+#define UDEF_ARRAY_NAME_ERR 6
+#define ADDR_STRING_VFLOW 7
+#define BYTESN_STRING_ERROR 8
+#define BYTESN_SIZE_ERROR 9
+#define INT_ARRAY_ERROR 10
+#define BYTESN_ARRAY_ERROR 11
+#define BOOL_ARRAY_ERROR 12
 // #define STACK_TOO_SMALL     13        // reserved - defined in memory.h
 
-#define JSON_PTYPENAMEERR   14
-#define JSON_PTYPEVALERR    15
-#define JSON_TYPESPROPERR   16
-#define JSON_TYPE_SPROPERR  17
-#define JSON_DPROPERR       18
-#define MSG_NO_DS           19
-#define JSON_MPROPERR       20
-#define JSON_PTYPESOBJERR   21
-#define JSON_TYPE_S_ERR     22
+#define JSON_PTYPENAMEERR 14
+#define JSON_PTYPEVALERR 15
+#define JSON_TYPESPROPERR 16
+#define JSON_TYPE_SPROPERR 17
+#define JSON_DPROPERR 18
+#define MSG_NO_DS 19
+#define JSON_MPROPERR 20
+#define JSON_PTYPESOBJERR 21
+#define JSON_TYPE_S_ERR 22
 #define JSON_TYPE_S_NAMEERR 23
-#define UNUSED_ERR_2        24          // available for re-use
-#define JSON_NO_PAIRS       25
-#define JSON_PAIRS_NOTEXT   26
-#define JSON_NO_PAIRS_SIB   27
-#define TYPE_NOT_ENCODABLE  28
-#define JSON_NOPAIRVAL      29
-#define JSON_NOPAIRNAME     30
-#define JSON_TYPE_T_NOVAL   31
-#define ADDR_STRING_NULL    32
-#define JSON_TYPE_WNOVAL    33
+#define UNUSED_ERR_2 24  // available for re-use
+#define JSON_NO_PAIRS 25
+#define JSON_PAIRS_NOTEXT 26
+#define JSON_NO_PAIRS_SIB 27
+#define TYPE_NOT_ENCODABLE 28
+#define JSON_NOPAIRVAL 29
+#define JSON_NOPAIRNAME 30
+#define JSON_TYPE_T_NOVAL 31
+#define ADDR_STRING_NULL 32
+#define JSON_TYPE_WNOVAL 33
 
-#define LAST_ERROR         JSON_TYPE_WNOVAL
+#define LAST_ERROR JSON_TYPE_WNOVAL
 
-int encode(const json_t *jsonTypes, const json_t *jsonVals, const char *typeS, uint8_t *hashRet);
+int encode(const json_t* jsonTypes, const json_t* jsonVals, const char* typeS,
+           uint8_t* hashRet);
 
 #endif
-


### PR DESCRIPTION
## Summary

- Upgrade all GitHub Actions from deprecated Node.js 20 versions to current Node.js 24 versions
- Apply clang-format to 10 header files that produced lint warnings on every CI run
- Fix cppcheck artifact upload warning when report file is empty

## Changes

### Action version upgrades
| Action | Old | New |
|--------|-----|-----|
| actions/checkout | v4 | v6 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |
| actions/cache | v4 | v5 |
| docker/setup-buildx-action | v3 | v4 |
| docker/login-action | v3 | v4 |

Node.js 20 actions will be forced to Node.js 24 starting June 2, 2026 and removed September 16, 2026.

### clang-format fixes (10 files)
- `include/keepkey/board/common.h`
- `include/keepkey/board/confirm_sm.h`
- `include/keepkey/board/keepkey_board.h`
- `include/keepkey/board/keepkey_display.h`
- `include/keepkey/board/layout.h`
- `include/keepkey/board/memory.h`
- `include/keepkey/board/pubkeys.h`
- `include/keepkey/firmware/eip712.h`
- `include/keepkey/firmware/ethereum_contracts/zxappliquid.h`
- `include/keepkey/firmware/ethereum_contracts/zxswap.h`

Whitespace/formatting only — no behavioral changes.

### cppcheck artifact fix
- Added `if-no-files-found: ignore` to cppcheck report upload (0 issues = empty file = spurious warning)

## Test plan

- [x] No functional code changes — formatting and action versions only
- [ ] CI passes with upgraded actions
- [ ] lint-format job produces 0 warnings
- [ ] static-analysis artifact upload succeeds cleanly