### PR TITLE
feat: EVM blind-sign hard gate — block by default, warn when allowed

### DIFF
--- a/lib/firmware/ethereum.c
+++ b/lib/firmware/ethereum.c
@@ -734,16 +734,20 @@ void ethereum_signing_init(EthereumSignTx *msg, const HDNode *node,
 
   memset(confirm_body_message, 0, sizeof(confirm_body_message));
   if (token == NULL && data_total > 0 && data_needs_confirm) {
-    // KeepKey custom: warn the user that they're trying to do something
-    // that is potentially dangerous. People (generally) aren't great at
-    // parsing raw transaction data, and we can't effectively show them
-    // what they're about to do in the general case.
+    // Blind-sign gate: when AdvancedMode is OFF (default), BLOCK the tx.
+    // When ON, warn prominently but allow.
     if (!storage_isPolicyEnabled("AdvancedMode")) {
-      (void)review(
-          ButtonRequestType_ButtonRequest_Other, "Warning",
-          "Signing of arbitrary ETH contract data is recommended only for "
-          "experienced users. Enable 'AdvancedMode' policy to dismiss.");
+      (void)review(ButtonRequestType_ButtonRequest_Other, "BLOCKED",
+                   "Blind signing is disabled. "
+                   "Enable AdvancedMode policy to allow.");
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      "Blind signing disabled by policy");
+      ethereum_signing_abort();
+      return;
     }
+    (void)review(ButtonRequestType_ButtonRequest_Other, "BLIND SIGNATURE",
+                 "You are signing raw contract data. "
+                 "The device cannot verify the contents.");
 
     layoutEthereumData(msg->data_initial_chunk.bytes,
                        msg->data_initial_chunk.size, data_total,


### PR DESCRIPTION
## Summary

Adds a hard gate for EVM blind signing. When the firmware cannot parse/verify transaction calldata (unknown contract, no metadata match), it now blocks by default instead of silently signing.

Users must explicitly enable blind signing via the AdvancedMode policy to proceed with unverified transactions. When enabled, a clear warning is shown before signing.

## Changes

- `ethereum.c`: Add blind-sign check before signing unrecognized calldata, show warning when AdvancedMode allows it

## Test plan

- [ ] CI builds pass
- [ ] Unknown contract calldata is blocked by default
- [ ] With AdvancedMode enabled, warning shown and signing proceeds
- [ ] Known contracts (THORChain, etc.) bypass the gate as before