### PR TITLE
feat: libkkemu — firmware emulator as shared library (.dylib)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(BOOTLOADER_MINOR_VERSION 0)
 set(BOOTLOADER_PATCH_VERSION 0)
 
 option(KK_EMULATOR "Build the emulator" OFF)
+option(KK_BUILD_DYLIB "Build libkkemu shared library (.dylib/.so)" OFF)
 option(KK_DEBUG_LINK "Build with debug-link enabled" OFF)
 option(KK_HAVE_STRLCPY "Does the target platform have strlcpy?" ON)
 option(KK_HAVE_STRLCAT "Does the target platform have strlcat?" ON)

--- a/include/keepkey/emulator/libkkemu.h
+++ b/include/keepkey/emulator/libkkemu.h
@@ -1,0 +1,97 @@
+/*
+ * libkkemu — KeepKey firmware emulator as a shared library.
+ *
+ * The host process provides a pre-allocated 1MB flash buffer.
+ * All I/O goes through ring buffers (no UDP sockets).
+ * Single-threaded: call kkemu_poll() from your event loop.
+ */
+#ifndef LIBKKEMU_H
+#define LIBKKEMU_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define KKEMU_FLASH_SIZE   (1024 * 1024)  /* 1 MB */
+#define KKEMU_PACKET_SIZE  64             /* HID report size */
+#define KKEMU_IFACE_MAIN   0
+#define KKEMU_IFACE_DEBUG  1
+
+/**
+ * Initialize the emulator with a host-provided flash buffer.
+ *
+ * @param flash_buf  Pointer to 1MB buffer (host-owned, must remain valid).
+ *                   If contents are all 0xFF, treated as fresh/erased device.
+ *                   If contents are from a previous session, device state is restored.
+ * @param flash_len  Must be KKEMU_FLASH_SIZE (1048576).
+ * @return 0 on success, -1 on error.
+ *
+ * After this call, the emulator is ready to process messages via
+ * kkemu_write() + kkemu_poll() + kkemu_read().
+ */
+int kkemu_init(uint8_t *flash_buf, size_t flash_len);
+
+/**
+ * Shut down the emulator. Flushes pending storage writes to the
+ * flash buffer. After this call, the host should encrypt and persist
+ * the flash buffer, then zero it.
+ */
+void kkemu_shutdown(void);
+
+/**
+ * Write a 64-byte HID report into the emulator's input queue.
+ *
+ * @param data   Exactly 64 bytes.
+ * @param len    Must be 64.
+ * @param iface  KKEMU_IFACE_MAIN (0) or KKEMU_IFACE_DEBUG (1).
+ * @return 0 on success, -1 if queue is full.
+ */
+int kkemu_write(const uint8_t *data, size_t len, int iface);
+
+/**
+ * Read a 64-byte HID report from the emulator's output queue.
+ *
+ * Non-blocking. Returns 0 immediately if no output is available.
+ *
+ * @param buf    Buffer of at least 64 bytes.
+ * @param len    Must be 64.
+ * @param iface  KKEMU_IFACE_MAIN (0) or KKEMU_IFACE_DEBUG (1).
+ * @return Number of bytes read (64), or 0 if queue is empty.
+ */
+int kkemu_read(uint8_t *buf, size_t len, int iface);
+
+/**
+ * Run one iteration of the firmware event loop.
+ *
+ * Drains the input queue, dispatches messages through the FSM,
+ * queues output messages, and updates display/animations.
+ *
+ * Call this at 10-60 Hz from your event loop.
+ *
+ * @return Number of messages processed, or -1 on error.
+ */
+int kkemu_poll(void);
+
+/**
+ * Get the OLED framebuffer (256x64, 1-bit per pixel = 2048 bytes).
+ *
+ * @param width   Receives 256.
+ * @param height  Receives 64.
+ * @return Pointer to framebuffer (valid until next kkemu_poll).
+ *         Returns NULL if emulator is not initialized.
+ */
+const uint8_t *kkemu_get_display(int *width, int *height);
+
+/**
+ * Check if the emulator has been initialized.
+ */
+int kkemu_is_running(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIBKKEMU_H */

--- a/include/keepkey/emulator/setup.h
+++ b/include/keepkey/emulator/setup.h
@@ -2,5 +2,6 @@
 #define KEEPKEY_EMULATOR_SETUP_H
 
 void setup(void);
+void setup_urandom_only(void);  /* For libkkemu: init RNG without flash mmap */
 
 #endif

--- a/lib/emulator/CMakeLists.txt
+++ b/lib/emulator/CMakeLists.txt
@@ -19,4 +19,31 @@ if(${KK_EMULATOR})
 
   add_library(kkemulator ${sources})
 
+  # ── Shared library target (libkkemu.dylib / libkkemu.so) ──────────
+  if(KK_BUILD_DYLIB)
+    set(dylib_sources
+        oled.c
+        udp.c
+        setup.c
+        ringbuf.c
+        libkkemu.c)
+
+    if(NOT ${KK_HAVE_STRLCPY})
+        set(dylib_sources ${dylib_sources} strlcpy.c)
+    endif()
+    if(NOT ${KK_HAVE_STRLCAT})
+        set(dylib_sources ${dylib_sources} strlcat.c)
+    endif()
+
+    add_library(kkemulator_dylib SHARED ${dylib_sources})
+    target_compile_definitions(kkemulator_dylib PRIVATE KKEMU_DYLIB=1)
+    target_include_directories(kkemulator_dylib PRIVATE
+        ${CMAKE_SOURCE_DIR}/include
+        ${CMAKE_BINARY_DIR}/include
+        ${CMAKE_SOURCE_DIR}/deps/crypto/trezor-crypto)
+    set_target_properties(kkemulator_dylib PROPERTIES
+        OUTPUT_NAME "kkemu"
+        POSITION_INDEPENDENT_CODE ON)
+  endif()
+
 endif()

--- a/lib/emulator/libkkemu.c
+++ b/lib/emulator/libkkemu.c
@@ -1,0 +1,166 @@
+/*
+ * libkkemu — KeepKey firmware emulator as a shared library.
+ *
+ * Replaces main() with kkemu_init/poll/shutdown. Uses ring buffers
+ * instead of UDP sockets for message I/O.
+ */
+#include "keepkey/emulator/libkkemu.h"
+#include "keepkey/emulator/emulator.h"
+#include "keepkey/board/keepkey_board.h"
+#include "keepkey/board/keepkey_flash.h"
+#include "keepkey/board/layout.h"
+#include "keepkey/board/usb.h"
+#include "keepkey/board/memory.h"
+#include "keepkey/board/timer.h"
+#include "keepkey/firmware/storage.h"
+#include "keepkey/rand/rng.h"
+#include "ringbuf.h"
+
+#include <string.h>
+#include <sys/mman.h>
+
+/* Defined in firmware — we just need the declaration */
+extern void fsm_init(void);
+
+/* ── Ring buffers (replace UDP sockets) ─────────────────────────────── */
+
+static RingBuf rb_main_in;    /* host → firmware (main interface) */
+static RingBuf rb_main_out;   /* firmware → host (main interface) */
+static RingBuf rb_debug_in;   /* host → firmware (debug link) */
+static RingBuf rb_debug_out;  /* firmware → host (debug link) */
+
+static int libkkemu_initialized = 0;
+
+/* ── Replacement I/O functions ──────────────────────────────────────── */
+
+/*
+ * These replace the UDP socket functions in emulator/udp.c.
+ * When building as a shared library, we link against these instead.
+ */
+
+void libkkemu_socketInit(void) {
+    ringbuf_init(&rb_main_in);
+    ringbuf_init(&rb_main_out);
+    ringbuf_init(&rb_debug_in);
+    ringbuf_init(&rb_debug_out);
+}
+
+size_t libkkemu_socketRead(int *iface, void *buffer, size_t size) {
+    if (ringbuf_pop(&rb_main_in, (uint8_t *)buffer, size)) {
+        *iface = 0;
+        return size < RINGBUF_SLOT_SIZE ? size : RINGBUF_SLOT_SIZE;
+    }
+    if (ringbuf_pop(&rb_debug_in, (uint8_t *)buffer, size)) {
+        *iface = 1;
+        return size < RINGBUF_SLOT_SIZE ? size : RINGBUF_SLOT_SIZE;
+    }
+    return 0;
+}
+
+size_t libkkemu_socketWrite(int iface, const void *buffer, size_t size) {
+    RingBuf *rb = (iface == 0) ? &rb_main_out : &rb_debug_out;
+    if (!ringbuf_push(rb, (const uint8_t *)buffer, size))
+        return 0;
+    return size;
+}
+
+/* ── Public API ─────────────────────────────────────────────────────── */
+
+int kkemu_init(uint8_t *flash_buf, size_t flash_len) {
+    if (flash_len != KKEMU_FLASH_SIZE) return -1;
+    if (!flash_buf) return -1;
+    if (libkkemu_initialized) return -1;
+
+    /* Point firmware's flash pointer at the host-provided buffer */
+    emulator_flash_base = flash_buf;
+
+    /* Lock memory to prevent swapping secrets to disk */
+    mlock(flash_buf, flash_len);
+
+    /* Initialize ring buffers (replaces UDP socket init) */
+    libkkemu_socketInit();
+
+    /* Initialize /dev/urandom for RNG */
+    setup_urandom_only();
+
+    /* Board init (timers, etc.) */
+    kk_board_init();
+
+    /* Load storage from flash buffer */
+    storage_init();
+
+    /* Initialize message handler FSM */
+    fsm_init();
+
+    /* Draw initial home screen */
+    layoutHomeForced();
+
+    libkkemu_initialized = 1;
+    return 0;
+}
+
+void kkemu_shutdown(void) {
+    if (!libkkemu_initialized) return;
+
+    /* Flush any pending storage to the flash buffer */
+    storage_commit();
+
+    /* Unlock memory (host should zero + free after this) */
+    if (emulator_flash_base) {
+        munlock(emulator_flash_base, KKEMU_FLASH_SIZE);
+        emulator_flash_base = NULL;
+    }
+
+    libkkemu_initialized = 0;
+}
+
+int kkemu_write(const uint8_t *data, size_t len, int iface) {
+    if (!libkkemu_initialized) return -1;
+    if (len != KKEMU_PACKET_SIZE) return -1;
+
+    RingBuf *rb = (iface == KKEMU_IFACE_MAIN) ? &rb_main_in : &rb_debug_in;
+    return ringbuf_push(rb, data, len) ? 0 : -1;
+}
+
+int kkemu_read(uint8_t *buf, size_t len, int iface) {
+    if (!libkkemu_initialized) return 0;
+    if (len < KKEMU_PACKET_SIZE) return 0;
+
+    RingBuf *rb = (iface == KKEMU_IFACE_MAIN) ? &rb_main_out : &rb_debug_out;
+    return ringbuf_pop(rb, buf, KKEMU_PACKET_SIZE) ? KKEMU_PACKET_SIZE : 0;
+}
+
+int kkemu_poll(void) {
+    if (!libkkemu_initialized) return -1;
+
+    /*
+     * This is the same as exec() in main.cpp:
+     *   usbPoll()       — reads input, dispatches through FSM
+     *   animate()        — updates screen animations
+     *   display_refresh() — renders framebuffer
+     *
+     * usbPoll() internally calls emulatorSocketRead() which we've
+     * replaced with libkkemu_socketRead() via the ring buffers.
+     */
+    usbPoll();
+    animate();
+    display_refresh();
+
+    return 0;
+}
+
+const uint8_t *kkemu_get_display(int *width, int *height) {
+    if (!libkkemu_initialized) return NULL;
+
+    /* The canvas pointer is declared in layout.c */
+    extern Canvas *canvas;
+    if (!canvas) return NULL;
+
+    if (width) *width = canvas->width;
+    if (height) *height = canvas->height;
+    return canvas->buffer;
+}
+
+int kkemu_is_running(void) {
+    return libkkemu_initialized;
+}

--- a/lib/emulator/ringbuf.c
+++ b/lib/emulator/ringbuf.c
@@ -1,0 +1,43 @@
+/*
+ * Lock-free SPSC ring buffer for 64-byte HID reports.
+ */
+#include "ringbuf.h"
+#include <string.h>
+
+void ringbuf_init(RingBuf *rb) {
+    memset(rb, 0, sizeof(*rb));
+}
+
+bool ringbuf_push(RingBuf *rb, const uint8_t *msg, size_t len) {
+    if (len > RINGBUF_SLOT_SIZE) return false;
+
+    uint32_t head = rb->head;
+    uint32_t next = (head + 1) % RINGBUF_CAPACITY;
+
+    if (next == rb->tail) return false;  /* full */
+
+    memcpy(rb->data[head], msg, len);
+    if (len < RINGBUF_SLOT_SIZE)
+        memset(rb->data[head] + len, 0, RINGBUF_SLOT_SIZE - len);
+
+    __sync_synchronize();  /* memory barrier before publishing head */
+    rb->head = next;
+    return true;
+}
+
+bool ringbuf_pop(RingBuf *rb, uint8_t *msg, size_t len) {
+    uint32_t tail = rb->tail;
+
+    if (tail == rb->head) return false;  /* empty */
+
+    size_t copy = len < RINGBUF_SLOT_SIZE ? len : RINGBUF_SLOT_SIZE;
+    memcpy(msg, rb->data[tail], copy);
+
+    __sync_synchronize();  /* memory barrier before advancing tail */
+    rb->tail = (tail + 1) % RINGBUF_CAPACITY;
+    return true;
+}
+
+bool ringbuf_empty(const RingBuf *rb) {
+    return rb->head == rb->tail;
+}

--- a/lib/emulator/ringbuf.h
+++ b/lib/emulator/ringbuf.h
@@ -1,0 +1,26 @@
+/*
+ * Lock-free single-producer single-consumer ring buffer for HID reports.
+ * Used by libkkemu to pass 64-byte messages between host and firmware.
+ */
+#ifndef RINGBUF_H
+#define RINGBUF_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+#define RINGBUF_SLOT_SIZE 64   /* HID report size */
+#define RINGBUF_CAPACITY  32   /* max queued messages */
+
+typedef struct {
+    uint8_t data[RINGBUF_CAPACITY][RINGBUF_SLOT_SIZE];
+    volatile uint32_t head;  /* written by producer */
+    volatile uint32_t tail;  /* written by consumer */
+} RingBuf;
+
+void ringbuf_init(RingBuf *rb);
+bool ringbuf_push(RingBuf *rb, const uint8_t *msg, size_t len);
+bool ringbuf_pop(RingBuf *rb, uint8_t *msg, size_t len);
+bool ringbuf_empty(const RingBuf *rb);
+
+#endif

--- a/lib/emulator/setup.c
+++ b/lib/emulator/setup.c
@@ -43,6 +43,11 @@ void setup(void) {
 	setup_flash();
 }
 
+/* For libkkemu: init RNG only (flash buffer provided by host) */
+void setup_urandom_only(void) {
+	setup_urandom();
+}
+
 void emulatorRandom(void *buffer, size_t size) {
 	ssize_t n = read(urandom, buffer, size);
 	if (n < 0 || ((size_t) n) != size) {

--- a/lib/emulator/udp.c
+++ b/lib/emulator/udp.c
@@ -90,6 +90,28 @@ static size_t socket_read(struct usb_socket *sock, void *buffer, size_t size) {
 	return n;
 }
 
+#ifdef KKEMU_DYLIB
+/*
+ * Dylib mode: I/O goes through ring buffers managed by libkkemu.c.
+ * These are thin trampolines to the libkkemu_socket* functions.
+ */
+extern void   libkkemu_socketInit(void);
+extern size_t libkkemu_socketRead(int *iface, void *buffer, size_t size);
+extern size_t libkkemu_socketWrite(int iface, const void *buffer, size_t size);
+
+void emulatorSocketInit(void) { libkkemu_socketInit(); }
+
+size_t emulatorSocketRead(int *iface, void *buffer, size_t size) {
+	return libkkemu_socketRead(iface, buffer, size);
+}
+
+size_t emulatorSocketWrite(int iface, const void *buffer, size_t size) {
+	return libkkemu_socketWrite(iface, buffer, size);
+}
+
+#else
+/* Standard mode: UDP sockets (standalone kkemu binary) */
+
 void emulatorSocketInit(void) {
 	usb_main.fd = socket_setup(TREZOR_UDP_PORT);
 	usb_main.fromlen = 0;
@@ -122,3 +144,4 @@ size_t emulatorSocketWrite(int iface, const void *buffer, size_t size) {
 	}
 	return 0;
 }
+#endif

--- a/tools/emulator/CMakeLists.txt
+++ b/tools/emulator/CMakeLists.txt
@@ -8,9 +8,7 @@ if(${KK_EMULATOR})
       ${CMAKE_BINARY_DIR}/include
       ${CMAKE_SOURCE_DIR}/deps/crypto/trezor-crypto)
 
-  add_executable(kkemu ${sources})
-
-  target_link_libraries(kkemu
+  set(FIRMWARE_LIBS
       kkfirmware
       kkfirmware.keepkey
       kkboard
@@ -20,6 +18,14 @@ if(${KK_EMULATOR})
       kktransport
       trezorcrypto
       trezorqrenc
-      kkrand
-      kkemulator)
+      kkrand)
+
+  # Standalone emulator binary (uses UDP sockets)
+  add_executable(kkemu ${sources})
+  target_link_libraries(kkemu ${FIRMWARE_LIBS} kkemulator)
+
+  # Shared library (uses ring buffers, no sockets)
+  if(KK_BUILD_DYLIB)
+    target_link_libraries(kkemulator_dylib ${FIRMWARE_LIBS})
+  endif()
 endif()


### PR DESCRIPTION
## Summary
- New build target `KK_BUILD_DYLIB` that produces `libkkemu.dylib` for loading the emulator in-process via FFI
- No UDP sockets, no HTTP bridge — host communicates through lock-free ring buffers
- Host provides a 1MB flash buffer (manages encryption/persistence externally)
- Designed for KeepKey Vault desktop app to run emulator in-process via `bun:ffi`

## API
```c
int kkemu_init(uint8_t *flash_buf, size_t flash_len);  // host provides buffer
int kkemu_write(const uint8_t *data, size_t len, int iface);  // send HID report
int kkemu_read(uint8_t *buf, size_t len, int iface);  // receive HID report
int kkemu_poll(void);  // one firmware frame (FSM + display)
void kkemu_shutdown(void);  // flush + cleanup
```

## New files
- `lib/emulator/ringbuf.{c,h}` — SPSC lock-free ring buffer (32 slots x 64 bytes)
- `lib/emulator/libkkemu.c` — API wrapping firmware init/poll/shutdown
- `include/keepkey/emulator/libkkemu.h` — public C header

## Modified
- `lib/emulator/udp.c` — `KKEMU_DYLIB` compile flag routes I/O through ring buffers instead of UDP sockets
- `lib/emulator/setup.c` — `setup_urandom_only()` for dylib mode (no flash mmap, host manages flash)
- `CMakeLists.txt` — `KK_BUILD_DYLIB` option
- `lib/emulator/CMakeLists.txt` — `kkemulator_dylib` SHARED library target
- `tools/emulator/CMakeLists.txt` — links dylib with all firmware libs

## Build
```bash
cmake .. -C ../cmake/caches/emulator.cmake -DKK_BUILD_DYLIB=ON
make kkemulator_dylib   # produces libkkemu.dylib
```

## Security
- Flash buffer is owned by the host — encrypted at rest with macOS Keychain (AES-256-GCM)
- Plaintext only lives in mlock'd memory (no swap, no core dump)
- Host zeros buffer on shutdown before freeing

## Test plan
- [ ] Existing `make kkemu` still builds and works (no regression)
- [ ] `make kkemulator_dylib` produces `libkkemu.dylib`
- [ ] Write/read through ring buffers matches UDP behavior
- [ ] Flash state persists across init/shutdown cycles