### PR TITLE
fix(ci): enforce fail-fast — no more silent passes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,9 @@ jobs:
           done
           if [ "$FAILED" = "1" ]; then
             echo ""
-            echo "Run: clang-format -i <file> to fix formatting"
+            echo "::error::Code formatting check failed. Run: clang-format -i <file> to fix."
+            exit 1
           fi
-        # Warn-only until existing code is reformatted
-        continue-on-error: true
 
   secret-scan:
     runs-on: ubuntu-latest
@@ -130,16 +129,18 @@ jobs:
             -DPB_FIELD_16BIT=1 \
             -DEMULATOR=1 \
             --template='::warning file={file},line={line},col={column}::{severity}: {message} [{id}]' \
-            --error-exitcode=0 \
-            lib/ include/keepkey/ tools/ 2>&1 | tee cppcheck_report.txt
+            --output-file=cppcheck_report.txt \
+            --error-exitcode=1 \
+            lib/ include/keepkey/ tools/ 2>&1; CPPCHECK_RC=$?
 
-          # Count issues by severity (match only ::warning annotation lines)
-          ERRORS=$(grep -c '::warning.*\berror:' cppcheck_report.txt 2>/dev/null || true)
-          WARNINGS=$(grep -c '::warning.*\bwarning:' cppcheck_report.txt 2>/dev/null || true)
-          STYLE=$(grep -c '::warning.*\bstyle:' cppcheck_report.txt 2>/dev/null || true)
-          PERF=$(grep -c '::warning.*\bperformance:' cppcheck_report.txt 2>/dev/null || true)
-          : "${ERRORS:=0}" "${WARNINGS:=0}" "${STYLE:=0}" "${PERF:=0}"
-          TOTAL=$((ERRORS + WARNINGS + STYLE + PERF))
+          # Count issues by severity
+          ERRORS=$(grep -c '\berror:' cppcheck_report.txt 2>/dev/null || true)
+          WARNINGS=$(grep -c '\bwarning:' cppcheck_report.txt 2>/dev/null || true)
+          STYLE=$(grep -c '\bstyle:' cppcheck_report.txt 2>/dev/null || true)
+          PERF=$(grep -c '\bperformance:' cppcheck_report.txt 2>/dev/null || true)
+          PORT=$(grep -c '\bportability:' cppcheck_report.txt 2>/dev/null || true)
+          : "${ERRORS:=0}" "${WARNINGS:=0}" "${STYLE:=0}" "${PERF:=0}" "${PORT:=0}"
+          TOTAL=$((ERRORS + WARNINGS + STYLE + PERF + PORT))
 
           echo "## cppcheck summary" >> "$GITHUB_STEP_SUMMARY"
           echo "| Severity | Count |" >> "$GITHUB_STEP_SUMMARY"
@@ -148,21 +149,23 @@ jobs:
           echo "| warning | $WARNINGS |" >> "$GITHUB_STEP_SUMMARY"
           echo "| style | $STYLE |" >> "$GITHUB_STEP_SUMMARY"
           echo "| performance | $PERF |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| portability | $PORT |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **total** | **$TOTAL** |" >> "$GITHUB_STEP_SUMMARY"
 
-          echo ""
-          echo "=== cppcheck full report ==="
-          grep '::warning' cppcheck_report.txt || echo "(no findings)"
-          echo "=== end report ==="
+          # Print findings as GitHub annotations
+          cat cppcheck_report.txt
 
-          if [ "$ERRORS" -gt 0 ]; then
-            echo "::error::cppcheck found $ERRORS error(s) — failing build"
+          if [ "$CPPCHECK_RC" -ne 0 ]; then
+            echo "::error::cppcheck exited with error code $CPPCHECK_RC"
             exit 1
-          elif [ "$TOTAL" -gt 0 ]; then
-            echo "cppcheck found $TOTAL non-error issue(s) — warnings only, not blocking"
-          else
-            echo "cppcheck: clean"
           fi
+
+          if [ "$TOTAL" -gt 0 ]; then
+            echo "::error::cppcheck found $TOTAL issue(s) — zero-warning policy enforced"
+            exit 1
+          fi
+
+          echo "cppcheck: clean — zero findings"
 
       - name: Upload cppcheck report
         uses: actions/upload-artifact@v7
@@ -208,7 +211,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════
 
   build-emulator:
-    needs: [check-submodules, secret-scan]
+    needs: [lint-format, static-analysis, check-submodules, secret-scan]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -264,7 +267,7 @@ jobs:
           retention-days: 1
 
   build-arm-firmware:
-    needs: [check-submodules, secret-scan]
+    needs: [lint-format, static-analysis, check-submodules, secret-scan]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -386,8 +389,7 @@ jobs:
           retention-days: 30
 
   python-integration-tests:
-    needs: [check-submodules, secret-scan]
-    if: ${{ !cancelled() }}
+    needs: [lint-format, static-analysis, check-submodules, secret-scan]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -408,17 +410,15 @@ jobs:
       - name: Build and run tests (docker compose)
         working-directory: scripts/emulator
         run: |
-          set +e
-          docker compose up --build firmware-unit
-          docker compose up --build python-keepkey
-          set -e
+          # Run each test container — capture exit codes, always extract reports
+          docker compose up --build --exit-code-from firmware-unit firmware-unit; FW_RC=$?
+          docker compose up --build --exit-code-from python-keepkey python-keepkey; PY_RC=$?
+
           mkdir -p ${{ github.workspace }}/test-reports
 
           echo "=== Extracting test reports from Docker ==="
           PY_CONTAINER=$(docker compose ps -a -q python-keepkey)
           FW_CONTAINER=$(docker compose ps -a -q firmware-unit)
-          echo "python-keepkey container: $PY_CONTAINER"
-          echo "firmware-unit container: $FW_CONTAINER"
 
           docker cp "$FW_CONTAINER":/kkemu/test-reports/. ${{ github.workspace }}/test-reports/ || echo "WARN: firmware-unit docker cp failed"
           docker cp "$PY_CONTAINER":/kkemu/test-reports/. ${{ github.workspace }}/test-reports/ || echo "WARN: python-keepkey docker cp failed"
@@ -429,11 +429,16 @@ jobs:
           find ${{ github.workspace }}/test-reports/screenshots -name '*.png' 2>/dev/null | wc -l
           echo "PNGs on host"
 
-          UNIT_STATUS=$(cat ${{ github.workspace }}/test-reports/firmware-unit/status 2>/dev/null || echo "1")
-          PY_STATUS=$(cat ${{ github.workspace }}/test-reports/python-keepkey/status 2>/dev/null || echo "1")
-          echo "Unit tests exit status: $UNIT_STATUS"
-          echo "Python tests exit status: $PY_STATUS"
-          [ "${UNIT_STATUS}${PY_STATUS}" = "00" ] || exit 1
+          echo "firmware-unit exit code: $FW_RC"
+          echo "python-keepkey exit code: $PY_RC"
+
+          if [ "$FW_RC" -ne 0 ]; then
+            echo "::error::firmware-unit tests failed (exit code $FW_RC)"
+          fi
+          if [ "$PY_RC" -ne 0 ]; then
+            echo "::error::python-keepkey tests failed (exit code $PY_RC)"
+          fi
+          [ "$FW_RC" -eq 0 ] && [ "$PY_RC" -eq 0 ] || exit 1
 
       - name: Upload Python test results
         uses: actions/upload-artifact@v7

--- a/include/keepkey/firmware/ripple_base58.h
+++ b/include/keepkey/firmware/ripple_base58.h
@@ -33,8 +33,8 @@
 extern const char ripple_b58digits_ordered[];
 extern const int8_t ripple_b58digits_map[];
 
-int ripple_encode_check(const uint8_t* data, int datalen, HasherType hasher_type,
-                        char* str, int strsize);
+int ripple_encode_check(const uint8_t* data, int datalen,
+                        HasherType hasher_type, char* str, int strsize);
 int ripple_decode_check(const char* str, HasherType hasher_type, uint8_t* data,
                         int datalen);
 

--- a/lib/board/draw.c
+++ b/lib/board/draw.c
@@ -109,7 +109,8 @@ bool draw_char_with_shift(Canvas* canvas, DrawableParams* p, uint16_t* x_shift,
  *     none
  */
 void draw_string(Canvas* canvas, const Font* font, const char* str_write,
-                 const DrawableParams* p, uint16_t width, uint16_t line_height) {
+                 const DrawableParams* p, uint16_t width,
+                 uint16_t line_height) {
   uint16_t sepPixels =
       0;  // font char separation pixels for large font (pin font)
 

--- a/lib/board/memory.c
+++ b/lib/board/memory.c
@@ -45,25 +45,27 @@ uint8_t* emulator_flash_base = NULL;
 #endif
 
 #ifndef EMULATOR
-extern unsigned end;    // This is at the end of the data + bss, used for recursion guard
+extern unsigned
+    end;  // This is at the end of the data + bss, used for recursion guard
 #endif
 
 int memcheck(unsigned stackGuardSize) {
 #ifdef EMULATOR
-    // In emulator, we have plenty of stack space, just return STACK_GOOD
-    (void)stackGuardSize;
-    return STACK_GOOD;
+  // In emulator, we have plenty of stack space, just return STACK_GOOD
+  (void)stackGuardSize;
+  return STACK_GOOD;
 #else
-    void *stackBottom;    // this is the bottom of the stack, it is shrinking toward static mem at variable "end".
-    //char buf[33] = {0};
-    //snprintf(buf, 64, "RAM available %u", (unsigned)&stackBottom - (unsigned)&end);
-    //snprintf(buf, 64, "stack bottom %x", (unsigned)&stackBottom);
-    //DEBUG_DISPLAY(buf);
-    if (stackGuardSize > ((unsigned)&stackBottom - (unsigned)&end)) {
-        return STACK_TOO_SMALL;
-    } else {
-        return STACK_GOOD;
-    }
+  void* stackBottom;  // this is the bottom of the stack, it is shrinking toward
+                      // static mem at variable "end".
+  // char buf[33] = {0};
+  // snprintf(buf, 64, "RAM available %u", (unsigned)&stackBottom -
+  // (unsigned)&end); snprintf(buf, 64, "stack bottom %x",
+  // (unsigned)&stackBottom); DEBUG_DISPLAY(buf);
+  if (stackGuardSize > ((unsigned)&stackBottom - (unsigned)&end)) {
+    return STACK_TOO_SMALL;
+  } else {
+    return STACK_GOOD;
+  }
 #endif
 }
 

--- a/lib/firmware/eip712.c
+++ b/lib/firmware/eip712.c
@@ -403,7 +403,7 @@ int parseVals(const json_t* eip712Types, const json_t* jType,
               const json_t* nextVal, struct SHA3_CTX* msgCtx) {
   json_t const *tarray, *pairs, *walkVals, *obTest;
   int ctr;
-  const char *typeType = NULL;
+  const char* typeType = NULL;
   uint8_t encBytes[32] = {0};  // holds the encrypted bytes for the message
   const char* valStr = NULL;
   struct SHA3_CTX valCtx = {0};  // local hash context

--- a/lib/firmware/ethereum_contracts/thortx.c
+++ b/lib/firmware/ethereum_contracts/thortx.c
@@ -42,8 +42,8 @@ bool thor_confirmThorTx(uint32_t data_total, const EthereumSignTx* msg) {
 
   char confStr[41], *conf;
   const TokenType* assetToken;
-  uint8_t *thorchainData;
-  const uint8_t *contractAssetAddress;
+  uint8_t* thorchainData;
+  const uint8_t* contractAssetAddress;
   const uint8_t *vaultAddress, *assetAddress;
   uint32_t ctr;
   bignum256 Amount;

--- a/lib/firmware/ethereum_contracts/zxliquidtx.c
+++ b/lib/firmware/ethereum_contracts/zxliquidtx.c
@@ -93,7 +93,8 @@ static bool confirmFromAccountMatch(const EthereumSignTx* msg,
     memzero(node, sizeof(*node));
   }
 
-  fromAddress = (const uint8_t*)(msg->data_initial_chunk.bytes + 4 + 5 * 32 - 20);
+  fromAddress =
+      (const uint8_t*)(msg->data_initial_chunk.bytes + 4 + 5 * 32 - 20);
 
   if (memcmp(fromAddress, addressBytes, 20) == 0) {
     fromSrc = "self";
@@ -142,7 +143,8 @@ bool zx_confirmZxLiquidTx(uint32_t data_total, const EthereumSignTx* msg) {
 
   tokenAddress = (const uint8_t*)(msg->data_initial_chunk.bytes + 4 + 32 - 20);
   token = tokenByChainAddress(msg->chain_id, tokenAddress);
-  deadlineBytes = (const uint8_t*)(msg->data_initial_chunk.bytes + 4 + 6 * 32 - 8);
+  deadlineBytes =
+      (const uint8_t*)(msg->data_initial_chunk.bytes + 4 + 6 * 32 - 8);
   deadline = ((uint64_t)deadlineBytes[0] << 8 * 7) |
              ((uint64_t)deadlineBytes[1] << 8 * 6) |
              ((uint64_t)deadlineBytes[2] << 8 * 5) |

--- a/lib/firmware/ethereum_contracts/zxswap.c
+++ b/lib/firmware/ethereum_contracts/zxswap.c
@@ -71,9 +71,10 @@ bool zx_confirmZxSwap(uint32_t data_total, const EthereumSignTx* msg) {
       break;
   }
 
-  fromAddress = (const uint8_t*)(msg->data_initial_chunk.bytes + 4 + 5 * 32 + 12);
-  toAddress =
-      (const uint8_t*)(msg->data_initial_chunk.bytes + 4 + (6 + adder) * 32 + 12);
+  fromAddress =
+      (const uint8_t*)(msg->data_initial_chunk.bytes + 4 + 5 * 32 + 12);
+  toAddress = (const uint8_t*)(msg->data_initial_chunk.bytes + 4 +
+                               (6 + adder) * 32 + 12);
 
   from = tokenByChainAddress(msg->chain_id, fromAddress);
   to = tokenByChainAddress(msg->chain_id, toAddress);

--- a/lib/firmware/fsm_msg_debug.h
+++ b/lib/firmware/fsm_msg_debug.h
@@ -60,7 +60,7 @@ void fsm_msgDebugLinkGetState(DebugLinkGetState* msg) {
    * Each byte in layout holds 8 vertical pixels (LSB = top).
    * Total: 256 columns x (64/8) rows = 2048 bytes. */
   {
-    const Canvas *c = display_canvas();
+    const Canvas* c = display_canvas();
     if (c && c->buffer) {
       resp->has_layout = true;
       resp->layout.size = 2048;

--- a/lib/firmware/fsm_msg_osmosis.h
+++ b/lib/firmware/fsm_msg_osmosis.h
@@ -549,10 +549,9 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
     }
   } else if (msg->has_swap) {
     /** Confirm required transaction parameters exist */
-    if (!msg->swap.has_sender ||
-        !msg->swap.has_pool_id || !msg->swap.has_token_out_denom ||
-        !msg->swap.has_token_in_denom || !msg->swap.has_token_in_amount ||
-        !msg->swap.has_token_out_min_amount) {
+    if (!msg->swap.has_sender || !msg->swap.has_pool_id ||
+        !msg->swap.has_token_out_denom || !msg->swap.has_token_in_denom ||
+        !msg->swap.has_token_in_amount || !msg->swap.has_token_out_min_amount) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_FirmwareError,
                       _("Message is missing required parameters"));

--- a/lib/firmware/storage.c
+++ b/lib/firmware/storage.c
@@ -1275,9 +1275,9 @@ static void storage_setRootSeedCache(const SessionState* ss, ConfigFlash* cfg,
 /// \param curve[in] ECDSA curve name being used.
 /// \param seed[out] The root seed value.
 /// \returns true on success.
-static bool storage_getRootSeedCache(const SessionState* ss, const ConfigFlash* cfg,
-                                     const char* curve, bool usePassphrase,
-                                     uint8_t* seed) {
+static bool storage_getRootSeedCache(const SessionState* ss,
+                                     const ConfigFlash* cfg, const char* curve,
+                                     bool usePassphrase, uint8_t* seed) {
   if (!cfg->storage.has_sec) return false;
 
   if (cfg->storage.sec.cache.root_seed_cache_status != CACHE_EXISTS)

--- a/lib/firmware/storage.h
+++ b/lib/firmware/storage.h
@@ -161,8 +161,7 @@ void storage_resetUuid_impl(ConfigFlash* cfg);
 
 void storage_reset_impl(SessionState* ss, ConfigFlash* cfg);
 
-void storage_setPin_impl(SessionState* ss, Storage* storage,
-                         const char* pin);
+void storage_setPin_impl(SessionState* ss, Storage* storage, const char* pin);
 
 bool storage_hasPin_impl(const Storage* storage);
 
@@ -210,8 +209,8 @@ void storage_writeV16(char* flash, size_t len, const ConfigFlash* src);
 void storage_readMeta(Metadata* meta, const char* ptr, size_t len);
 void storage_readPolicyV1(PolicyType* policy, const char* ptr, size_t len);
 void storage_readHDNode(HDNodeType* node, const char* ptr, size_t len);
-void storage_readStorageV1(SessionState* ss, Storage* storage,
-                           const char* ptr, size_t len);
+void storage_readStorageV1(SessionState* ss, Storage* storage, const char* ptr,
+                           size_t len);
 void storage_readStorageV11(Storage* storage, const char* ptr, size_t len);
 void storage_readCacheV1(Cache* cache, const char* ptr, size_t len);
 


### PR DESCRIPTION
## Summary
- Remove every "cheat green" pattern from the CI pipeline
- Gate stage now **actually blocks** builds and tests on failure
- Integration tests now use real exit codes instead of `set +e`

## What changed

### Gate stage (lint + cppcheck) now blocks everything
| Before | After |
|--------|-------|
| `lint-format` had `continue-on-error: true` | Fails the pipeline on any formatting diff |
| `static-analysis` used `--error-exitcode=0` | Uses `--error-exitcode=1` + fails on ANY finding |
| Builds only waited on submodules + secrets | Builds wait on ALL 4 gate jobs |

### Integration tests now fail honestly
| Before | After |
|--------|-------|
| `set +e` swallowed docker compose failures | Uses `--exit-code-from` for real exit codes |
| Read status from files (missing = assume fail) | Direct capture of container exit codes |
| `if: !cancelled()` bypassed gate failures | Standard `needs:` dependency on full gate |

## Expected behavior
**This PR will go red** — that's the point. The existing codebase has clang-format diffs and (without PR #407) cppcheck warnings. Merge order:

1. #407 — cppcheck warning fixes (currently green)
2. This PR — CI hardening (will go green once #407 is merged)
3. Follow-up — clang-format fixes (to make lint-format pass)

## Test plan
- [ ] Verify this PR goes red on lint-format and/or static-analysis (expected)
- [ ] After #407 merges, verify static-analysis passes
- [ ] After clang-format fixes, verify full pipeline is green