### PR TITLE
fix(ci): pin clang-format to version 18 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,12 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Install clang-format
+      - name: Install clang-format-18 (pinned LTS)
         run: |
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble main" | sudo tee /etc/apt/sources.list.d/llvm.list
-          sudo apt-get update -qq && sudo apt-get install -y -qq clang-format
+          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-18 main" | sudo tee /etc/apt/sources.list.d/llvm.list
+          sudo apt-get update -qq && sudo apt-get install -y -qq clang-format-18
+          sudo ln -sf /usr/bin/clang-format-18 /usr/bin/clang-format
 
       - name: Check code formatting
         run: |


### PR DESCRIPTION
## Summary
Pin clang-format to version 18 (Ubuntu 24.04 LTS) instead of LLVM nightly.

The `llvm-toolchain-noble main` repo installs the latest nightly (currently v23), which produces different formatting than v18. This causes branches that format correctly locally to fail CI lint.

## Changes
- `ci.yml`: install `clang-format-18` from `llvm-toolchain-noble-18` instead of unpinned `clang-format` from nightly
- Symlink `/usr/bin/clang-format` to the pinned version

## Test Plan
- [ ] CI lint-format passes on develop
- [ ] Feature branches stop getting spurious lint failures