### PR TITLE
fix(ci): pin clang-format to v20 stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,12 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Install clang-format
+      - name: Install clang-format-20 (pinned stable)
         run: |
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble main" | sudo tee /etc/apt/sources.list.d/llvm.list
-          sudo apt-get update -qq && sudo apt-get install -y -qq clang-format
+          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" | sudo tee /etc/apt/sources.list.d/llvm.list
+          sudo apt-get update -qq && sudo apt-get install -y -qq clang-format-20
+          sudo ln -sf /usr/bin/clang-format-20 /usr/bin/clang-format
 
       - name: Check code formatting
         run: |

--- a/lib/firmware/ethereum_contracts/zxappliquid.c
+++ b/lib/firmware/ethereum_contracts/zxappliquid.c
@@ -35,7 +35,7 @@
 #include "trezor/crypto/sha3.h"
 
 bool zx_confirmApproveLiquidity(uint32_t data_total,
-                                const EthereumSignTx* msg) {
+                                const EthereumSignTx *msg) {
   (void)data_total;
   const char *to, *tikstr, *poolstr, *allowance, *amt;
   unsigned char data[40];
@@ -47,14 +47,14 @@ bool zx_confirmApproveLiquidity(uint32_t data_total,
   const TokenType *WETH, *ttoken;
 
   if (!tokenByTicker(msg->chain_id, "WETH", &WETH)) return false;
-  wethord = read_be((const uint8_t*)WETH->address);
-  to = (const char*)msg->to.bytes;
+  wethord = read_be((const uint8_t *)WETH->address);
+  to = (const char *)msg->to.bytes;
   tokctr = 0;
   while (tokctr != -1) {
     ttoken = tokenIter(&tokctr);
 
     // https://uniswap.org/docs/v2/smart-contract-integration/getting-pair-addresses/
-    uint32_t ttokenord = read_be((const uint8_t*)ttoken->address);
+    uint32_t ttokenord = read_be((const uint8_t *)ttoken->address);
     if (ttokenord < wethord) {
       memcpy(data, ttoken->address, 20);
       memcpy(&data[20], WETH->address, 20);
@@ -65,7 +65,7 @@ bool zx_confirmApproveLiquidity(uint32_t data_total,
     keccak_256(data, sizeof(data), tokdigest);
     SHA3_CTX ctx = {0};
     keccak_256_Init(&ctx);
-    keccak_Update(&ctx, (unsigned char*)"\xff", 1);
+    keccak_Update(&ctx, (unsigned char *)"\xff", 1);
     keccak_Update(&ctx, (unsigned char *)"\x5C\x69\xbE\xe7\x01\xef\x81\x4a\x2B\x6a\x3E\xDD\x4B\x16\x52\xCB\x9c\xc5\xaA\x6f", 20);
     keccak_Update(&ctx, tokdigest, sizeof(tokdigest));
     keccak_Update(&ctx, (unsigned char *)"\x96\xe8\xac\x42\x77\x19\x8f\xf8\xb6\xf7\x85\x47\x8a\xa9\xa3\x9f\x40\x3c\xb7\x68\xdd\x02\xcb\xee\x32\x6c\x3e\x7d\xa3\x48\x84\x5f", 32);
@@ -87,8 +87,8 @@ bool zx_confirmApproveLiquidity(uint32_t data_total,
     poolstr = digestStr;
   }
 
-  allowance = (char*)(msg->data_initial_chunk.bytes + 4 + 32);
-  if (memcmp(allowance, (uint8_t*)&MAX_ALLOWANCE, 32) == 0) {
+  allowance = (char *)(msg->data_initial_chunk.bytes + 4 + 32);
+  if (memcmp(allowance, (uint8_t *)&MAX_ALLOWANCE, 32) == 0) {
     amt = "full balance";
   } else {
     for (ctr = 0; ctr < 32; ctr++) {
@@ -97,7 +97,7 @@ bool zx_confirmApproveLiquidity(uint32_t data_total,
     amt = amtStr;
   }
 
-  const char* appStr = "uniswap approve liquidity";
+  const char *appStr = "uniswap approve liquidity";
   confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, appStr, "Amount: %s",
           amt);
   confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, appStr,
@@ -105,9 +105,9 @@ bool zx_confirmApproveLiquidity(uint32_t data_total,
   return true;
 }
 
-bool zx_isZxApproveLiquid(const EthereumSignTx* msg) {
+bool zx_isZxApproveLiquid(const EthereumSignTx *msg) {
   if (memcmp(msg->data_initial_chunk.bytes, "\x09\x5e\xa7\xb3", 4) == 0)
-    if (memcmp((uint8_t*)(msg->data_initial_chunk.bytes + 4 + 32 - 20),
+    if (memcmp((uint8_t *)(msg->data_initial_chunk.bytes + 4 + 32 - 20),
                UNISWAP_ROUTER_ADDRESS, 20) == 0)
       return true;
   return false;


### PR DESCRIPTION
## Summary
Pin clang-format to version 20 (latest LLVM stable) instead of unpinned nightly (currently v23).

Different nightly versions produce different formatting output, causing feature branches to fail lint even when formatted correctly. Pinning to a stable release makes CI reproducible.

## Changes
- `ci.yml`: install `clang-format-20` from `llvm-toolchain-noble-20`
- `zxappliquid.c`: reformat one file that differed between v20 and v23

## Test Plan
- [ ] Full lint check passes with v20 (verified locally via Docker)
- [ ] All existing develop files pass (1 file reformatted)