### PR TITLE
chore: bump device-protocol to master + update nanopb options

### DIFF
--- a/include/keepkey/transport/messages-ethereum.options
+++ b/include/keepkey/transport/messages-ethereum.options
@@ -47,3 +47,6 @@ Ethereum712TypesValues.eip712types               max_size:2048
 Ethereum712TypesValues.eip712primetype           max_size:80
 Ethereum712TypesValues.eip712data			          max_size:2048
 
+EthereumTxMetadata.signed_payload                 max_size:1024
+EthereumMetadataAck.display_summary               max_size:32
+

--- a/include/keepkey/transport/messages-solana.options
+++ b/include/keepkey/transport/messages-solana.options
@@ -3,9 +3,13 @@ SolanaGetAddress.coin_name max_size:21
 
 SolanaAddress.address max_size:64
 
+SolanaTokenInfo.mint max_size:32
+SolanaTokenInfo.symbol max_size:13
+
 SolanaSignTx.address_n max_count:8
 SolanaSignTx.coin_name max_size:21
 SolanaSignTx.raw_tx max_size:2048
+SolanaSignTx.token_info max_count:4
 
 SolanaSignedTx.signature max_size:64
 

--- a/include/keepkey/transport/messages-ton.options
+++ b/include/keepkey/transport/messages-ton.options
@@ -8,5 +8,6 @@ TonSignTx.address_n max_count:8
 TonSignTx.coin_name max_size:21
 TonSignTx.raw_tx max_size:1024
 TonSignTx.to_address max_size:50
+TonSignTx.memo max_size:121
 
 TonSignedTx.signature max_size:64

--- a/include/keepkey/transport/messages-tron.options
+++ b/include/keepkey/transport/messages-tron.options
@@ -12,3 +12,8 @@ TronSignTx.contract_type max_size:64
 TronSignTx.to_address max_size:35
 
 TronSignedTx.signature max_size:65
+TronTransferContract.to_address max_size:35
+TronTriggerSmartContract.contract_address max_size:35
+TronTriggerSmartContract.data max_size:512
+TronSignTx.data max_size:256
+TronSignedTx.serialized_tx max_size:1024


### PR DESCRIPTION
## Summary
Bump device-protocol submodule from b07589f to bf8646b (upstream master).

Adds nanopb options entries for all new proto fields introduced in device-protocol PRs #100 and #101. Without these, nanopb generates `pb_callback_t` types which the build rejects.

## Changes (5 files, +14/-1)
- `deps/device-protocol` → bf8646b
- `messages-ethereum.options` += EthereumTxMetadata, EthereumMetadataAck
- `messages-solana.options` += SolanaTokenInfo, token_info
- `messages-ton.options` += TonSignTx.memo
- `messages-tron.options` += TronTransferContract, TronTriggerSmartContract, etc.

## Test Plan
- [ ] Build compiles without pb_callback_t errors
- [ ] Existing tests unaffected (no firmware code changes)