### PR TITLE
feat: Solana support (GetAddress, SignTx, SignMessage)

### DIFF
--- a/include/keepkey/firmware/fsm.h
+++ b/include/keepkey/firmware/fsm.h
@@ -122,6 +122,9 @@ void fsm_msgTronGetAddress(const TronGetAddress* msg);
 void fsm_msgTronSignTx(TronSignTx* msg);
 void fsm_msgTonGetAddress(const TonGetAddress* msg);
 void fsm_msgTonSignTx(TonSignTx* msg);
+void fsm_msgSolanaGetAddress(const SolanaGetAddress* msg);
+void fsm_msgSolanaSignTx(const SolanaSignTx* msg);
+void fsm_msgSolanaSignMessage(const SolanaSignMessage* msg);
 
 #if DEBUG_LINK
 // void fsm_msgDebugLinkDecision(DebugLinkDecision *msg);

--- a/include/keepkey/firmware/solana.h
+++ b/include/keepkey/firmware/solana.h
@@ -1,0 +1,143 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2025 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPKEY_FIRMWARE_SOLANA_H
+#define KEEPKEY_FIRMWARE_SOLANA_H
+
+#include "trezor/crypto/bip32.h"
+#include "messages-solana.pb.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define SOL_DECIMALS 9
+#define SOL_PUBKEY_SIZE 32
+#define SOL_SIG_SIZE 64
+
+/* Well-known program IDs */
+extern const uint8_t SOL_SYSTEM_PROGRAM[SOL_PUBKEY_SIZE];
+extern const uint8_t SOL_TOKEN_PROGRAM[SOL_PUBKEY_SIZE];
+extern const uint8_t SOL_TOKEN_2022_PROGRAM[SOL_PUBKEY_SIZE];
+extern const uint8_t SOL_STAKE_PROGRAM[SOL_PUBKEY_SIZE];
+extern const uint8_t SOL_VOTE_PROGRAM[SOL_PUBKEY_SIZE];
+extern const uint8_t SOL_ATA_PROGRAM[SOL_PUBKEY_SIZE];
+extern const uint8_t SOL_COMPUTE_BUDGET_PROGRAM[SOL_PUBKEY_SIZE];
+extern const uint8_t SOL_MEMO_PROGRAM[SOL_PUBKEY_SIZE];
+
+/* Instruction types recognized by the parser */
+typedef enum {
+  SOL_INSTR_SYSTEM_TRANSFER,
+  SOL_INSTR_SYSTEM_CREATE_ACCOUNT,
+  SOL_INSTR_SYSTEM_ADVANCE_NONCE,
+  SOL_INSTR_SYSTEM_WITHDRAW_NONCE,
+  SOL_INSTR_SYSTEM_INITIALIZE_NONCE,
+  SOL_INSTR_SYSTEM_AUTHORIZE_NONCE,
+  SOL_INSTR_SYSTEM_ASSIGN,
+  SOL_INSTR_SYSTEM_ALLOCATE,
+  SOL_INSTR_TOKEN_TRANSFER,
+  SOL_INSTR_TOKEN_TRANSFER_CHECKED,
+  SOL_INSTR_TOKEN_APPROVE,
+  SOL_INSTR_TOKEN_REVOKE,
+  SOL_INSTR_TOKEN_SET_AUTHORITY,
+  SOL_INSTR_TOKEN_MINT_TO,
+  SOL_INSTR_TOKEN_BURN,
+  SOL_INSTR_TOKEN_CLOSE_ACCOUNT,
+  SOL_INSTR_TOKEN_FREEZE_ACCOUNT,
+  SOL_INSTR_TOKEN_THAW_ACCOUNT,
+  SOL_INSTR_TOKEN_SYNC_NATIVE,
+  SOL_INSTR_STAKE_DELEGATE,
+  SOL_INSTR_STAKE_WITHDRAW,
+  SOL_INSTR_STAKE_AUTHORIZE,
+  SOL_INSTR_STAKE_SPLIT,
+  SOL_INSTR_STAKE_DEACTIVATE,
+  SOL_INSTR_STAKE_MERGE,
+  SOL_INSTR_VOTE_AUTHORIZE,
+  SOL_INSTR_VOTE_WITHDRAW,
+  SOL_INSTR_VOTE_UPDATE_VALIDATOR,
+  SOL_INSTR_VOTE_UPDATE_COMMISSION,
+  SOL_INSTR_ATA_CREATE,
+  SOL_INSTR_COMPUTE_BUDGET_HEAP_FRAME,
+  SOL_INSTR_COMPUTE_BUDGET_UNIT_LIMIT,
+  SOL_INSTR_COMPUTE_BUDGET_UNIT_PRICE,
+  SOL_INSTR_COMPUTE_BUDGET_LOADED_ACCOUNTS_SIZE,
+  SOL_INSTR_MEMO,
+  SOL_INSTR_UNKNOWN,
+} SolanaInstrType;
+
+/* Parsed instruction */
+typedef struct {
+  SolanaInstrType type;
+  uint8_t program_id[SOL_PUBKEY_SIZE];
+  /* Decoded fields (filled based on type) */
+  uint8_t from[SOL_PUBKEY_SIZE];
+  uint8_t to[SOL_PUBKEY_SIZE];
+  uint8_t authority[SOL_PUBKEY_SIZE];
+  uint8_t extra[SOL_PUBKEY_SIZE];
+  uint64_t amount;
+  uint64_t lamports;
+  uint64_t extra_value;
+  /* For token transfers */
+  uint8_t mint[SOL_PUBKEY_SIZE];
+  bool has_mint;
+  uint8_t extra_u8;
+} SolanaParsedInstruction;
+
+/* Parsed transaction header */
+typedef struct {
+  uint8_t num_required_sigs;
+  uint8_t num_readonly_signed;
+  uint8_t num_readonly_unsigned;
+  uint8_t num_accounts;
+  uint8_t accounts[32][SOL_PUBKEY_SIZE]; /* max 32 account keys */
+  uint8_t recent_blockhash[SOL_PUBKEY_SIZE];
+  uint8_t num_instructions;
+  SolanaParsedInstruction instructions[8]; /* max 8 instructions */
+} SolanaParsedTx;
+
+/* Firmware review result for a Solana message */
+typedef enum {
+  SOL_TX_REVIEW_MALFORMED = 0,
+  SOL_TX_REVIEW_OPAQUE,
+  SOL_TX_REVIEW_VERIFIED,
+} SolanaTxReview;
+
+/* Inspect a raw Solana transaction and classify it for signing UX */
+SolanaTxReview solana_inspectTx(const uint8_t* raw, size_t raw_len,
+                                SolanaParsedTx* tx);
+
+/* Parse a raw Solana transaction */
+bool solana_parseTx(const uint8_t* raw, size_t raw_len, SolanaParsedTx* tx);
+
+/* Format SOL amount */
+void solana_formatAmount(char* buf, size_t len, uint64_t lamports);
+
+/* Format token amount with decimals */
+void solana_formatTokenAmount(char* buf, size_t len, uint64_t amount,
+                              const char* symbol, uint8_t decimals);
+
+/* Look up token info from the host-provided list */
+const SolanaTokenInfo* solana_findTokenInfo(
+    const SolanaSignTx* msg, const uint8_t mint[SOL_PUBKEY_SIZE]);
+
+/* Sign transaction */
+bool solana_signTx(const HDNode* node, const SolanaSignTx* msg,
+                   SolanaSignedTx* resp);
+
+#endif /* KEEPKEY_FIRMWARE_SOLANA_H */

--- a/include/keepkey/firmware/solana.h
+++ b/include/keepkey/firmware/solana.h
@@ -30,6 +30,65 @@
 #define SOL_DECIMALS 9
 #define SOL_PUBKEY_SIZE 32
 #define SOL_SIG_SIZE 64
+#define SOL_MAX_ACCOUNTS 32
+#define SOL_MAX_INSTRUCTIONS 8
+#define SOL_LAMPORTS_DIVISOR 1000000000ULL
+#define SOL_MAX_TOKEN_DECIMALS 18
+#define SOL_MAX_DISPLAY_DECIMALS 9
+
+/* Versioned transaction marker */
+#define SOL_VERSION_FLAG 0x80
+#define SOL_VERSION_MASK 0x7F
+
+/* Compact-u16 encoding constants */
+#define SOL_COMPACT_U16_CONTINUATION 0x80
+#define SOL_COMPACT_U16_DATA_MASK 0x7F
+#define SOL_COMPACT_U16_BYTE3_MAX 3
+
+/* System program instruction indices */
+#define SOL_SYS_CREATE_ACCOUNT 0
+#define SOL_SYS_ASSIGN 1
+#define SOL_SYS_TRANSFER 2
+#define SOL_SYS_ADVANCE_NONCE 4
+#define SOL_SYS_WITHDRAW_NONCE 5
+#define SOL_SYS_INITIALIZE_NONCE 6
+#define SOL_SYS_AUTHORIZE_NONCE 7
+#define SOL_SYS_ALLOCATE 8
+
+/* SPL Token program instruction indices */
+#define SOL_TOKEN_TRANSFER_IX 3
+#define SOL_TOKEN_APPROVE_IX 4
+#define SOL_TOKEN_REVOKE_IX 5
+#define SOL_TOKEN_SET_AUTHORITY_IX 6
+#define SOL_TOKEN_MINT_TO_IX 7
+#define SOL_TOKEN_BURN_IX 8
+#define SOL_TOKEN_CLOSE_ACCOUNT_IX 9
+#define SOL_TOKEN_FREEZE_ACCOUNT_IX 10
+#define SOL_TOKEN_THAW_ACCOUNT_IX 11
+#define SOL_TOKEN_TRANSFER_CHECKED_IX 12
+#define SOL_TOKEN_MINT_TO_CHECKED_IX 14
+#define SOL_TOKEN_BURN_CHECKED_IX 15
+#define SOL_TOKEN_SYNC_NATIVE_IX 17
+
+/* Stake program instruction indices */
+#define SOL_STAKE_AUTHORIZE_IX 1
+#define SOL_STAKE_DELEGATE_IX 2
+#define SOL_STAKE_SPLIT_IX 3
+#define SOL_STAKE_WITHDRAW_IX 4
+#define SOL_STAKE_DEACTIVATE_IX 5
+#define SOL_STAKE_MERGE_IX 7
+
+/* Vote program instruction indices */
+#define SOL_VOTE_AUTHORIZE_IX 1
+#define SOL_VOTE_WITHDRAW_IX 3
+#define SOL_VOTE_UPDATE_VALIDATOR_IX 4
+#define SOL_VOTE_UPDATE_COMMISSION_IX 5
+
+/* Compute Budget program instruction indices */
+#define SOL_CB_REQUEST_HEAP_FRAME 1
+#define SOL_CB_SET_COMPUTE_UNIT_LIMIT 2
+#define SOL_CB_SET_COMPUTE_UNIT_PRICE 3
+#define SOL_CB_SET_LOADED_ACCOUNTS_SIZE 4
 
 /* Well-known program IDs */
 extern const uint8_t SOL_SYSTEM_PROGRAM[SOL_PUBKEY_SIZE];
@@ -105,10 +164,10 @@ typedef struct {
   uint8_t num_readonly_signed;
   uint8_t num_readonly_unsigned;
   uint8_t num_accounts;
-  uint8_t accounts[32][SOL_PUBKEY_SIZE]; /* max 32 account keys */
+  uint8_t accounts[SOL_MAX_ACCOUNTS][SOL_PUBKEY_SIZE];
   uint8_t recent_blockhash[SOL_PUBKEY_SIZE];
   uint8_t num_instructions;
-  SolanaParsedInstruction instructions[8]; /* max 8 instructions */
+  SolanaParsedInstruction instructions[SOL_MAX_INSTRUCTIONS];
 } SolanaParsedTx;
 
 /* Firmware review result for a Solana message */

--- a/include/keepkey/transport/interface.h
+++ b/include/keepkey/transport/interface.h
@@ -37,6 +37,7 @@
 #include "messages-mayachain.pb.h"
 #include "messages-tron.pb.h"
 #include "messages-ton.pb.h"
+#include "messages-solana.pb.h"
 
 #include "types.pb.h"
 #include "trezor_transport.h"

--- a/lib/firmware/CMakeLists.txt
+++ b/lib/firmware/CMakeLists.txt
@@ -33,6 +33,7 @@ set(sources
     ripple_base58.c
     signing.c
     signtx_tendermint.c
+    solana.c
     storage.c
     tron.c
     ton.c

--- a/lib/firmware/fsm.c
+++ b/lib/firmware/fsm.c
@@ -55,6 +55,7 @@
 #include "keepkey/firmware/ripple.h"
 #include "keepkey/firmware/signing.h"
 #include "keepkey/firmware/signtx_tendermint.h"
+#include "keepkey/firmware/solana.h"
 #include "keepkey/firmware/storage.h"
 #include "keepkey/firmware/tendermint.h"
 #include "keepkey/firmware/thorchain.h"
@@ -88,6 +89,7 @@
 #include "messages-mayachain.pb.h"
 #include "messages-tron.pb.h"
 #include "messages-ton.pb.h"
+#include "messages-solana.pb.h"
 
 #include <stdio.h>
 
@@ -290,3 +292,4 @@ void fsm_msgClearSession(ClearSession* msg) {
 #include "fsm_msg_mayachain.h"
 #include "fsm_msg_tron.h"
 #include "fsm_msg_ton.h"
+#include "fsm_msg_solana.h"

--- a/lib/firmware/fsm_msg_solana.h
+++ b/lib/firmware/fsm_msg_solana.h
@@ -1,0 +1,548 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2025 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Helper: Raw base58 encode (no checksum) for Solana pubkeys/addresses.
+ * Uses b58enc() from trezor-crypto, which is the raw base58 encoder.
+ * Solana addresses are raw base58-encoded 32-byte Ed25519 public keys. */
+static bool solana_base58_encode(const uint8_t* data, size_t data_len,
+                                 char* out, size_t* out_len) {
+  return b58enc(out, out_len, data, data_len);
+}
+
+/* Helper: Base58-encode a 32-byte pubkey for display (full address).
+ * Solana base58 addresses are 32-44 chars; out must be >= 45 bytes.
+ * Never truncate — truncation is a spoofing vector. */
+static void solana_pubkeyToStr(const uint8_t key[SOL_PUBKEY_SIZE], char* out,
+                               size_t out_len) {
+  size_t enc_len = out_len;
+  if (solana_base58_encode(key, SOL_PUBKEY_SIZE, out, &enc_len)) {
+    /* b58enc null-terminates and sets enc_len including the NUL */
+    return;
+  }
+  /* Fallback to hex if base58 fails (middle-ellipsis OK for raw hex) */
+  snprintf(out, out_len, "%02x%02x...%02x%02x", key[0], key[1], key[30],
+           key[31]);
+}
+
+/* Confirm a single parsed instruction */
+static bool solana_confirmInstruction(const SolanaParsedInstruction* pi,
+                                      const SolanaSignTx* msg, uint8_t idx,
+                                      uint8_t total) {
+  char title[32];
+  snprintf(title, sizeof(title), "Instr %d/%d", idx + 1, total);
+
+  switch (pi->type) {
+    case SOL_INSTR_SYSTEM_TRANSFER: {
+      char amount_str[32];
+      solana_formatAmount(amount_str, sizeof(amount_str), pi->lamports);
+      char to_str[45];
+      solana_pubkeyToStr(pi->to, to_str, sizeof(to_str));
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Send %s to %s?", amount_str, to_str);
+    }
+
+    case SOL_INSTR_SYSTEM_CREATE_ACCOUNT: {
+      char amount_str[32];
+      solana_formatAmount(amount_str, sizeof(amount_str), pi->lamports);
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Create account with %s?", amount_str);
+    }
+
+    case SOL_INSTR_SYSTEM_ADVANCE_NONCE:
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Advance nonce account?");
+
+    case SOL_INSTR_SYSTEM_WITHDRAW_NONCE: {
+      char amount_str[32];
+      solana_formatAmount(amount_str, sizeof(amount_str), pi->lamports);
+      char to_str[45];
+      solana_pubkeyToStr(pi->to, to_str, sizeof(to_str));
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Withdraw nonce %s to %s?", amount_str, to_str);
+    }
+
+    case SOL_INSTR_SYSTEM_INITIALIZE_NONCE:
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Initialize nonce account?");
+
+    case SOL_INSTR_SYSTEM_AUTHORIZE_NONCE: {
+      char auth_str[45];
+      solana_pubkeyToStr(pi->extra, auth_str, sizeof(auth_str));
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Authorize nonce to %s?", auth_str);
+    }
+
+    case SOL_INSTR_SYSTEM_ASSIGN: {
+      char prog_str[45];
+      solana_pubkeyToStr(pi->extra, prog_str, sizeof(prog_str));
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Assign account to %s?", prog_str);
+    }
+
+    case SOL_INSTR_SYSTEM_ALLOCATE:
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Allocate %llu bytes?",
+                     (unsigned long long)pi->extra_value);
+
+    case SOL_INSTR_TOKEN_TRANSFER:
+    case SOL_INSTR_TOKEN_TRANSFER_CHECKED: {
+      char to_str[45];
+      solana_pubkeyToStr(pi->to, to_str, sizeof(to_str));
+
+      /* Try to find token info from host-provided metadata */
+      const SolanaTokenInfo* ti = NULL;
+      if (pi->has_mint) {
+        ti = solana_findTokenInfo(msg, pi->mint);
+      }
+
+      if (ti && ti->has_symbol && ti->has_decimals) {
+        char amount_str[48];
+        solana_formatTokenAmount(amount_str, sizeof(amount_str), pi->amount,
+                                 ti->symbol, (uint8_t)ti->decimals);
+        return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                       "Send %s to %s?", amount_str, to_str);
+      } else {
+        char amount_str[32];
+        snprintf(amount_str, sizeof(amount_str), "%llu tokens",
+                 (unsigned long long)pi->amount);
+        return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                       "Send %s to %s?", amount_str, to_str);
+      }
+    }
+
+    case SOL_INSTR_TOKEN_APPROVE: {
+      char to_str[45];
+      solana_pubkeyToStr(pi->to, to_str, sizeof(to_str));
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Approve %llu tokens to %s?",
+                     (unsigned long long)pi->amount, to_str);
+    }
+
+    case SOL_INSTR_TOKEN_REVOKE:
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Revoke token approval?");
+
+    case SOL_INSTR_TOKEN_SET_AUTHORITY: {
+      char auth_str[45];
+      solana_pubkeyToStr(pi->extra, auth_str, sizeof(auth_str));
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Set token authority to %s?", auth_str);
+    }
+
+    case SOL_INSTR_TOKEN_MINT_TO:
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Mint %llu tokens?", (unsigned long long)pi->amount);
+
+    case SOL_INSTR_TOKEN_BURN:
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Burn %llu tokens?", (unsigned long long)pi->amount);
+
+    case SOL_INSTR_TOKEN_CLOSE_ACCOUNT:
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Close token account?");
+
+    case SOL_INSTR_TOKEN_FREEZE_ACCOUNT:
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Freeze token account?");
+
+    case SOL_INSTR_TOKEN_THAW_ACCOUNT:
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Thaw token account?");
+
+    case SOL_INSTR_TOKEN_SYNC_NATIVE:
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Sync wrapped SOL?");
+
+    case SOL_INSTR_STAKE_DELEGATE: {
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Delegate stake?");
+    }
+
+    case SOL_INSTR_STAKE_WITHDRAW: {
+      char amount_str[32];
+      solana_formatAmount(amount_str, sizeof(amount_str), pi->lamports);
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Withdraw %s from stake?", amount_str);
+    }
+
+    case SOL_INSTR_STAKE_AUTHORIZE: {
+      char auth_str[45];
+      solana_pubkeyToStr(pi->extra, auth_str, sizeof(auth_str));
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Authorize stake to %s?", auth_str);
+    }
+
+    case SOL_INSTR_STAKE_SPLIT: {
+      char amount_str[32];
+      solana_formatAmount(amount_str, sizeof(amount_str), pi->lamports);
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Split stake by %s?", amount_str);
+    }
+
+    case SOL_INSTR_STAKE_DEACTIVATE:
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Deactivate stake?");
+
+    case SOL_INSTR_STAKE_MERGE:
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Merge stake accounts?");
+
+    case SOL_INSTR_VOTE_AUTHORIZE: {
+      char auth_str[45];
+      solana_pubkeyToStr(pi->extra, auth_str, sizeof(auth_str));
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Authorize vote to %s?", auth_str);
+    }
+
+    case SOL_INSTR_VOTE_WITHDRAW: {
+      char amount_str[32];
+      solana_formatAmount(amount_str, sizeof(amount_str), pi->lamports);
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Withdraw vote %s?", amount_str);
+    }
+
+    case SOL_INSTR_VOTE_UPDATE_VALIDATOR: {
+      char validator_str[45];
+      solana_pubkeyToStr(pi->extra, validator_str, sizeof(validator_str));
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Update validator to %s?", validator_str);
+    }
+
+    case SOL_INSTR_VOTE_UPDATE_COMMISSION:
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Set vote commission to %u%%?", pi->extra_u8);
+
+    case SOL_INSTR_ATA_CREATE:
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Create associated token account?");
+
+    case SOL_INSTR_COMPUTE_BUDGET_HEAP_FRAME:
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Set heap frame to %llu bytes?",
+                     (unsigned long long)pi->extra_value);
+
+    case SOL_INSTR_COMPUTE_BUDGET_UNIT_LIMIT:
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Set compute unit limit to %llu?",
+                     (unsigned long long)pi->extra_value);
+
+    case SOL_INSTR_COMPUTE_BUDGET_UNIT_PRICE:
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Set compute unit price to %llu?",
+                     (unsigned long long)pi->extra_value);
+
+    case SOL_INSTR_COMPUTE_BUDGET_LOADED_ACCOUNTS_SIZE:
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Set loaded account data to %llu bytes?",
+                     (unsigned long long)pi->extra_value);
+
+    case SOL_INSTR_MEMO:
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                     "Memo attached");
+
+    case SOL_INSTR_UNKNOWN:
+    default: {
+      char prog_str[45];
+      solana_pubkeyToStr(pi->program_id, prog_str, sizeof(prog_str));
+      return confirm(ButtonRequestType_ButtonRequest_SignTx, title,
+                     "Unknown instruction to program %s. "
+                     "Cannot verify contents.",
+                     prog_str);
+    }
+  }
+}
+
+/* Validate Solana derivation path: m/44'/501'/account'[/change'] */
+static bool solana_pathIsStandard(const uint32_t* path, size_t count) {
+  if (count < 3 || count > 4) return false;
+  if (path[0] != (0x80000000 | 44)) return false;  /* 44' */
+  if (path[1] != (0x80000000 | 501)) return false; /* 501' */
+  for (size_t i = 2; i < count; i++) {
+    if (!(path[i] & 0x80000000)) return false; /* must be hardened */
+  }
+  return true;
+}
+
+/* Verify derived pubkey appears in tx accounts[0..num_required_sigs) */
+static bool solana_signerInTx(const uint8_t* pubkey, const SolanaParsedTx* tx) {
+  for (uint8_t i = 0; i < tx->num_required_sigs && i < tx->num_accounts; i++) {
+    if (memcmp(pubkey, tx->accounts[i], SOL_PUBKEY_SIZE) == 0) return true;
+  }
+  return false;
+}
+
+void fsm_msgSolanaGetAddress(const SolanaGetAddress* msg) {
+  RESP_INIT(SolanaAddress);
+
+  CHECK_INITIALIZED
+  CHECK_PIN
+
+  /* Path validation: warn on non-standard derivation */
+  if (!solana_pathIsStandard(msg->address_n, msg->address_n_count)) {
+    if (!confirm(ButtonRequestType_ButtonRequest_Other, "WARNING",
+                 "Non-standard Solana derivation path. Continue?")) {
+      fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+      layoutHome();
+      return;
+    }
+  }
+
+  HDNode* node = fsm_getDerivedNode(ED25519_NAME, msg->address_n,
+                                    msg->address_n_count, NULL);
+  if (!node) return;
+  hdnode_fill_public_key(node);
+
+  /* Solana address = raw Base58 of the 32-byte Ed25519 public key.
+   * node->public_key is 33 bytes (0x00 prefix + 32 bytes for Ed25519).
+   * Use b58enc() for raw base58 encoding (no checksum). */
+  char address[45];
+  size_t addr_len = sizeof(address);
+  if (solana_base58_encode(node->public_key + 1, SOL_PUBKEY_SIZE, address,
+                           &addr_len)) {
+    resp->has_address = true;
+    strncpy(resp->address, address, sizeof(resp->address) - 1);
+  } else {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_Other, _("Address encoding failed"));
+    layoutHome();
+    return;
+  }
+
+  if (msg->has_show_display && msg->show_display) {
+    if (!confirm_ethereum_address("Solana", resp->address)) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      _("Show address cancelled"));
+      layoutHome();
+      return;
+    }
+  }
+
+  memzero(node, sizeof(*node));
+  msg_write(MessageType_MessageType_SolanaAddress, resp);
+  layoutHome();
+}
+
+void fsm_msgSolanaSignTx(const SolanaSignTx* msg) {
+  RESP_INIT(SolanaSignedTx);
+
+  CHECK_INITIALIZED
+  CHECK_PIN
+
+  if (!msg->has_raw_tx || msg->raw_tx.size == 0) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError, _("Missing raw_tx"));
+    layoutHome();
+    return;
+  }
+
+  /* Path validation: warn on non-standard derivation */
+  if (!solana_pathIsStandard(msg->address_n, msg->address_n_count)) {
+    if (!confirm(ButtonRequestType_ButtonRequest_Other, "WARNING",
+                 "Non-standard Solana derivation path. Continue?")) {
+      fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+      layoutHome();
+      return;
+    }
+  }
+
+  HDNode* node = fsm_getDerivedNode(ED25519_NAME, msg->address_n,
+                                    msg->address_n_count, NULL);
+  if (!node) return;
+  hdnode_fill_public_key(node);
+
+  /* Classify transaction for verified vs opaque signing UX */
+  SolanaParsedTx parsed;
+  SolanaTxReview tx_review =
+      solana_inspectTx(msg->raw_tx.bytes, msg->raw_tx.size, &parsed);
+
+  /* Signer verification: derived key must be a required signer.
+   * For verified txs this is mandatory. For opaque txs we still check
+   * when we were able to parse the header (num_accounts > 0). */
+  if (tx_review == SOL_TX_REVIEW_VERIFIED ||
+      (tx_review == SOL_TX_REVIEW_OPAQUE && parsed.num_accounts > 0)) {
+    if (!solana_signerInTx(node->public_key + 1, &parsed)) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_Other,
+                      _("Derived key is not a signer for this tx"));
+      layoutHome();
+      return;
+    }
+  }
+
+  if (tx_review == SOL_TX_REVIEW_VERIFIED) {
+    /* Per-instruction confirmation for fully verified messages */
+    for (uint8_t i = 0; i < parsed.num_instructions; i++) {
+      if (!solana_confirmInstruction(&parsed.instructions[i], msg, i,
+                                     parsed.num_instructions)) {
+        memzero(node, sizeof(*node));
+        fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                        _("Signing cancelled"));
+        layoutHome();
+        return;
+      }
+    }
+  } else if (tx_review == SOL_TX_REVIEW_OPAQUE) {
+    /* Unsupported or opaque message: allow explicit blind-sign only. */
+    if (!storage_isPolicyEnabled("AdvancedMode")) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_Other,
+                      _("Enable AdvancedMode to blind-sign"));
+      layoutHome();
+      return;
+    }
+
+    if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Blind Sign",
+                 "Sign unverified Solana transaction? "
+                 "The device cannot fully verify the contents.")) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      _("Signing cancelled"));
+      layoutHome();
+      return;
+    }
+  } else {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Malformed Solana transaction"));
+    layoutHome();
+    return;
+  }
+
+  /* Final confirmation */
+  if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Solana",
+               "Sign this Solana transaction?")) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                    _("Signing cancelled"));
+    layoutHome();
+    return;
+  }
+
+  if (!solana_signTx(node, msg, resp)) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_Other, _("Signing failed"));
+    layoutHome();
+    return;
+  }
+
+  memzero(node, sizeof(*node));
+  msg_write(MessageType_MessageType_SolanaSignedTx, resp);
+  layoutHome();
+}
+
+void fsm_msgSolanaSignMessage(const SolanaSignMessage* msg) {
+  RESP_INIT(SolanaMessageSignature);
+
+  CHECK_INITIALIZED
+  CHECK_PIN
+
+  if (!msg->has_message || msg->message.size == 0) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError, _("Missing message"));
+    layoutHome();
+    return;
+  }
+
+  /* AdvancedMode gate: Solana message signing has no domain separation.
+   * A signed message is indistinguishable from a signed transaction on
+   * the Solana network (both are raw Ed25519 over arbitrary bytes).
+   * A malicious dApp could craft a message that is also a valid tx.
+   * See: https://github.com/trezor/trezor-firmware/issues/4371
+   * Require AdvancedMode to proceed — same gate as ETH blind-signing. */
+  if (!storage_isPolicyEnabled("AdvancedMode")) {
+    (void)review(ButtonRequestType_ButtonRequest_Other, "Blocked",
+                 "Solana message signing is experimental. "
+                 "Enable AdvancedMode in device settings.");
+    fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                    _("Message signing disabled by policy"));
+    layoutHome();
+    return;
+  }
+
+  /* Path validation: warn on non-standard derivation */
+  if (!solana_pathIsStandard(msg->address_n, msg->address_n_count)) {
+    if (!confirm(ButtonRequestType_ButtonRequest_Other, "WARNING",
+                 "Non-standard Solana derivation path. Continue?")) {
+      fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+      layoutHome();
+      return;
+    }
+  }
+
+  HDNode* node = fsm_getDerivedNode(ED25519_NAME, msg->address_n,
+                                    msg->address_n_count, NULL);
+  if (!node) return;
+  hdnode_fill_public_key(node);
+
+  /* Always require on-device confirmation (matches Ethereum behavior).
+   * Display message content if printable, hex preview otherwise. */
+  {
+    char msgBuf[129] = {0};
+    const char* typeLabel;
+    bool printable = true;
+    for (unsigned i = 0; i < msg->message.size; i++) {
+      if (msg->message.bytes[i] < 0x20 || msg->message.bytes[i] > 0x7e) {
+        printable = false;
+        break;
+      }
+    }
+    if (printable && msg->message.size <= sizeof(msgBuf) - 1) {
+      typeLabel = "Sign Message";
+      memcpy(msgBuf, msg->message.bytes, msg->message.size);
+      msgBuf[msg->message.size] = '\0';
+    } else {
+      typeLabel = "Sign Bytes";
+      /* Show hex preview (up to 64 hex chars = 32 bytes) */
+      unsigned show = msg->message.size;
+      if (show > 32) show = 32;
+      for (unsigned i = 0; i < show; i++) {
+        snprintf(&msgBuf[2 * i], 3, "%02x", msg->message.bytes[i]);
+      }
+      msgBuf[2 * show] = '\0';
+      if (msg->message.size > 32) {
+        snprintf(&msgBuf[64], sizeof(msgBuf) - 64, "... (%u bytes)",
+                 (unsigned)msg->message.size);
+      }
+    }
+    if (!confirm(ButtonRequestType_ButtonRequest_ProtectCall, _(typeLabel),
+                 "%s", msgBuf)) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      _("Signing cancelled"));
+      layoutHome();
+      return;
+    }
+  }
+
+  /* Ed25519 sign */
+  uint8_t sig[SOL_SIG_SIZE];
+  ed25519_sign(msg->message.bytes, msg->message.size, node->private_key,
+               node->public_key + 1, sig);
+
+  resp->has_signature = true;
+  resp->signature.size = SOL_SIG_SIZE;
+  memcpy(resp->signature.bytes, sig, SOL_SIG_SIZE);
+
+  resp->has_public_key = true;
+  resp->public_key.size = SOL_PUBKEY_SIZE;
+  memcpy(resp->public_key.bytes, node->public_key + 1, SOL_PUBKEY_SIZE);
+
+  memzero(node, sizeof(*node));
+  msg_write(MessageType_MessageType_SolanaMessageSignature, resp);
+  layoutHome();
+}

--- a/lib/firmware/messagemap.def
+++ b/lib/firmware/messagemap.def
@@ -146,6 +146,15 @@
     MSG_OUT(MessageType_MessageType_TonAddress,                    TonAddress,                  NO_PROCESS_FUNC)
     MSG_OUT(MessageType_MessageType_TonSignedTx,                   TonSignedTx,                 NO_PROCESS_FUNC)
 
+    /* Solana */
+    MSG_IN(MessageType_MessageType_SolanaGetAddress,               SolanaGetAddress,            fsm_msgSolanaGetAddress)
+    MSG_IN(MessageType_MessageType_SolanaSignTx,                   SolanaSignTx,                fsm_msgSolanaSignTx)
+    MSG_IN(MessageType_MessageType_SolanaSignMessage,              SolanaSignMessage,           fsm_msgSolanaSignMessage)
+
+    MSG_OUT(MessageType_MessageType_SolanaAddress,                 SolanaAddress,               NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_SolanaSignedTx,                SolanaSignedTx,              NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_SolanaMessageSignature,        SolanaMessageSignature,      NO_PROCESS_FUNC)
+
 #if DEBUG_LINK
     /* Debug Messages */
     DEBUG_IN(MessageType_MessageType_DebugLinkDecision,             DebugLinkDecision,           NO_PROCESS_FUNC)

--- a/lib/firmware/solana.c
+++ b/lib/firmware/solana.c
@@ -1,0 +1,660 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2025 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "keepkey/firmware/solana.h"
+
+#include "trezor/crypto/memzero.h"
+
+#include <stdio.h>
+#include <string.h>
+
+/* ------------------------------------------------------------------ */
+/*  Well-known program IDs                                             */
+/* ------------------------------------------------------------------ */
+
+/* 11111111111111111111111111111111 */
+const uint8_t SOL_SYSTEM_PROGRAM[SOL_PUBKEY_SIZE] = {0};
+
+/* TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA */
+const uint8_t SOL_TOKEN_PROGRAM[SOL_PUBKEY_SIZE] = {
+    0x06, 0xdd, 0xf6, 0xe1, 0xd7, 0x65, 0xa1, 0x93, 0xd9, 0xcb, 0xe1,
+    0x46, 0xce, 0xeb, 0x79, 0xac, 0x1c, 0xb4, 0x85, 0xed, 0x5f, 0x5b,
+    0x37, 0x91, 0x3a, 0x8c, 0xf5, 0x85, 0x7e, 0xff, 0x00, 0xa9};
+
+/* TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb */
+const uint8_t SOL_TOKEN_2022_PROGRAM[SOL_PUBKEY_SIZE] = {
+    0x06, 0xdd, 0xf6, 0xe1, 0xee, 0x75, 0x8f, 0xde, 0x18, 0x42, 0x5d,
+    0xbc, 0xe4, 0x6c, 0xcd, 0xda, 0xb6, 0x1a, 0xfc, 0x4d, 0x83, 0xb9,
+    0x0d, 0x27, 0xfe, 0xbd, 0xf9, 0x28, 0xd8, 0xa1, 0x8b, 0xfc};
+
+/* Stake11111111111111111111111111111111111111 */
+const uint8_t SOL_STAKE_PROGRAM[SOL_PUBKEY_SIZE] = {
+    0x06, 0xa1, 0xd8, 0x17, 0x91, 0x37, 0x54, 0x2a, 0x98, 0x34, 0x37,
+    0xbd, 0xfe, 0x2a, 0x7a, 0xb2, 0x55, 0x7f, 0x53, 0x5c, 0x8a, 0x78,
+    0x72, 0x2b, 0x68, 0xa4, 0x9d, 0xc0, 0x00, 0x00, 0x00, 0x00};
+
+/* Vote111111111111111111111111111111111111111 */
+const uint8_t SOL_VOTE_PROGRAM[SOL_PUBKEY_SIZE] = {
+    0x07, 0x61, 0x48, 0x1d, 0x35, 0x74, 0x74, 0xbb, 0x7c, 0x4d, 0x76,
+    0x24, 0xeb, 0xd3, 0xbd, 0xb3, 0xd8, 0x35, 0x5e, 0x73, 0xd1, 0x10,
+    0x43, 0xfc, 0x0d, 0xa3, 0x53, 0x80, 0x00, 0x00, 0x00, 0x00};
+
+/* ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL */
+const uint8_t SOL_ATA_PROGRAM[SOL_PUBKEY_SIZE] = {
+    0x8c, 0x97, 0x25, 0x8f, 0x4e, 0x24, 0x89, 0xf1, 0xbb, 0x3d, 0x10,
+    0x29, 0x14, 0x8e, 0x0d, 0x83, 0x0b, 0x5a, 0x13, 0x99, 0xda, 0xff,
+    0x10, 0x84, 0x04, 0x8e, 0x7b, 0xd8, 0xdb, 0xe9, 0xf8, 0x59};
+
+/* ComputeBudget111111111111111111111111111111 */
+const uint8_t SOL_COMPUTE_BUDGET_PROGRAM[SOL_PUBKEY_SIZE] = {
+    0x03, 0x06, 0x46, 0x6f, 0xe5, 0x21, 0x17, 0x32, 0xff, 0xec, 0xad,
+    0xba, 0x72, 0xc3, 0x9b, 0xe7, 0xbc, 0x8c, 0xe5, 0xbb, 0xc5, 0xf7,
+    0x12, 0x6b, 0x2c, 0x43, 0x9b, 0x3a, 0x40, 0x00, 0x00, 0x00};
+
+/* MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr */
+const uint8_t SOL_MEMO_PROGRAM[SOL_PUBKEY_SIZE] = {
+    0x05, 0x4a, 0x53, 0x5a, 0x99, 0x29, 0x21, 0x06, 0x4d, 0x24, 0xe8,
+    0x71, 0x60, 0xda, 0x38, 0x7c, 0x7c, 0x35, 0xb5, 0xdd, 0xbc, 0x92,
+    0xbb, 0x81, 0xe4, 0x1f, 0xa8, 0x40, 0x41, 0x05, 0x44, 0x8d};
+
+/* ------------------------------------------------------------------ */
+/*  Compact-u16 decoder (Solana transaction format)                    */
+/* ------------------------------------------------------------------ */
+
+static int read_compact_u16(const uint8_t* data, size_t len, uint16_t* out) {
+  if (len < 1) return -1;
+
+  if (data[0] < 0x80) {
+    *out = data[0];
+    return 1;
+  }
+
+  if (len < 2) return -1;
+  if (data[1] < 0x80) {
+    *out = (uint16_t)((data[0] & 0x7F) | ((uint16_t)data[1] << 7));
+    return 2;
+  }
+
+  if (len < 3) return -1;
+  /* Third byte uses bits 14-15, so only values 0-3 are valid
+   * (max compact-u16 value is 0xFFFF = 65535). */
+  if (data[2] > 3) return -1;
+  *out = (uint16_t)((data[0] & 0x7F) | ((data[1] & 0x7F) << 7) |
+                    ((uint16_t)data[2] << 14));
+  return 3;
+}
+
+static uint64_t read_le64(const uint8_t* p) {
+  return (uint64_t)p[0] | ((uint64_t)p[1] << 8) | ((uint64_t)p[2] << 16) |
+         ((uint64_t)p[3] << 24) | ((uint64_t)p[4] << 32) |
+         ((uint64_t)p[5] << 40) | ((uint64_t)p[6] << 48) |
+         ((uint64_t)p[7] << 56);
+}
+
+static uint32_t read_le32(const uint8_t* p) {
+  return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) |
+         ((uint32_t)p[3] << 24);
+}
+
+static void copy_account(uint8_t out[SOL_PUBKEY_SIZE], const SolanaParsedTx* tx,
+                         const uint8_t* acct_indices, uint16_t num_acct_indices,
+                         uint16_t idx) {
+  if (idx < num_acct_indices) {
+    memcpy(out, tx->accounts[acct_indices[idx]], SOL_PUBKEY_SIZE);
+  }
+}
+
+static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
+                                     size_t* pos_io, SolanaParsedTx* tx,
+                                     uint16_t num_accounts, bool* has_unknown,
+                                     bool* force_opaque) {
+  size_t pos = *pos_io;
+  uint16_t num_instructions;
+  int n = read_compact_u16(raw + pos, raw_len - pos, &num_instructions);
+  if (n < 0) return -1;
+  pos += n;
+
+  if (num_instructions > 8) {
+    *force_opaque = true;
+    tx->num_instructions = 0;
+    /* Don't attempt to parse instruction data — treat as opaque. */
+    *pos_io = raw_len;
+    return 0;
+  } else {
+    tx->num_instructions = (uint8_t)num_instructions;
+  }
+
+  for (uint16_t i = 0; i < num_instructions; i++) {
+    if (pos >= raw_len) return -1;
+    uint8_t program_idx = raw[pos++];
+    if (program_idx >= num_accounts) return -1;
+
+    uint16_t num_acct_indices;
+    n = read_compact_u16(raw + pos, raw_len - pos, &num_acct_indices);
+    if (n < 0) return -1;
+    pos += n;
+
+    if (pos + num_acct_indices > raw_len) return -1;
+    const uint8_t* acct_indices = raw + pos;
+    pos += num_acct_indices;
+
+    for (uint16_t j = 0; j < num_acct_indices; j++) {
+      if (acct_indices[j] >= num_accounts) return -1;
+    }
+
+    uint16_t data_len;
+    n = read_compact_u16(raw + pos, raw_len - pos, &data_len);
+    if (n < 0) return -1;
+    pos += n;
+
+    if (pos + data_len > raw_len) return -1;
+    const uint8_t* instr_data = raw + pos;
+    pos += data_len;
+
+    if (i >= 8) {
+      continue;
+    }
+
+    SolanaParsedInstruction* pi = &tx->instructions[i];
+    memcpy(pi->program_id, tx->accounts[program_idx], SOL_PUBKEY_SIZE);
+
+    /* Classify and decode */
+    if (memcmp(pi->program_id, SOL_SYSTEM_PROGRAM, SOL_PUBKEY_SIZE) == 0) {
+      /* System program */
+      if (data_len >= 4) {
+        uint32_t instr_type = read_le32(instr_data);
+        if (instr_type == 2 && data_len >= 12) {
+          pi->type = SOL_INSTR_SYSTEM_TRANSFER;
+          pi->lamports = read_le64(instr_data + 4);
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
+        } else if (instr_type == 0 && data_len >= 12) {
+          pi->type = SOL_INSTR_SYSTEM_CREATE_ACCOUNT;
+          pi->lamports = read_le64(instr_data + 4);
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
+        } else if (instr_type == 4) {
+          pi->type = SOL_INSTR_SYSTEM_ADVANCE_NONCE;
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
+        } else if (instr_type == 5 && data_len >= 12) {
+          pi->type = SOL_INSTR_SYSTEM_WITHDRAW_NONCE;
+          pi->lamports = read_le64(instr_data + 4);
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 4);
+        } else if (instr_type == 6 && data_len >= 36) {
+          pi->type = SOL_INSTR_SYSTEM_INITIALIZE_NONCE;
+          memcpy(pi->authority, instr_data + 4, SOL_PUBKEY_SIZE);
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+        } else if (instr_type == 7 && data_len >= 36) {
+          pi->type = SOL_INSTR_SYSTEM_AUTHORIZE_NONCE;
+          memcpy(pi->extra, instr_data + 4, SOL_PUBKEY_SIZE);
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 1);
+        } else if (instr_type == 1 && data_len >= 36) {
+          pi->type = SOL_INSTR_SYSTEM_ASSIGN;
+          memcpy(pi->extra, instr_data + 4, SOL_PUBKEY_SIZE);
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+        } else if (instr_type == 8 && data_len >= 12) {
+          pi->type = SOL_INSTR_SYSTEM_ALLOCATE;
+          pi->extra_value = read_le64(instr_data + 4);
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+        } else {
+          pi->type = SOL_INSTR_UNKNOWN;
+          *has_unknown = true;
+        }
+      } else {
+        pi->type = SOL_INSTR_UNKNOWN;
+        *has_unknown = true;
+      }
+    } else if (memcmp(pi->program_id, SOL_TOKEN_PROGRAM, SOL_PUBKEY_SIZE) ==
+                   0 ||
+               memcmp(pi->program_id, SOL_TOKEN_2022_PROGRAM,
+                      SOL_PUBKEY_SIZE) == 0) {
+      if (data_len >= 1) {
+        uint8_t token_instr = instr_data[0];
+        if (token_instr == 3 && data_len >= 9) {
+          pi->type = SOL_INSTR_TOKEN_TRANSFER;
+          pi->amount = read_le64(instr_data + 1);
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
+        } else if (token_instr == 12 && data_len >= 9) {
+          pi->type = SOL_INSTR_TOKEN_TRANSFER_CHECKED;
+          pi->amount = read_le64(instr_data + 1);
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->mint, tx, acct_indices, num_acct_indices, 1);
+          pi->has_mint = (num_acct_indices >= 2);
+          copy_account(pi->to, tx, acct_indices, num_acct_indices, 2);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 3);
+          pi->extra_u8 = data_len >= 10 ? instr_data[9] : 0;
+        } else if (token_instr == 4 && data_len >= 9) {
+          pi->type = SOL_INSTR_TOKEN_APPROVE;
+          pi->amount = read_le64(instr_data + 1);
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
+        } else if (token_instr == 5) {
+          pi->type = SOL_INSTR_TOKEN_REVOKE;
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 1);
+        } else if (token_instr == 6 && data_len >= 2) {
+          pi->type = SOL_INSTR_TOKEN_SET_AUTHORITY;
+          pi->extra_u8 = instr_data[1];
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 1);
+          if (data_len >= 35 && instr_data[2] == 1) {
+            memcpy(pi->extra, instr_data + 3, SOL_PUBKEY_SIZE);
+          }
+        } else if ((token_instr == 7 || token_instr == 14) && data_len >= 9) {
+          pi->type = SOL_INSTR_TOKEN_MINT_TO;
+          pi->amount = read_le64(instr_data + 1);
+          copy_account(pi->mint, tx, acct_indices, num_acct_indices, 0);
+          pi->has_mint = (num_acct_indices >= 1);
+          copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
+          pi->extra_u8 =
+              (token_instr == 14 && data_len >= 10) ? instr_data[9] : 0;
+        } else if ((token_instr == 8 || token_instr == 15) && data_len >= 9) {
+          pi->type = SOL_INSTR_TOKEN_BURN;
+          pi->amount = read_le64(instr_data + 1);
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->mint, tx, acct_indices, num_acct_indices, 1);
+          pi->has_mint = (num_acct_indices >= 2);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
+          pi->extra_u8 =
+              (token_instr == 15 && data_len >= 10) ? instr_data[9] : 0;
+        } else if (token_instr == 9) {
+          pi->type = SOL_INSTR_TOKEN_CLOSE_ACCOUNT;
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
+        } else if (token_instr == 10) {
+          pi->type = SOL_INSTR_TOKEN_FREEZE_ACCOUNT;
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->mint, tx, acct_indices, num_acct_indices, 1);
+          pi->has_mint = (num_acct_indices >= 2);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
+        } else if (token_instr == 11) {
+          pi->type = SOL_INSTR_TOKEN_THAW_ACCOUNT;
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->mint, tx, acct_indices, num_acct_indices, 1);
+          pi->has_mint = (num_acct_indices >= 2);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
+        } else if (token_instr == 17) {
+          pi->type = SOL_INSTR_TOKEN_SYNC_NATIVE;
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+        } else {
+          pi->type = SOL_INSTR_UNKNOWN;
+          *has_unknown = true;
+        }
+      } else {
+        pi->type = SOL_INSTR_UNKNOWN;
+        *has_unknown = true;
+      }
+    } else if (memcmp(pi->program_id, SOL_STAKE_PROGRAM, SOL_PUBKEY_SIZE) ==
+               0) {
+      if (data_len >= 4) {
+        uint32_t stake_instr = read_le32(instr_data);
+        if (stake_instr == 2) {
+          pi->type = SOL_INSTR_STAKE_DELEGATE;
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 5);
+          copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
+        } else if (stake_instr == 4 && data_len >= 12) {
+          pi->type = SOL_INSTR_STAKE_WITHDRAW;
+          pi->lamports = read_le64(instr_data + 4);
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 4);
+        } else if (stake_instr == 1 && data_len >= 36) {
+          pi->type = SOL_INSTR_STAKE_AUTHORIZE;
+          memcpy(pi->extra, instr_data + 4, SOL_PUBKEY_SIZE);
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 1);
+          pi->extra_u8 = (uint8_t)read_le32(instr_data + 36);
+        } else if (stake_instr == 3 && data_len >= 12) {
+          pi->type = SOL_INSTR_STAKE_SPLIT;
+          pi->lamports = read_le64(instr_data + 4);
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
+        } else if (stake_instr == 5) {
+          pi->type = SOL_INSTR_STAKE_DEACTIVATE;
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
+        } else if (stake_instr == 7) {
+          pi->type = SOL_INSTR_STAKE_MERGE;
+          copy_account(pi->to, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 1);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 4);
+        } else {
+          pi->type = SOL_INSTR_UNKNOWN;
+          *has_unknown = true;
+        }
+      } else {
+        pi->type = SOL_INSTR_UNKNOWN;
+        *has_unknown = true;
+      }
+    } else if (memcmp(pi->program_id, SOL_VOTE_PROGRAM, SOL_PUBKEY_SIZE) == 0) {
+      if (data_len >= 4) {
+        uint32_t vote_instr = read_le32(instr_data);
+        if (vote_instr == 1 && data_len >= 40) {
+          pi->type = SOL_INSTR_VOTE_AUTHORIZE;
+          memcpy(pi->extra, instr_data + 4, SOL_PUBKEY_SIZE);
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 1);
+          pi->extra_u8 = (uint8_t)read_le32(instr_data + 36);
+        } else if (vote_instr == 3 && data_len >= 12) {
+          pi->type = SOL_INSTR_VOTE_WITHDRAW;
+          pi->lamports = read_le64(instr_data + 4);
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
+        } else if (vote_instr == 4 && data_len >= 36) {
+          pi->type = SOL_INSTR_VOTE_UPDATE_VALIDATOR;
+          memcpy(pi->extra, instr_data + 4, SOL_PUBKEY_SIZE);
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 1);
+        } else if (vote_instr == 5 && data_len >= 5) {
+          pi->type = SOL_INSTR_VOTE_UPDATE_COMMISSION;
+          pi->extra_u8 = instr_data[4];
+          copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+          copy_account(pi->authority, tx, acct_indices, num_acct_indices, 1);
+        } else {
+          pi->type = SOL_INSTR_UNKNOWN;
+          *has_unknown = true;
+        }
+      } else {
+        pi->type = SOL_INSTR_UNKNOWN;
+        *has_unknown = true;
+      }
+    } else if (memcmp(pi->program_id, SOL_ATA_PROGRAM, SOL_PUBKEY_SIZE) == 0) {
+      if (data_len == 0 || (data_len == 1 && instr_data[0] == 0)) {
+        pi->type = SOL_INSTR_ATA_CREATE;
+        copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
+        copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
+        copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
+        copy_account(pi->mint, tx, acct_indices, num_acct_indices, 3);
+        pi->has_mint = (num_acct_indices >= 4);
+      } else {
+        pi->type = SOL_INSTR_UNKNOWN;
+        *has_unknown = true;
+      }
+    } else if (memcmp(pi->program_id, SOL_COMPUTE_BUDGET_PROGRAM,
+                      SOL_PUBKEY_SIZE) == 0) {
+      if (data_len >= 1) {
+        uint8_t cb_instr = instr_data[0];
+        if (cb_instr == 1 && data_len >= 5) {
+          pi->type = SOL_INSTR_COMPUTE_BUDGET_HEAP_FRAME;
+          pi->extra_value = read_le32(instr_data + 1);
+        } else if (cb_instr == 2 && data_len >= 5) {
+          pi->type = SOL_INSTR_COMPUTE_BUDGET_UNIT_LIMIT;
+          pi->extra_value = read_le32(instr_data + 1);
+        } else if (cb_instr == 3 && data_len >= 9) {
+          pi->type = SOL_INSTR_COMPUTE_BUDGET_UNIT_PRICE;
+          pi->extra_value = read_le64(instr_data + 1);
+        } else if (cb_instr == 4 && data_len >= 5) {
+          pi->type = SOL_INSTR_COMPUTE_BUDGET_LOADED_ACCOUNTS_SIZE;
+          pi->extra_value = read_le32(instr_data + 1);
+        } else {
+          pi->type = SOL_INSTR_UNKNOWN;
+          *has_unknown = true;
+        }
+      } else {
+        pi->type = SOL_INSTR_UNKNOWN;
+        *has_unknown = true;
+      }
+    } else if (memcmp(pi->program_id, SOL_MEMO_PROGRAM, SOL_PUBKEY_SIZE) == 0) {
+      pi->type = SOL_INSTR_MEMO;
+    } else {
+      pi->type = SOL_INSTR_UNKNOWN;
+      *has_unknown = true;
+    }
+  }
+
+  *pos_io = pos;
+  return num_instructions;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Transaction parser                                                 */
+/* ------------------------------------------------------------------ */
+
+static SolanaTxReview solana_parseLegacyTx(const uint8_t* raw, size_t raw_len,
+                                           SolanaParsedTx* tx) {
+  memset(tx, 0, sizeof(*tx));
+  size_t pos = 0;
+  bool has_unknown = false;
+  bool force_opaque = false;
+
+  /* Header: num_required_sigs, num_readonly_signed, num_readonly_unsigned */
+  if (raw_len < 3) return SOL_TX_REVIEW_MALFORMED;
+  tx->num_required_sigs = raw[pos++];
+  tx->num_readonly_signed = raw[pos++];
+  tx->num_readonly_unsigned = raw[pos++];
+
+  /* Account keys count (compact-u16) */
+  uint16_t num_accounts;
+  int n = read_compact_u16(raw + pos, raw_len - pos, &num_accounts);
+  if (n < 0) return SOL_TX_REVIEW_MALFORMED;
+  pos += n;
+
+  if (num_accounts > 32) return SOL_TX_REVIEW_OPAQUE;
+  tx->num_accounts = (uint8_t)num_accounts;
+
+  /* Read account keys */
+  for (uint16_t i = 0; i < num_accounts; i++) {
+    if (pos + SOL_PUBKEY_SIZE > raw_len) return SOL_TX_REVIEW_MALFORMED;
+    memcpy(tx->accounts[i], raw + pos, SOL_PUBKEY_SIZE);
+    pos += SOL_PUBKEY_SIZE;
+  }
+
+  /* Recent blockhash */
+  if (pos + SOL_PUBKEY_SIZE > raw_len) return SOL_TX_REVIEW_MALFORMED;
+  memcpy(tx->recent_blockhash, raw + pos, SOL_PUBKEY_SIZE);
+  pos += SOL_PUBKEY_SIZE;
+
+  n = parse_instruction_section(raw, raw_len, &pos, tx, num_accounts,
+                                &has_unknown, &force_opaque);
+  if (n < 0) return SOL_TX_REVIEW_MALFORMED;
+
+  /* Reject if there are unconsumed bytes — prevents hidden trailing data */
+  if (pos != raw_len) return SOL_TX_REVIEW_MALFORMED;
+
+  if (tx->num_instructions == 0 || has_unknown || force_opaque) {
+    return SOL_TX_REVIEW_OPAQUE;
+  }
+  return SOL_TX_REVIEW_VERIFIED;
+}
+
+static SolanaTxReview solana_parseVersionedTx(const uint8_t* raw,
+                                              size_t raw_len,
+                                              SolanaParsedTx* tx) {
+  memset(tx, 0, sizeof(*tx));
+  size_t pos = 0;
+  bool has_unknown = false;
+  bool force_opaque = true;
+
+  if (raw_len < 1) return SOL_TX_REVIEW_MALFORMED;
+  uint8_t version_prefix = raw[pos++];
+  if ((version_prefix & 0x80) == 0) return SOL_TX_REVIEW_MALFORMED;
+  if ((version_prefix & 0x7f) != 0) return SOL_TX_REVIEW_OPAQUE;
+
+  if (raw_len - pos < 3) return SOL_TX_REVIEW_MALFORMED;
+  tx->num_required_sigs = raw[pos++];
+  tx->num_readonly_signed = raw[pos++];
+  tx->num_readonly_unsigned = raw[pos++];
+
+  uint16_t num_accounts;
+  int n = read_compact_u16(raw + pos, raw_len - pos, &num_accounts);
+  if (n < 0) return SOL_TX_REVIEW_MALFORMED;
+  pos += n;
+
+  if (num_accounts > 32) return SOL_TX_REVIEW_OPAQUE;
+  tx->num_accounts = (uint8_t)num_accounts;
+
+  for (uint16_t i = 0; i < num_accounts; i++) {
+    if (pos + SOL_PUBKEY_SIZE > raw_len) return SOL_TX_REVIEW_MALFORMED;
+    memcpy(tx->accounts[i], raw + pos, SOL_PUBKEY_SIZE);
+    pos += SOL_PUBKEY_SIZE;
+  }
+
+  if (pos + SOL_PUBKEY_SIZE > raw_len) return SOL_TX_REVIEW_MALFORMED;
+  memcpy(tx->recent_blockhash, raw + pos, SOL_PUBKEY_SIZE);
+  pos += SOL_PUBKEY_SIZE;
+
+  n = parse_instruction_section(raw, raw_len, &pos, tx, num_accounts,
+                                &has_unknown, &force_opaque);
+  if (n < 0) return SOL_TX_REVIEW_MALFORMED;
+
+  uint16_t lookup_table_count;
+  n = read_compact_u16(raw + pos, raw_len - pos, &lookup_table_count);
+  if (n < 0) return SOL_TX_REVIEW_MALFORMED;
+  pos += n;
+
+  for (uint16_t i = 0; i < lookup_table_count; i++) {
+    uint16_t writable_count, readonly_count;
+    if (pos + SOL_PUBKEY_SIZE > raw_len) return SOL_TX_REVIEW_MALFORMED;
+    pos += SOL_PUBKEY_SIZE; /* lookup table account key */
+
+    n = read_compact_u16(raw + pos, raw_len - pos, &writable_count);
+    if (n < 0) return SOL_TX_REVIEW_MALFORMED;
+    pos += n;
+    if (pos + writable_count > raw_len) return SOL_TX_REVIEW_MALFORMED;
+    pos += writable_count;
+
+    n = read_compact_u16(raw + pos, raw_len - pos, &readonly_count);
+    if (n < 0) return SOL_TX_REVIEW_MALFORMED;
+    pos += n;
+    if (pos + readonly_count > raw_len) return SOL_TX_REVIEW_MALFORMED;
+    pos += readonly_count;
+  }
+
+  if (pos != raw_len) return SOL_TX_REVIEW_MALFORMED;
+  return SOL_TX_REVIEW_OPAQUE;
+}
+
+SolanaTxReview solana_inspectTx(const uint8_t* raw, size_t raw_len,
+                                SolanaParsedTx* tx) {
+  if (raw_len == 0) {
+    memset(tx, 0, sizeof(*tx));
+    return SOL_TX_REVIEW_MALFORMED;
+  }
+
+  /* Skip signature count prefix if present.
+   * Clients may send either the raw message (header starts at byte 0)
+   * or a full unsigned transaction (compact-u16 sig count = 0 at byte 0).
+   * A valid legacy message header has num_required_sigs >= 1 at byte 0.
+   * If byte 0 is 0, it's a signature count prefix — skip it. */
+  if (raw[0] == 0 && raw_len > 1) {
+    raw++;
+    raw_len--;
+  }
+
+  /* Versioned Solana messages set the top bit in byte 0.
+   * Parse them structurally so malformed v0/ALT payloads fail closed,
+   * but keep the result opaque until the firmware can verify semantics. */
+  if (raw[0] & 0x80) {
+    return solana_parseVersionedTx(raw, raw_len, tx);
+  }
+
+  return solana_parseLegacyTx(raw, raw_len, tx);
+}
+
+bool solana_parseTx(const uint8_t* raw, size_t raw_len, SolanaParsedTx* tx) {
+  return solana_inspectTx(raw, raw_len, tx) == SOL_TX_REVIEW_VERIFIED;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Formatting                                                         */
+/* ------------------------------------------------------------------ */
+
+void solana_formatAmount(char* buf, size_t len, uint64_t lamports) {
+  uint64_t whole = lamports / 1000000000ULL;
+  uint64_t frac = lamports % 1000000000ULL;
+  snprintf(buf, len, "%llu.%09llu SOL", (unsigned long long)whole,
+           (unsigned long long)frac);
+}
+
+void solana_formatTokenAmount(char* buf, size_t len, uint64_t amount,
+                              const char* symbol, uint8_t decimals) {
+  if (decimals == 0 || decimals > 18) {
+    snprintf(buf, len, "%llu %s", (unsigned long long)amount, symbol);
+    return;
+  }
+
+  uint64_t divisor = 1;
+  for (uint8_t i = 0; i < decimals; i++) divisor *= 10;
+
+  uint64_t whole = amount / divisor;
+  uint64_t frac = amount % divisor;
+
+  /* Format with appropriate decimal places (max 9 shown) */
+  uint8_t show_dec = decimals > 9 ? 9 : decimals;
+  uint64_t show_div = 1;
+  for (uint8_t i = 0; i < show_dec; i++) show_div *= 10;
+  (void)show_div;
+  uint64_t show_frac = frac;
+  if (decimals > 9) {
+    for (uint8_t i = 0; i < decimals - 9; i++) show_frac /= 10;
+  }
+
+  char frac_str[10];
+  for (int8_t i = (int8_t)show_dec - 1; i >= 0; i--) {
+    frac_str[i] = '0' + (show_frac % 10);
+    show_frac /= 10;
+  }
+  frac_str[show_dec] = '\0';
+  snprintf(buf, len, "%llu.%s %s", (unsigned long long)whole, frac_str, symbol);
+}
+
+const SolanaTokenInfo* solana_findTokenInfo(
+    const SolanaSignTx* msg, const uint8_t mint[SOL_PUBKEY_SIZE]) {
+  for (size_t i = 0; i < msg->token_info_count; i++) {
+    if (msg->token_info[i].has_mint &&
+        msg->token_info[i].mint.size == SOL_PUBKEY_SIZE &&
+        memcmp(msg->token_info[i].mint.bytes, mint, SOL_PUBKEY_SIZE) == 0) {
+      return &msg->token_info[i];
+    }
+  }
+  return NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Signing                                                            */
+/* ------------------------------------------------------------------ */
+
+bool solana_signTx(const HDNode* node, const SolanaSignTx* msg,
+                   SolanaSignedTx* resp) {
+  if (!msg->has_raw_tx || msg->raw_tx.size == 0) return false;
+
+  /* Ed25519 sign the raw transaction message directly
+   * (Solana signs the serialized message, not a hash of it) */
+  uint8_t sig[SOL_SIG_SIZE];
+  ed25519_sign(msg->raw_tx.bytes, msg->raw_tx.size, node->private_key,
+               node->public_key + 1, sig);
+
+  resp->has_signature = true;
+  resp->signature.size = SOL_SIG_SIZE;
+  memcpy(resp->signature.bytes, sig, SOL_SIG_SIZE);
+
+  return true;
+}

--- a/lib/firmware/solana.c
+++ b/lib/firmware/solana.c
@@ -87,7 +87,8 @@ static int read_compact_u16(const uint8_t* data, size_t len, uint16_t* out) {
 
   if (len < 2) return -1;
   if (data[1] < SOL_COMPACT_U16_CONTINUATION) {
-    *out = (uint16_t)((data[0] & SOL_COMPACT_U16_DATA_MASK) | ((uint16_t)data[1] << 7));
+    *out = (uint16_t)((data[0] & SOL_COMPACT_U16_DATA_MASK) |
+                      ((uint16_t)data[1] << 7));
     return 2;
   }
 
@@ -95,7 +96,8 @@ static int read_compact_u16(const uint8_t* data, size_t len, uint16_t* out) {
   /* Third byte uses bits 14-15, so only values 0-3 are valid
    * (max compact-u16 value is 0xFFFF = 65535). */
   if (data[2] > SOL_COMPACT_U16_BYTE3_MAX) return -1;
-  *out = (uint16_t)((data[0] & SOL_COMPACT_U16_DATA_MASK) | ((data[1] & SOL_COMPACT_U16_DATA_MASK) << 7) |
+  *out = (uint16_t)((data[0] & SOL_COMPACT_U16_DATA_MASK) |
+                    ((data[1] & SOL_COMPACT_U16_DATA_MASK) << 7) |
                     ((uint16_t)data[2] << 14));
   return 3;
 }
@@ -236,7 +238,8 @@ static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
-        } else if (token_instr == SOL_TOKEN_TRANSFER_CHECKED_IX && data_len >= 9) {
+        } else if (token_instr == SOL_TOKEN_TRANSFER_CHECKED_IX &&
+                   data_len >= 9) {
           pi->type = SOL_INSTR_TOKEN_TRANSFER_CHECKED;
           pi->amount = read_le64(instr_data + 1);
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
@@ -263,7 +266,9 @@ static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
           if (data_len >= 35 && instr_data[2] == 1) {
             memcpy(pi->extra, instr_data + 3, SOL_PUBKEY_SIZE);
           }
-        } else if ((token_instr == SOL_TOKEN_MINT_TO_IX || token_instr == SOL_TOKEN_MINT_TO_CHECKED_IX) && data_len >= 9) {
+        } else if ((token_instr == SOL_TOKEN_MINT_TO_IX ||
+                    token_instr == SOL_TOKEN_MINT_TO_CHECKED_IX) &&
+                   data_len >= 9) {
           pi->type = SOL_INSTR_TOKEN_MINT_TO;
           pi->amount = read_le64(instr_data + 1);
           copy_account(pi->mint, tx, acct_indices, num_acct_indices, 0);
@@ -271,8 +276,12 @@ static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
           copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
           pi->extra_u8 =
-              (token_instr == SOL_TOKEN_MINT_TO_CHECKED_IX && data_len >= 10) ? instr_data[9] : 0;
-        } else if ((token_instr == SOL_TOKEN_BURN_IX || token_instr == SOL_TOKEN_BURN_CHECKED_IX) && data_len >= 9) {
+              (token_instr == SOL_TOKEN_MINT_TO_CHECKED_IX && data_len >= 10)
+                  ? instr_data[9]
+                  : 0;
+        } else if ((token_instr == SOL_TOKEN_BURN_IX ||
+                    token_instr == SOL_TOKEN_BURN_CHECKED_IX) &&
+                   data_len >= 9) {
           pi->type = SOL_INSTR_TOKEN_BURN;
           pi->amount = read_le64(instr_data + 1);
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
@@ -280,7 +289,9 @@ static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
           pi->has_mint = (num_acct_indices >= 2);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
           pi->extra_u8 =
-              (token_instr == SOL_TOKEN_BURN_CHECKED_IX && data_len >= 10) ? instr_data[9] : 0;
+              (token_instr == SOL_TOKEN_BURN_CHECKED_IX && data_len >= 10)
+                  ? instr_data[9]
+                  : 0;
         } else if (token_instr == SOL_TOKEN_CLOSE_ACCOUNT_IX) {
           pi->type = SOL_INSTR_TOKEN_CLOSE_ACCOUNT;
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
@@ -368,12 +379,14 @@ static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
-        } else if (vote_instr == SOL_VOTE_UPDATE_VALIDATOR_IX && data_len >= 36) {
+        } else if (vote_instr == SOL_VOTE_UPDATE_VALIDATOR_IX &&
+                   data_len >= 36) {
           pi->type = SOL_INSTR_VOTE_UPDATE_VALIDATOR;
           memcpy(pi->extra, instr_data + 4, SOL_PUBKEY_SIZE);
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 1);
-        } else if (vote_instr == SOL_VOTE_UPDATE_COMMISSION_IX && data_len >= 5) {
+        } else if (vote_instr == SOL_VOTE_UPDATE_COMMISSION_IX &&
+                   data_len >= 5) {
           pi->type = SOL_INSTR_VOTE_UPDATE_COMMISSION;
           pi->extra_u8 = instr_data[4];
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
@@ -411,7 +424,8 @@ static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
         } else if (cb_instr == SOL_CB_SET_COMPUTE_UNIT_PRICE && data_len >= 9) {
           pi->type = SOL_INSTR_COMPUTE_BUDGET_UNIT_PRICE;
           pi->extra_value = read_le64(instr_data + 1);
-        } else if (cb_instr == SOL_CB_SET_LOADED_ACCOUNTS_SIZE && data_len >= 5) {
+        } else if (cb_instr == SOL_CB_SET_LOADED_ACCOUNTS_SIZE &&
+                   data_len >= 5) {
           pi->type = SOL_INSTR_COMPUTE_BUDGET_LOADED_ACCOUNTS_SIZE;
           pi->extra_value = read_le32(instr_data + 1);
         } else {
@@ -608,13 +622,15 @@ void solana_formatTokenAmount(char* buf, size_t len, uint64_t amount,
   uint64_t frac = amount % divisor;
 
   /* Format with appropriate decimal places (max 9 shown) */
-  uint8_t show_dec = decimals > SOL_MAX_DISPLAY_DECIMALS ? SOL_MAX_DISPLAY_DECIMALS : decimals;
+  uint8_t show_dec =
+      decimals > SOL_MAX_DISPLAY_DECIMALS ? SOL_MAX_DISPLAY_DECIMALS : decimals;
   uint64_t show_div = 1;
   for (uint8_t i = 0; i < show_dec; i++) show_div *= 10;
   (void)show_div;
   uint64_t show_frac = frac;
   if (decimals > SOL_MAX_DISPLAY_DECIMALS) {
-    for (uint8_t i = 0; i < decimals - SOL_MAX_DISPLAY_DECIMALS; i++) show_frac /= 10;
+    for (uint8_t i = 0; i < decimals - SOL_MAX_DISPLAY_DECIMALS; i++)
+      show_frac /= 10;
   }
 
   char frac_str[10];

--- a/lib/firmware/solana.c
+++ b/lib/firmware/solana.c
@@ -80,22 +80,22 @@ const uint8_t SOL_MEMO_PROGRAM[SOL_PUBKEY_SIZE] = {
 static int read_compact_u16(const uint8_t* data, size_t len, uint16_t* out) {
   if (len < 1) return -1;
 
-  if (data[0] < 0x80) {
+  if (data[0] < SOL_COMPACT_U16_CONTINUATION) {
     *out = data[0];
     return 1;
   }
 
   if (len < 2) return -1;
-  if (data[1] < 0x80) {
-    *out = (uint16_t)((data[0] & 0x7F) | ((uint16_t)data[1] << 7));
+  if (data[1] < SOL_COMPACT_U16_CONTINUATION) {
+    *out = (uint16_t)((data[0] & SOL_COMPACT_U16_DATA_MASK) | ((uint16_t)data[1] << 7));
     return 2;
   }
 
   if (len < 3) return -1;
   /* Third byte uses bits 14-15, so only values 0-3 are valid
    * (max compact-u16 value is 0xFFFF = 65535). */
-  if (data[2] > 3) return -1;
-  *out = (uint16_t)((data[0] & 0x7F) | ((data[1] & 0x7F) << 7) |
+  if (data[2] > SOL_COMPACT_U16_BYTE3_MAX) return -1;
+  *out = (uint16_t)((data[0] & SOL_COMPACT_U16_DATA_MASK) | ((data[1] & SOL_COMPACT_U16_DATA_MASK) << 7) |
                     ((uint16_t)data[2] << 14));
   return 3;
 }
@@ -130,7 +130,7 @@ static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
   if (n < 0) return -1;
   pos += n;
 
-  if (num_instructions > 8) {
+  if (num_instructions > SOL_MAX_INSTRUCTIONS) {
     *force_opaque = true;
     tx->num_instructions = 0;
     /* Don't attempt to parse instruction data — treat as opaque. */
@@ -167,7 +167,7 @@ static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
     const uint8_t* instr_data = raw + pos;
     pos += data_len;
 
-    if (i >= 8) {
+    if (i >= SOL_MAX_INSTRUCTIONS) {
       continue;
     }
 
@@ -179,40 +179,40 @@ static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
       /* System program */
       if (data_len >= 4) {
         uint32_t instr_type = read_le32(instr_data);
-        if (instr_type == 2 && data_len >= 12) {
+        if (instr_type == SOL_SYS_TRANSFER && data_len >= 12) {
           pi->type = SOL_INSTR_SYSTEM_TRANSFER;
           pi->lamports = read_le64(instr_data + 4);
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
-        } else if (instr_type == 0 && data_len >= 12) {
+        } else if (instr_type == SOL_SYS_CREATE_ACCOUNT && data_len >= 12) {
           pi->type = SOL_INSTR_SYSTEM_CREATE_ACCOUNT;
           pi->lamports = read_le64(instr_data + 4);
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
-        } else if (instr_type == 4) {
+        } else if (instr_type == SOL_SYS_ADVANCE_NONCE) {
           pi->type = SOL_INSTR_SYSTEM_ADVANCE_NONCE;
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
-        } else if (instr_type == 5 && data_len >= 12) {
+        } else if (instr_type == SOL_SYS_WITHDRAW_NONCE && data_len >= 12) {
           pi->type = SOL_INSTR_SYSTEM_WITHDRAW_NONCE;
           pi->lamports = read_le64(instr_data + 4);
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 4);
-        } else if (instr_type == 6 && data_len >= 36) {
+        } else if (instr_type == SOL_SYS_INITIALIZE_NONCE && data_len >= 36) {
           pi->type = SOL_INSTR_SYSTEM_INITIALIZE_NONCE;
           memcpy(pi->authority, instr_data + 4, SOL_PUBKEY_SIZE);
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
-        } else if (instr_type == 7 && data_len >= 36) {
+        } else if (instr_type == SOL_SYS_AUTHORIZE_NONCE && data_len >= 36) {
           pi->type = SOL_INSTR_SYSTEM_AUTHORIZE_NONCE;
           memcpy(pi->extra, instr_data + 4, SOL_PUBKEY_SIZE);
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 1);
-        } else if (instr_type == 1 && data_len >= 36) {
+        } else if (instr_type == SOL_SYS_ASSIGN && data_len >= 36) {
           pi->type = SOL_INSTR_SYSTEM_ASSIGN;
           memcpy(pi->extra, instr_data + 4, SOL_PUBKEY_SIZE);
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
-        } else if (instr_type == 8 && data_len >= 12) {
+        } else if (instr_type == SOL_SYS_ALLOCATE && data_len >= 12) {
           pi->type = SOL_INSTR_SYSTEM_ALLOCATE;
           pi->extra_value = read_le64(instr_data + 4);
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
@@ -230,13 +230,13 @@ static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
                       SOL_PUBKEY_SIZE) == 0) {
       if (data_len >= 1) {
         uint8_t token_instr = instr_data[0];
-        if (token_instr == 3 && data_len >= 9) {
+        if (token_instr == SOL_TOKEN_TRANSFER_IX && data_len >= 9) {
           pi->type = SOL_INSTR_TOKEN_TRANSFER;
           pi->amount = read_le64(instr_data + 1);
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
-        } else if (token_instr == 12 && data_len >= 9) {
+        } else if (token_instr == SOL_TOKEN_TRANSFER_CHECKED_IX && data_len >= 9) {
           pi->type = SOL_INSTR_TOKEN_TRANSFER_CHECKED;
           pi->amount = read_le64(instr_data + 1);
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
@@ -245,17 +245,17 @@ static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
           copy_account(pi->to, tx, acct_indices, num_acct_indices, 2);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 3);
           pi->extra_u8 = data_len >= 10 ? instr_data[9] : 0;
-        } else if (token_instr == 4 && data_len >= 9) {
+        } else if (token_instr == SOL_TOKEN_APPROVE_IX && data_len >= 9) {
           pi->type = SOL_INSTR_TOKEN_APPROVE;
           pi->amount = read_le64(instr_data + 1);
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
-        } else if (token_instr == 5) {
+        } else if (token_instr == SOL_TOKEN_REVOKE_IX) {
           pi->type = SOL_INSTR_TOKEN_REVOKE;
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 1);
-        } else if (token_instr == 6 && data_len >= 2) {
+        } else if (token_instr == SOL_TOKEN_SET_AUTHORITY_IX && data_len >= 2) {
           pi->type = SOL_INSTR_TOKEN_SET_AUTHORITY;
           pi->extra_u8 = instr_data[1];
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
@@ -263,7 +263,7 @@ static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
           if (data_len >= 35 && instr_data[2] == 1) {
             memcpy(pi->extra, instr_data + 3, SOL_PUBKEY_SIZE);
           }
-        } else if ((token_instr == 7 || token_instr == 14) && data_len >= 9) {
+        } else if ((token_instr == SOL_TOKEN_MINT_TO_IX || token_instr == SOL_TOKEN_MINT_TO_CHECKED_IX) && data_len >= 9) {
           pi->type = SOL_INSTR_TOKEN_MINT_TO;
           pi->amount = read_le64(instr_data + 1);
           copy_account(pi->mint, tx, acct_indices, num_acct_indices, 0);
@@ -271,8 +271,8 @@ static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
           copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
           pi->extra_u8 =
-              (token_instr == 14 && data_len >= 10) ? instr_data[9] : 0;
-        } else if ((token_instr == 8 || token_instr == 15) && data_len >= 9) {
+              (token_instr == SOL_TOKEN_MINT_TO_CHECKED_IX && data_len >= 10) ? instr_data[9] : 0;
+        } else if ((token_instr == SOL_TOKEN_BURN_IX || token_instr == SOL_TOKEN_BURN_CHECKED_IX) && data_len >= 9) {
           pi->type = SOL_INSTR_TOKEN_BURN;
           pi->amount = read_le64(instr_data + 1);
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
@@ -280,25 +280,25 @@ static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
           pi->has_mint = (num_acct_indices >= 2);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
           pi->extra_u8 =
-              (token_instr == 15 && data_len >= 10) ? instr_data[9] : 0;
-        } else if (token_instr == 9) {
+              (token_instr == SOL_TOKEN_BURN_CHECKED_IX && data_len >= 10) ? instr_data[9] : 0;
+        } else if (token_instr == SOL_TOKEN_CLOSE_ACCOUNT_IX) {
           pi->type = SOL_INSTR_TOKEN_CLOSE_ACCOUNT;
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
-        } else if (token_instr == 10) {
+        } else if (token_instr == SOL_TOKEN_FREEZE_ACCOUNT_IX) {
           pi->type = SOL_INSTR_TOKEN_FREEZE_ACCOUNT;
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->mint, tx, acct_indices, num_acct_indices, 1);
           pi->has_mint = (num_acct_indices >= 2);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
-        } else if (token_instr == 11) {
+        } else if (token_instr == SOL_TOKEN_THAW_ACCOUNT_IX) {
           pi->type = SOL_INSTR_TOKEN_THAW_ACCOUNT;
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->mint, tx, acct_indices, num_acct_indices, 1);
           pi->has_mint = (num_acct_indices >= 2);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
-        } else if (token_instr == 17) {
+        } else if (token_instr == SOL_TOKEN_SYNC_NATIVE_IX) {
           pi->type = SOL_INSTR_TOKEN_SYNC_NATIVE;
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
         } else {
@@ -313,34 +313,34 @@ static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
                0) {
       if (data_len >= 4) {
         uint32_t stake_instr = read_le32(instr_data);
-        if (stake_instr == 2) {
+        if (stake_instr == SOL_STAKE_DELEGATE_IX) {
           pi->type = SOL_INSTR_STAKE_DELEGATE;
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 5);
           copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
-        } else if (stake_instr == 4 && data_len >= 12) {
+        } else if (stake_instr == SOL_STAKE_WITHDRAW_IX && data_len >= 12) {
           pi->type = SOL_INSTR_STAKE_WITHDRAW;
           pi->lamports = read_le64(instr_data + 4);
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 4);
-        } else if (stake_instr == 1 && data_len >= 36) {
+        } else if (stake_instr == SOL_STAKE_AUTHORIZE_IX && data_len >= 36) {
           pi->type = SOL_INSTR_STAKE_AUTHORIZE;
           memcpy(pi->extra, instr_data + 4, SOL_PUBKEY_SIZE);
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 1);
           pi->extra_u8 = (uint8_t)read_le32(instr_data + 36);
-        } else if (stake_instr == 3 && data_len >= 12) {
+        } else if (stake_instr == SOL_STAKE_SPLIT_IX && data_len >= 12) {
           pi->type = SOL_INSTR_STAKE_SPLIT;
           pi->lamports = read_le64(instr_data + 4);
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
-        } else if (stake_instr == 5) {
+        } else if (stake_instr == SOL_STAKE_DEACTIVATE_IX) {
           pi->type = SOL_INSTR_STAKE_DEACTIVATE;
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
-        } else if (stake_instr == 7) {
+        } else if (stake_instr == SOL_STAKE_MERGE_IX) {
           pi->type = SOL_INSTR_STAKE_MERGE;
           copy_account(pi->to, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 1);
@@ -356,24 +356,24 @@ static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
     } else if (memcmp(pi->program_id, SOL_VOTE_PROGRAM, SOL_PUBKEY_SIZE) == 0) {
       if (data_len >= 4) {
         uint32_t vote_instr = read_le32(instr_data);
-        if (vote_instr == 1 && data_len >= 40) {
+        if (vote_instr == SOL_VOTE_AUTHORIZE_IX && data_len >= 40) {
           pi->type = SOL_INSTR_VOTE_AUTHORIZE;
           memcpy(pi->extra, instr_data + 4, SOL_PUBKEY_SIZE);
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 1);
           pi->extra_u8 = (uint8_t)read_le32(instr_data + 36);
-        } else if (vote_instr == 3 && data_len >= 12) {
+        } else if (vote_instr == SOL_VOTE_WITHDRAW_IX && data_len >= 12) {
           pi->type = SOL_INSTR_VOTE_WITHDRAW;
           pi->lamports = read_le64(instr_data + 4);
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->to, tx, acct_indices, num_acct_indices, 1);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 2);
-        } else if (vote_instr == 4 && data_len >= 36) {
+        } else if (vote_instr == SOL_VOTE_UPDATE_VALIDATOR_IX && data_len >= 36) {
           pi->type = SOL_INSTR_VOTE_UPDATE_VALIDATOR;
           memcpy(pi->extra, instr_data + 4, SOL_PUBKEY_SIZE);
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
           copy_account(pi->authority, tx, acct_indices, num_acct_indices, 1);
-        } else if (vote_instr == 5 && data_len >= 5) {
+        } else if (vote_instr == SOL_VOTE_UPDATE_COMMISSION_IX && data_len >= 5) {
           pi->type = SOL_INSTR_VOTE_UPDATE_COMMISSION;
           pi->extra_u8 = instr_data[4];
           copy_account(pi->from, tx, acct_indices, num_acct_indices, 0);
@@ -402,16 +402,16 @@ static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
                       SOL_PUBKEY_SIZE) == 0) {
       if (data_len >= 1) {
         uint8_t cb_instr = instr_data[0];
-        if (cb_instr == 1 && data_len >= 5) {
+        if (cb_instr == SOL_CB_REQUEST_HEAP_FRAME && data_len >= 5) {
           pi->type = SOL_INSTR_COMPUTE_BUDGET_HEAP_FRAME;
           pi->extra_value = read_le32(instr_data + 1);
-        } else if (cb_instr == 2 && data_len >= 5) {
+        } else if (cb_instr == SOL_CB_SET_COMPUTE_UNIT_LIMIT && data_len >= 5) {
           pi->type = SOL_INSTR_COMPUTE_BUDGET_UNIT_LIMIT;
           pi->extra_value = read_le32(instr_data + 1);
-        } else if (cb_instr == 3 && data_len >= 9) {
+        } else if (cb_instr == SOL_CB_SET_COMPUTE_UNIT_PRICE && data_len >= 9) {
           pi->type = SOL_INSTR_COMPUTE_BUDGET_UNIT_PRICE;
           pi->extra_value = read_le64(instr_data + 1);
-        } else if (cb_instr == 4 && data_len >= 5) {
+        } else if (cb_instr == SOL_CB_SET_LOADED_ACCOUNTS_SIZE && data_len >= 5) {
           pi->type = SOL_INSTR_COMPUTE_BUDGET_LOADED_ACCOUNTS_SIZE;
           pi->extra_value = read_le32(instr_data + 1);
         } else {
@@ -457,7 +457,7 @@ static SolanaTxReview solana_parseLegacyTx(const uint8_t* raw, size_t raw_len,
   if (n < 0) return SOL_TX_REVIEW_MALFORMED;
   pos += n;
 
-  if (num_accounts > 32) return SOL_TX_REVIEW_OPAQUE;
+  if (num_accounts > SOL_MAX_ACCOUNTS) return SOL_TX_REVIEW_OPAQUE;
   tx->num_accounts = (uint8_t)num_accounts;
 
   /* Read account keys */
@@ -495,8 +495,8 @@ static SolanaTxReview solana_parseVersionedTx(const uint8_t* raw,
 
   if (raw_len < 1) return SOL_TX_REVIEW_MALFORMED;
   uint8_t version_prefix = raw[pos++];
-  if ((version_prefix & 0x80) == 0) return SOL_TX_REVIEW_MALFORMED;
-  if ((version_prefix & 0x7f) != 0) return SOL_TX_REVIEW_OPAQUE;
+  if ((version_prefix & SOL_VERSION_FLAG) == 0) return SOL_TX_REVIEW_MALFORMED;
+  if ((version_prefix & SOL_VERSION_MASK) != 0) return SOL_TX_REVIEW_OPAQUE;
 
   if (raw_len - pos < 3) return SOL_TX_REVIEW_MALFORMED;
   tx->num_required_sigs = raw[pos++];
@@ -508,7 +508,7 @@ static SolanaTxReview solana_parseVersionedTx(const uint8_t* raw,
   if (n < 0) return SOL_TX_REVIEW_MALFORMED;
   pos += n;
 
-  if (num_accounts > 32) return SOL_TX_REVIEW_OPAQUE;
+  if (num_accounts > SOL_MAX_ACCOUNTS) return SOL_TX_REVIEW_OPAQUE;
   tx->num_accounts = (uint8_t)num_accounts;
 
   for (uint16_t i = 0; i < num_accounts; i++) {
@@ -572,7 +572,7 @@ SolanaTxReview solana_inspectTx(const uint8_t* raw, size_t raw_len,
   /* Versioned Solana messages set the top bit in byte 0.
    * Parse them structurally so malformed v0/ALT payloads fail closed,
    * but keep the result opaque until the firmware can verify semantics. */
-  if (raw[0] & 0x80) {
+  if (raw[0] & SOL_VERSION_FLAG) {
     return solana_parseVersionedTx(raw, raw_len, tx);
   }
 
@@ -588,15 +588,15 @@ bool solana_parseTx(const uint8_t* raw, size_t raw_len, SolanaParsedTx* tx) {
 /* ------------------------------------------------------------------ */
 
 void solana_formatAmount(char* buf, size_t len, uint64_t lamports) {
-  uint64_t whole = lamports / 1000000000ULL;
-  uint64_t frac = lamports % 1000000000ULL;
+  uint64_t whole = lamports / SOL_LAMPORTS_DIVISOR;
+  uint64_t frac = lamports % SOL_LAMPORTS_DIVISOR;
   snprintf(buf, len, "%llu.%09llu SOL", (unsigned long long)whole,
            (unsigned long long)frac);
 }
 
 void solana_formatTokenAmount(char* buf, size_t len, uint64_t amount,
                               const char* symbol, uint8_t decimals) {
-  if (decimals == 0 || decimals > 18) {
+  if (decimals == 0 || decimals > SOL_MAX_TOKEN_DECIMALS) {
     snprintf(buf, len, "%llu %s", (unsigned long long)amount, symbol);
     return;
   }
@@ -608,13 +608,13 @@ void solana_formatTokenAmount(char* buf, size_t len, uint64_t amount,
   uint64_t frac = amount % divisor;
 
   /* Format with appropriate decimal places (max 9 shown) */
-  uint8_t show_dec = decimals > 9 ? 9 : decimals;
+  uint8_t show_dec = decimals > SOL_MAX_DISPLAY_DECIMALS ? SOL_MAX_DISPLAY_DECIMALS : decimals;
   uint64_t show_div = 1;
   for (uint8_t i = 0; i < show_dec; i++) show_div *= 10;
   (void)show_div;
   uint64_t show_frac = frac;
-  if (decimals > 9) {
-    for (uint8_t i = 0; i < decimals - 9; i++) show_frac /= 10;
+  if (decimals > SOL_MAX_DISPLAY_DECIMALS) {
+    for (uint8_t i = 0; i < decimals - SOL_MAX_DISPLAY_DECIMALS; i++) show_frac /= 10;
   }
 
   char frac_str[10];

--- a/unittests/firmware/solana.cpp
+++ b/unittests/firmware/solana.cpp
@@ -1,0 +1,618 @@
+extern "C" {
+#include "keepkey/firmware/solana.h"
+#include "trezor/crypto/memzero.h"
+}
+
+#include "gtest/gtest.h"
+#include <cstring>
+
+TEST(Solana, FormatAmount) {
+  char buf[32];
+
+  solana_formatAmount(buf, sizeof(buf), 1000000000ULL);
+  EXPECT_STREQ(buf, "1.000000000 SOL");
+
+  solana_formatAmount(buf, sizeof(buf), 0);
+  EXPECT_STREQ(buf, "0.000000000 SOL");
+
+  solana_formatAmount(buf, sizeof(buf), 2500000000ULL);
+  EXPECT_STREQ(buf, "2.500000000 SOL");
+}
+
+TEST(Solana, ParseSystemTransfer) {
+  /* Construct a minimal Solana transaction with a system transfer.
+   *
+   * Format:
+   *   [header: 3 bytes]
+   *   [compact-u16: num_accounts]
+   *   [account keys: N * 32 bytes]
+   *   [recent_blockhash: 32 bytes]
+   *   [compact-u16: num_instructions]
+   *   [instruction: program_idx, compact-u16 acct_count, acct_indices,
+   *                 compact-u16 data_len, data]
+   */
+  uint8_t raw[256];
+  size_t pos = 0;
+
+  /* Header */
+  raw[pos++] = 1; /* num_required_sigs */
+  raw[pos++] = 0; /* num_readonly_signed */
+  raw[pos++] = 1; /* num_readonly_unsigned (system program) */
+
+  /* 3 accounts: sender, recipient, system program */
+  raw[pos++] = 3; /* compact-u16 */
+
+  /* Account 0: sender (32 bytes of 0x11) */
+  memset(raw + pos, 0x11, 32);
+  pos += 32;
+  /* Account 1: recipient (32 bytes of 0x22) */
+  memset(raw + pos, 0x22, 32);
+  pos += 32;
+  /* Account 2: system program (all zeros) */
+  memset(raw + pos, 0x00, 32);
+  pos += 32;
+
+  /* Recent blockhash (32 bytes) */
+  memset(raw + pos, 0xBB, 32);
+  pos += 32;
+
+  /* 1 instruction */
+  raw[pos++] = 1; /* compact-u16 */
+
+  /* Instruction: system transfer */
+  raw[pos++] = 2;  /* program_id index (system program) */
+  raw[pos++] = 2;  /* compact-u16: 2 account indices */
+  raw[pos++] = 0;  /* from (account 0) */
+  raw[pos++] = 1;  /* to (account 1) */
+  raw[pos++] = 12; /* compact-u16: data length */
+
+  /* System transfer instruction data:
+   * u32 LE instruction type (2 = Transfer)
+   * u64 LE lamports */
+  raw[pos++] = 2;
+  raw[pos++] = 0;
+  raw[pos++] = 0;
+  raw[pos++] = 0;
+  /* 1 SOL = 1000000000 = 0x3B9ACA00 */
+  raw[pos++] = 0x00;
+  raw[pos++] = 0xCA;
+  raw[pos++] = 0x9A;
+  raw[pos++] = 0x3B;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+
+  SolanaParsedTx tx;
+  EXPECT_EQ(solana_inspectTx(raw, pos, &tx), SOL_TX_REVIEW_VERIFIED);
+  ASSERT_TRUE(solana_parseTx(raw, pos, &tx));
+
+  EXPECT_EQ(tx.num_accounts, 3);
+  EXPECT_EQ(tx.num_instructions, 1);
+  EXPECT_EQ(tx.instructions[0].type, SOL_INSTR_SYSTEM_TRANSFER);
+  EXPECT_EQ(tx.instructions[0].lamports, 1000000000ULL);
+
+  /* Verify from/to accounts */
+  uint8_t expected_from[32], expected_to[32];
+  memset(expected_from, 0x11, 32);
+  memset(expected_to, 0x22, 32);
+  EXPECT_TRUE(memcmp(tx.instructions[0].from, expected_from, 32) == 0);
+  EXPECT_TRUE(memcmp(tx.instructions[0].to, expected_to, 32) == 0);
+}
+
+TEST(Solana, ParseMultiInstruction) {
+  /* Transaction with 2 system transfers */
+  uint8_t raw[512];
+  size_t pos = 0;
+
+  /* Header */
+  raw[pos++] = 1;
+  raw[pos++] = 0;
+  raw[pos++] = 1;
+
+  /* 4 accounts */
+  raw[pos++] = 4;
+  memset(raw + pos, 0x11, 32);
+  pos += 32; /* account 0: sender */
+  memset(raw + pos, 0x22, 32);
+  pos += 32; /* account 1: recipient 1 */
+  memset(raw + pos, 0x33, 32);
+  pos += 32; /* account 2: recipient 2 */
+  memset(raw + pos, 0x00, 32);
+  pos += 32; /* account 3: system program */
+
+  /* Blockhash */
+  memset(raw + pos, 0xBB, 32);
+  pos += 32;
+
+  /* 2 instructions */
+  raw[pos++] = 2;
+
+  /* Instruction 1: transfer 1 SOL to acct 1 */
+  raw[pos++] = 3; /* program = system */
+  raw[pos++] = 2;
+  raw[pos++] = 0;
+  raw[pos++] = 1;
+  raw[pos++] = 12;
+  raw[pos++] = 2;
+  raw[pos++] = 0;
+  raw[pos++] = 0;
+  raw[pos++] = 0;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0xCA;
+  raw[pos++] = 0x9A;
+  raw[pos++] = 0x3B;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+
+  /* Instruction 2: transfer 2 SOL to acct 2 */
+  raw[pos++] = 3;
+  raw[pos++] = 2;
+  raw[pos++] = 0;
+  raw[pos++] = 2;
+  raw[pos++] = 12;
+  raw[pos++] = 2;
+  raw[pos++] = 0;
+  raw[pos++] = 0;
+  raw[pos++] = 0;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x94;
+  raw[pos++] = 0x35;
+  raw[pos++] = 0x77;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+
+  SolanaParsedTx tx;
+  EXPECT_EQ(solana_inspectTx(raw, pos, &tx), SOL_TX_REVIEW_VERIFIED);
+  ASSERT_TRUE(solana_parseTx(raw, pos, &tx));
+
+  EXPECT_EQ(tx.num_instructions, 2);
+  EXPECT_EQ(tx.instructions[0].type, SOL_INSTR_SYSTEM_TRANSFER);
+  EXPECT_EQ(tx.instructions[0].lamports, 1000000000ULL);
+  EXPECT_EQ(tx.instructions[1].type, SOL_INSTR_SYSTEM_TRANSFER);
+  EXPECT_EQ(tx.instructions[1].lamports, 2000000000ULL);
+}
+
+TEST(Solana, ParseSPLTokenTransfer) {
+  /* Transaction with a SPL token transfer instruction */
+  uint8_t raw[512];
+  size_t pos = 0;
+
+  /* Header */
+  raw[pos++] = 1;
+  raw[pos++] = 0;
+  raw[pos++] = 1;
+
+  /* 4 accounts: source_ata, dest_ata, authority, token_program */
+  raw[pos++] = 4;
+  memset(raw + pos, 0x11, 32);
+  pos += 32; /* account 0: source ATA */
+  memset(raw + pos, 0x22, 32);
+  pos += 32; /* account 1: dest ATA */
+  memset(raw + pos, 0x33, 32);
+  pos += 32; /* account 2: authority */
+  /* account 3: SPL Token program */
+  memcpy(raw + pos, SOL_TOKEN_PROGRAM, 32);
+  pos += 32;
+
+  /* Blockhash */
+  memset(raw + pos, 0xBB, 32);
+  pos += 32;
+
+  /* 1 instruction */
+  raw[pos++] = 1;
+
+  /* SPL Token Transfer */
+  raw[pos++] = 3; /* program index = token program */
+  raw[pos++] = 3; /* 3 accounts */
+  raw[pos++] = 0; /* source */
+  raw[pos++] = 1; /* dest */
+  raw[pos++] = 2; /* authority */
+  raw[pos++] = 9; /* data length */
+  raw[pos++] = 3; /* instruction type = Transfer */
+  /* amount: 1000000 (1 USDC) in LE */
+  raw[pos++] = 0x40;
+  raw[pos++] = 0x42;
+  raw[pos++] = 0x0F;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+
+  SolanaParsedTx tx;
+  EXPECT_EQ(solana_inspectTx(raw, pos, &tx), SOL_TX_REVIEW_VERIFIED);
+  ASSERT_TRUE(solana_parseTx(raw, pos, &tx));
+
+  EXPECT_EQ(tx.num_instructions, 1);
+  EXPECT_EQ(tx.instructions[0].type, SOL_INSTR_TOKEN_TRANSFER);
+  EXPECT_EQ(tx.instructions[0].amount, 1000000ULL);
+}
+
+TEST(Solana, ParseAssociatedTokenAccountCreate) {
+  uint8_t raw[512];
+  size_t pos = 0;
+
+  raw[pos++] = 1;
+  raw[pos++] = 0;
+  raw[pos++] = 1;
+
+  raw[pos++] = 5;
+  memset(raw + pos, 0x11, 32);
+  pos += 32; /* funder */
+  memset(raw + pos, 0x22, 32);
+  pos += 32; /* ata */
+  memset(raw + pos, 0x33, 32);
+  pos += 32; /* owner */
+  memset(raw + pos, 0x44, 32);
+  pos += 32; /* mint */
+  memcpy(raw + pos, SOL_ATA_PROGRAM, 32);
+  pos += 32; /* program */
+
+  memset(raw + pos, 0xBB, 32);
+  pos += 32;
+
+  raw[pos++] = 1;
+  raw[pos++] = 4; /* ata program */
+  raw[pos++] = 4; /* 4 account indices */
+  raw[pos++] = 0;
+  raw[pos++] = 1;
+  raw[pos++] = 2;
+  raw[pos++] = 3;
+  raw[pos++] = 0; /* empty data */
+
+  SolanaParsedTx tx;
+  EXPECT_EQ(solana_inspectTx(raw, pos, &tx), SOL_TX_REVIEW_VERIFIED);
+  ASSERT_TRUE(solana_parseTx(raw, pos, &tx));
+  EXPECT_EQ(tx.instructions[0].type, SOL_INSTR_ATA_CREATE);
+  EXPECT_TRUE(tx.instructions[0].has_mint);
+}
+
+TEST(Solana, ParseComputeBudgetUnitPrice) {
+  uint8_t raw[256];
+  size_t pos = 0;
+
+  raw[pos++] = 1;
+  raw[pos++] = 0;
+  raw[pos++] = 1;
+
+  raw[pos++] = 2;
+  memset(raw + pos, 0x11, 32);
+  pos += 32;
+  memcpy(raw + pos, SOL_COMPUTE_BUDGET_PROGRAM, 32);
+  pos += 32;
+
+  memset(raw + pos, 0xBB, 32);
+  pos += 32;
+
+  raw[pos++] = 1;
+  raw[pos++] = 1; /* compute budget program */
+  raw[pos++] = 0; /* no account indices */
+  raw[pos++] = 9; /* data length */
+  raw[pos++] = 3; /* SetComputeUnitPrice */
+  raw[pos++] = 0x40;
+  raw[pos++] = 0x42;
+  raw[pos++] = 0x0F;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+
+  SolanaParsedTx tx;
+  EXPECT_EQ(solana_inspectTx(raw, pos, &tx), SOL_TX_REVIEW_VERIFIED);
+  ASSERT_TRUE(solana_parseTx(raw, pos, &tx));
+  EXPECT_EQ(tx.instructions[0].type, SOL_INSTR_COMPUTE_BUDGET_UNIT_PRICE);
+  EXPECT_EQ(tx.instructions[0].extra_value, 1000000ULL);
+}
+
+TEST(Solana, UnknownProgram) {
+  uint8_t raw[256];
+  size_t pos = 0;
+
+  /* Header */
+  raw[pos++] = 1;
+  raw[pos++] = 0;
+  raw[pos++] = 1;
+
+  /* 2 accounts */
+  raw[pos++] = 2;
+  memset(raw + pos, 0x11, 32);
+  pos += 32;
+  memset(raw + pos, 0xFF, 32);
+  pos += 32; /* unknown program */
+
+  /* Blockhash */
+  memset(raw + pos, 0xBB, 32);
+  pos += 32;
+
+  /* 1 instruction */
+  raw[pos++] = 1;
+  raw[pos++] = 1; /* program index = 1 (unknown) */
+  raw[pos++] = 1;
+  raw[pos++] = 0; /* 1 account */
+  raw[pos++] = 4; /* data length */
+  raw[pos++] = 0xDE;
+  raw[pos++] = 0xAD;
+  raw[pos++] = 0xBE;
+  raw[pos++] = 0xEF;
+
+  SolanaParsedTx tx;
+  EXPECT_EQ(solana_inspectTx(raw, pos, &tx), SOL_TX_REVIEW_OPAQUE);
+  ASSERT_FALSE(solana_parseTx(raw, pos, &tx));
+  EXPECT_EQ(tx.num_instructions, 1);
+  EXPECT_EQ(tx.instructions[0].type, SOL_INSTR_UNKNOWN);
+}
+
+TEST(Solana, ParseTxTooShort) {
+  uint8_t raw[2] = {0, 0};
+  SolanaParsedTx tx;
+  EXPECT_EQ(solana_inspectTx(raw, sizeof(raw), &tx), SOL_TX_REVIEW_MALFORMED);
+  EXPECT_FALSE(solana_parseTx(raw, sizeof(raw), &tx));
+}
+
+TEST(Solana, RejectsTrailingBytes) {
+  /* Build a valid 1-instruction system transfer, then append extra bytes */
+  uint8_t raw[256];
+  size_t pos = 0;
+
+  /* Header */
+  raw[pos++] = 1;
+  raw[pos++] = 0;
+  raw[pos++] = 1;
+
+  /* 3 accounts */
+  raw[pos++] = 3;
+  memset(raw + pos, 0x11, 32);
+  pos += 32;
+  memset(raw + pos, 0x22, 32);
+  pos += 32;
+  memset(raw + pos, 0x00, 32);
+  pos += 32;
+
+  /* Blockhash */
+  memset(raw + pos, 0xBB, 32);
+  pos += 32;
+
+  /* 1 instruction */
+  raw[pos++] = 1;
+  raw[pos++] = 2; /* program = system */
+  raw[pos++] = 2;
+  raw[pos++] = 0;
+  raw[pos++] = 1;
+  raw[pos++] = 12;
+  raw[pos++] = 2;
+  raw[pos++] = 0;
+  raw[pos++] = 0;
+  raw[pos++] = 0;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0xCA;
+  raw[pos++] = 0x9A;
+  raw[pos++] = 0x3B;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+
+  /* Verify the base transaction parses OK */
+  SolanaParsedTx tx;
+  EXPECT_EQ(solana_inspectTx(raw, pos, &tx), SOL_TX_REVIEW_VERIFIED);
+  ASSERT_TRUE(solana_parseTx(raw, pos, &tx));
+
+  /* Append trailing garbage */
+  raw[pos++] = 0xDE;
+  raw[pos++] = 0xAD;
+
+  EXPECT_EQ(solana_inspectTx(raw, pos, &tx), SOL_TX_REVIEW_MALFORMED);
+  EXPECT_FALSE(solana_parseTx(raw, pos, &tx));
+}
+
+TEST(Solana, RejectsOOBAccountIndex) {
+  /* Transaction with acct_indices[0] = 99 (> num_accounts) */
+  uint8_t raw[256];
+  size_t pos = 0;
+
+  /* Header */
+  raw[pos++] = 1;
+  raw[pos++] = 0;
+  raw[pos++] = 1;
+
+  /* 3 accounts */
+  raw[pos++] = 3;
+  memset(raw + pos, 0x11, 32);
+  pos += 32;
+  memset(raw + pos, 0x22, 32);
+  pos += 32;
+  memset(raw + pos, 0x00, 32);
+  pos += 32;
+
+  /* Blockhash */
+  memset(raw + pos, 0xBB, 32);
+  pos += 32;
+
+  /* 1 instruction */
+  raw[pos++] = 1;
+  raw[pos++] = 2;  /* program = system */
+  raw[pos++] = 2;  /* 2 account indices */
+  raw[pos++] = 99; /* OOB: only 3 accounts exist */
+  raw[pos++] = 1;
+  raw[pos++] = 12;
+  raw[pos++] = 2;
+  raw[pos++] = 0;
+  raw[pos++] = 0;
+  raw[pos++] = 0;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0xCA;
+  raw[pos++] = 0x9A;
+  raw[pos++] = 0x3B;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+
+  SolanaParsedTx tx;
+  EXPECT_EQ(solana_inspectTx(raw, pos, &tx), SOL_TX_REVIEW_MALFORMED);
+  EXPECT_FALSE(solana_parseTx(raw, pos, &tx));
+}
+
+TEST(Solana, RejectsExcessInstructions) {
+  /* Transaction with num_instructions = 9 (max is 8) */
+  uint8_t raw[256];
+  size_t pos = 0;
+
+  /* Header */
+  raw[pos++] = 1;
+  raw[pos++] = 0;
+  raw[pos++] = 1;
+
+  /* 2 accounts */
+  raw[pos++] = 2;
+  memset(raw + pos, 0x11, 32);
+  pos += 32;
+  memset(raw + pos, 0x00, 32);
+  pos += 32;
+
+  /* Blockhash */
+  memset(raw + pos, 0xBB, 32);
+  pos += 32;
+
+  /* 9 instructions (exceeds limit of 8) */
+  raw[pos++] = 9;
+
+  SolanaParsedTx tx;
+  EXPECT_EQ(solana_inspectTx(raw, pos, &tx), SOL_TX_REVIEW_OPAQUE);
+  EXPECT_FALSE(solana_parseTx(raw, pos, &tx));
+}
+
+TEST(Solana, VersionedMessageIsOpaque) {
+  uint8_t raw[256];
+  size_t pos = 0;
+
+  raw[pos++] = 0x80; /* v0 prefix */
+  raw[pos++] = 1;    /* num_required_sigs */
+  raw[pos++] = 0;    /* num_readonly_signed */
+  raw[pos++] = 1;    /* num_readonly_unsigned */
+
+  raw[pos++] = 3; /* static accounts */
+  memset(raw + pos, 0x11, 32);
+  pos += 32;
+  memset(raw + pos, 0x22, 32);
+  pos += 32;
+  memset(raw + pos, 0x00, 32);
+  pos += 32; /* system program */
+
+  memset(raw + pos, 0xBB, 32);
+  pos += 32; /* blockhash */
+
+  raw[pos++] = 1; /* instructions */
+  raw[pos++] = 2; /* program = system */
+  raw[pos++] = 2;
+  raw[pos++] = 0;
+  raw[pos++] = 1;  /* account indices */
+  raw[pos++] = 12; /* data length */
+  raw[pos++] = 2;
+  raw[pos++] = 0;
+  raw[pos++] = 0;
+  raw[pos++] = 0;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0xCA;
+  raw[pos++] = 0x9A;
+  raw[pos++] = 0x3B;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+
+  raw[pos++] = 0; /* zero lookup tables */
+
+  SolanaParsedTx tx;
+  EXPECT_EQ(solana_inspectTx(raw, pos, &tx), SOL_TX_REVIEW_OPAQUE);
+  EXPECT_FALSE(solana_parseTx(raw, pos, &tx));
+}
+
+TEST(Solana, VersionedMessageWithLookupTableIsOpaque) {
+  uint8_t raw[256];
+  size_t pos = 0;
+
+  raw[pos++] = 0x80; /* v0 prefix */
+  raw[pos++] = 1;
+  raw[pos++] = 0;
+  raw[pos++] = 1;
+
+  raw[pos++] = 3;
+  memset(raw + pos, 0x11, 32);
+  pos += 32;
+  memset(raw + pos, 0x22, 32);
+  pos += 32;
+  memset(raw + pos, 0x00, 32);
+  pos += 32;
+
+  memset(raw + pos, 0xBB, 32);
+  pos += 32;
+
+  raw[pos++] = 1;
+  raw[pos++] = 2;
+  raw[pos++] = 2;
+  raw[pos++] = 0;
+  raw[pos++] = 1;
+  raw[pos++] = 12;
+  raw[pos++] = 2;
+  raw[pos++] = 0;
+  raw[pos++] = 0;
+  raw[pos++] = 0;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0xCA;
+  raw[pos++] = 0x9A;
+  raw[pos++] = 0x3B;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+
+  raw[pos++] = 1; /* one lookup table */
+  memset(raw + pos, 0x55, 32);
+  pos += 32;      /* table key */
+  raw[pos++] = 1; /* writable indexes count */
+  raw[pos++] = 0; /* writable index */
+  raw[pos++] = 2; /* readonly indexes count */
+  raw[pos++] = 1;
+  raw[pos++] = 2;
+
+  SolanaParsedTx tx;
+  EXPECT_EQ(solana_inspectTx(raw, pos, &tx), SOL_TX_REVIEW_OPAQUE);
+  EXPECT_FALSE(solana_parseTx(raw, pos, &tx));
+}
+
+TEST(Solana, MalformedVersionedLookupTableRejects) {
+  uint8_t raw[256];
+  size_t pos = 0;
+
+  raw[pos++] = 0x80;
+  raw[pos++] = 1;
+  raw[pos++] = 0;
+  raw[pos++] = 1;
+
+  raw[pos++] = 3;
+  memset(raw + pos, 0x11, 32);
+  pos += 32;
+  memset(raw + pos, 0x22, 32);
+  pos += 32;
+  memset(raw + pos, 0x00, 32);
+  pos += 32;
+
+  memset(raw + pos, 0xBB, 32);
+  pos += 32;
+
+  raw[pos++] = 0; /* zero instructions */
+  raw[pos++] = 1; /* one lookup table */
+  memset(raw + pos, 0x55, 16);
+  pos += 16; /* truncated table key */
+
+  SolanaParsedTx tx;
+  EXPECT_EQ(solana_inspectTx(raw, pos, &tx), SOL_TX_REVIEW_MALFORMED);
+  EXPECT_FALSE(solana_parseTx(raw, pos, &tx));
+}


### PR DESCRIPTION
## Summary
- Solana GetAddress, SignTx, SignMessage support
- Rebased on develop (includes TON/TRON from #414)
- python-keepkey pinned to upstream master (a6c6602, PR #190)
- Refactored magic numbers to named constants in solana.c/solana.h

## Test plan
- [ ] CI passes (lint, build, unit tests, integration tests)
- [ ] Solana address derivation
- [ ] Solana sign tx
- [ ] Solana sign message