### PR TITLE
fix: EIP-1559 fee display overcounts and missing max_priority_fee field

### DIFF
--- a/lib/firmware/ethereum.c
+++ b/lib/firmware/ethereum.c
@@ -655,7 +655,8 @@ void ethereum_signing_init(EthereumSignTx* msg, const HDNode* node,
     return;
   }
 
-  if (ethereum_tx_type == ETHEREUM_TX_TYPE_EIP_1559 && !msg->has_max_fee_per_gas) {
+  if (ethereum_tx_type == ETHEREUM_TX_TYPE_EIP_1559 &&
+      !msg->has_max_fee_per_gas) {
     fsm_sendFailure(FailureType_Failure_SyntaxError,
                     _("EIP-1559 transactions require max_fee_per_gas"));
     ethereum_signing_abort();

--- a/lib/firmware/ethereum.c
+++ b/lib/firmware/ethereum.c
@@ -803,9 +803,8 @@ void ethereum_signing_init(EthereumSignTx* msg, const HDNode* node,
 
   rlp_length += rlp_calculate_length(msg->nonce.size, msg->nonce.bytes[0]);
   if (msg->has_max_fee_per_gas) {
-    rlp_length +=
-        rlp_calculate_length(msg->max_priority_fee_per_gas.size,
-                             msg->max_priority_fee_per_gas.bytes[0]);
+    rlp_length += rlp_calculate_length(msg->max_priority_fee_per_gas.size,
+                                       msg->max_priority_fee_per_gas.bytes[0]);
     rlp_length += rlp_calculate_length(msg->max_fee_per_gas.size,
                                        msg->max_fee_per_gas.bytes[0]);
   } else {

--- a/lib/firmware/ethereum.c
+++ b/lib/firmware/ethereum.c
@@ -517,9 +517,6 @@ static void formatEthereumFeeEIP1559(
   bn_read_be(pad_val, &max_pfee);
 
   bn_add(fee, &max_fee);
-  if (max_priority_fee_per_gas_len) {
-    bn_add(fee, &max_pfee);
-  }
 }
 
 static void layoutEthereumFee(const EthereumSignTx* msg, bool is_token,
@@ -806,11 +803,9 @@ void ethereum_signing_init(EthereumSignTx* msg, const HDNode* node,
 
   rlp_length += rlp_calculate_length(msg->nonce.size, msg->nonce.bytes[0]);
   if (msg->has_max_fee_per_gas) {
-    if (msg->has_max_priority_fee_per_gas) {
-      rlp_length +=
-          rlp_calculate_length(msg->max_priority_fee_per_gas.size,
-                               msg->max_priority_fee_per_gas.bytes[0]);
-    }
+    rlp_length +=
+        rlp_calculate_length(msg->max_priority_fee_per_gas.size,
+                             msg->max_priority_fee_per_gas.bytes[0]);
     rlp_length += rlp_calculate_length(msg->max_fee_per_gas.size,
                                        msg->max_fee_per_gas.bytes[0]);
   } else {
@@ -871,10 +866,8 @@ void ethereum_signing_init(EthereumSignTx* msg, const HDNode* node,
   hash_rlp_field(msg->nonce.bytes, msg->nonce.size);
 
   if (msg->has_max_fee_per_gas) {
-    if (msg->has_max_priority_fee_per_gas) {
-      hash_rlp_field(msg->max_priority_fee_per_gas.bytes,
-                     msg->max_priority_fee_per_gas.size);
-    }
+    hash_rlp_field(msg->max_priority_fee_per_gas.bytes,
+                   msg->max_priority_fee_per_gas.size);
     hash_rlp_field(msg->max_fee_per_gas.bytes, msg->max_fee_per_gas.size);
   } else {
     hash_rlp_field(msg->gas_price.bytes, msg->gas_price.size);

--- a/lib/firmware/ethereum.c
+++ b/lib/firmware/ethereum.c
@@ -180,7 +180,7 @@ static void hash_rlp_list_length(uint32_t length) {
  * Push an RLP encoded length field and data to the hash buffer.
  */
 static void hash_rlp_field(const uint8_t* buf, size_t size) {
-  hash_rlp_length(size, buf[0]);
+  hash_rlp_length(size, size ? buf[0] : 0);
   hash_data(buf, size);
 }
 
@@ -810,8 +810,11 @@ void ethereum_signing_init(EthereumSignTx* msg, const HDNode* node,
 
   rlp_length += rlp_calculate_length(msg->nonce.size, msg->nonce.bytes[0]);
   if (ethereum_tx_type == ETHEREUM_TX_TYPE_EIP_1559) {
-    rlp_length += rlp_calculate_length(msg->max_priority_fee_per_gas.size,
-                                       msg->max_priority_fee_per_gas.bytes[0]);
+    rlp_length +=
+        rlp_calculate_length(msg->max_priority_fee_per_gas.size,
+                             msg->max_priority_fee_per_gas.size
+                                 ? msg->max_priority_fee_per_gas.bytes[0]
+                                 : 0);
     rlp_length += rlp_calculate_length(msg->max_fee_per_gas.size,
                                        msg->max_fee_per_gas.bytes[0]);
   } else {

--- a/lib/firmware/ethereum.c
+++ b/lib/firmware/ethereum.c
@@ -523,7 +523,7 @@ static void layoutEthereumFee(const EthereumSignTx* msg, bool is_token,
   memzero(gas_value, sizeof(gas_value));
   memzero(tx_value, sizeof(tx_value));
 
-  if (msg->has_max_fee_per_gas) {
+  if (ethereum_tx_type == ETHEREUM_TX_TYPE_EIP_1559) {
     formatEthereumFeeEIP1559(&val, msg->max_fee_per_gas.bytes,
                              msg->max_fee_per_gas.size);
   } else {
@@ -659,6 +659,13 @@ void ethereum_signing_init(EthereumSignTx* msg, const HDNode* node,
       !msg->has_max_fee_per_gas) {
     fsm_sendFailure(FailureType_Failure_SyntaxError,
                     _("EIP-1559 transactions require max_fee_per_gas"));
+    ethereum_signing_abort();
+    return;
+  }
+
+  if (ethereum_tx_type == ETHEREUM_TX_TYPE_LEGACY && !msg->has_gas_price) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Legacy transactions require gas_price"));
     ethereum_signing_abort();
     return;
   }

--- a/lib/firmware/ethereum.c
+++ b/lib/firmware/ethereum.c
@@ -497,11 +497,10 @@ static void formatEthereumFee(bignum256* fee, const uint8_t* gas_price,
   bn_read_be(pad_val, fee);
 }
 
-static void formatEthereumFeeEIP1559(
-    bignum256* fee, const uint8_t* max_fee_per_gas,
-    const uint8_t max_fee_per_gas_len, const uint8_t* max_priority_fee_per_gas,
-    const uint8_t max_priority_fee_per_gas_len) {
-  bignum256 max_fee, max_pfee;
+static void formatEthereumFeeEIP1559(bignum256* fee,
+                                     const uint8_t* max_fee_per_gas,
+                                     const uint8_t max_fee_per_gas_len) {
+  bignum256 max_fee;
   uint8_t pad_val[32];
 
   bn_zero(fee);
@@ -510,11 +509,6 @@ static void formatEthereumFeeEIP1559(
   memcpy(pad_val + (32 - max_fee_per_gas_len), max_fee_per_gas,
          max_fee_per_gas_len);
   bn_read_be(pad_val, &max_fee);
-
-  memset(pad_val, 0, sizeof(pad_val));
-  memcpy(pad_val + (32 - max_priority_fee_per_gas_len),
-         max_priority_fee_per_gas, max_priority_fee_per_gas_len);
-  bn_read_be(pad_val, &max_pfee);
 
   bn_add(fee, &max_fee);
 }
@@ -531,9 +525,7 @@ static void layoutEthereumFee(const EthereumSignTx* msg, bool is_token,
 
   if (msg->has_max_fee_per_gas) {
     formatEthereumFeeEIP1559(&val, msg->max_fee_per_gas.bytes,
-                             msg->max_fee_per_gas.size,
-                             msg->max_priority_fee_per_gas.bytes,
-                             msg->max_priority_fee_per_gas.size);
+                             msg->max_fee_per_gas.size);
   } else {
     formatEthereumFee(&val, msg->gas_price.bytes, msg->gas_price.size);
   }
@@ -659,6 +651,13 @@ void ethereum_signing_init(EthereumSignTx* msg, const HDNode* node,
   if (ethereum_tx_type == ETHEREUM_TX_TYPE_EIP_1559 && chain_id == 0) {
     fsm_sendFailure(FailureType_Failure_SyntaxError,
                     _("EIP-1559 transactions require chain_id"));
+    ethereum_signing_abort();
+    return;
+  }
+
+  if (ethereum_tx_type == ETHEREUM_TX_TYPE_EIP_1559 && !msg->has_max_fee_per_gas) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("EIP-1559 transactions require max_fee_per_gas"));
     ethereum_signing_abort();
     return;
   }
@@ -802,7 +801,7 @@ void ethereum_signing_init(EthereumSignTx* msg, const HDNode* node,
   }
 
   rlp_length += rlp_calculate_length(msg->nonce.size, msg->nonce.bytes[0]);
-  if (msg->has_max_fee_per_gas) {
+  if (ethereum_tx_type == ETHEREUM_TX_TYPE_EIP_1559) {
     rlp_length += rlp_calculate_length(msg->max_priority_fee_per_gas.size,
                                        msg->max_priority_fee_per_gas.bytes[0]);
     rlp_length += rlp_calculate_length(msg->max_fee_per_gas.size,
@@ -864,7 +863,7 @@ void ethereum_signing_init(EthereumSignTx* msg, const HDNode* node,
 
   hash_rlp_field(msg->nonce.bytes, msg->nonce.size);
 
-  if (msg->has_max_fee_per_gas) {
+  if (ethereum_tx_type == ETHEREUM_TX_TYPE_EIP_1559) {
     hash_rlp_field(msg->max_priority_fee_per_gas.bytes,
                    msg->max_priority_fee_per_gas.size);
     hash_rlp_field(msg->max_fee_per_gas.bytes, msg->max_fee_per_gas.size);


### PR DESCRIPTION
Two related EIP-1559 bugs found during a full audit of `ethereum_signing_init()`.

## Bug 1 — Fee display overcounts (display only)

`formatEthereumFeeEIP1559()` computed the fee rate as:
```c
bn_add(fee, &max_fee);
bn_add(fee, &max_pfee);   // ← wrong
```
Then multiplied by `gas_limit`. The user saw `(max_fee_per_gas + max_priority_fee_per_gas) × gas_limit`.

The correct maximum cost is `max_fee_per_gas × gas_limit`. The priority fee is a validator tip — it is a component of `max_fee_per_gas`, not additive. The code double-counted the tip, overstating the fee to the user by `max_priority_fee_per_gas × gas_limit`.

**Fix:** remove the `bn_add(fee, &max_pfee)` block.

## Bug 2 — Missing `max_priority_fee_per_gas` produces invalid EIP-1559 tx

EIP-1559 requires exactly 9 fields in the RLP list:
```
[chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to, value, data, access_list]
```

Both the length calculation and the hash skipped `max_priority_fee_per_gas` when `has_max_priority_fee_per_gas = false`:

```c
if (msg->has_max_priority_fee_per_gas) {
    rlp_length += rlp_calculate_length(...);   // skipped if not set
}
// ...
if (msg->has_max_priority_fee_per_gas) {
    hash_rlp_field(...);   // skipped if not set
}
```

If the field was absent, the firmware produced an 8-field RLP list. The list header claimed the correct byte count (because length calculation also skipped it), so the hash itself wasn't corrupted, but the resulting transaction was non-decodable per EIP-1559 and would be rejected by any node.

**Fix:** remove the `has_max_priority_fee_per_gas` guards. nanopb zero-initialises unset fields, so `size = 0` encodes as `0x80` (the correct RLP for integer 0 / empty byte string), which is valid for `max_priority_fee_per_gas = 0`.

## Notes

- These are found as part of a full EIP-1559 audit following PR #427 (chain_id hash bug) and PR #428 (missing chain_id validation)
- Neither bug is currently triggered by known hosts — hdwallet always sends `max_priority_fee_per_gas`
- The fee display bug overstates cost (safe direction of error), but incorrect