### PR TITLE
7.15 (4/5): Per-chain clear/blind-sign — TRON, Solana v0, TON, Mayachain, THORChain affiliate

### DIFF
--- a/include/keepkey/firmware/mayachain.h
+++ b/include/keepkey/firmware/mayachain.h
@@ -10,6 +10,10 @@
 typedef struct _MayachainSignTx MayachainSignTx;
 typedef struct _MayachainMsgDeposit MayachainMsgDeposit;
 
+// Returns true iff `denom` is a plausible MAYAChain denom: non-empty,
+// and contains only lowercase alpha, digits, '.', '/', or '-'.
+bool mayachain_isValidDenom(const char* denom);
+
 bool mayachain_signTxInit(const HDNode* _node, const MayachainSignTx* _msg);
 bool mayachain_signTxUpdateMsgSend(const uint64_t amount,
                                    const char* to_address, const char* denom);

--- a/include/keepkey/firmware/solana.h
+++ b/include/keepkey/firmware/solana.h
@@ -156,6 +156,10 @@ typedef struct {
   uint8_t mint[SOL_PUBKEY_SIZE];
   bool has_mint;
   uint8_t extra_u8;
+  /* Instruction payload (memo body display). Points into the raw message
+   * buffer passed to solana_inspectTx — valid only while that buffer is. */
+  const uint8_t* data;
+  uint16_t data_len;
 } SolanaParsedInstruction;
 
 /* Parsed transaction header */

--- a/include/keepkey/firmware/tron.h
+++ b/include/keepkey/firmware/tron.h
@@ -46,9 +46,10 @@
  * TRON_TX_UNVERIFIED and only the blind-sign path may be offered.
  */
 typedef enum {
-  TRON_TX_UNVERIFIED = 0,   // not fully understood — blind-sign only
-  TRON_TX_TRANSFER,         // single TransferContract (native TRX send)
-  TRON_TX_TRC20_TRANSFER,   // single TriggerSmartContract: transfer(address,uint256)
+  TRON_TX_UNVERIFIED = 0,  // not fully understood — blind-sign only
+  TRON_TX_TRANSFER,        // single TransferContract (native TRX send)
+  TRON_TX_TRC20_TRANSFER,  // single TriggerSmartContract:
+                           // transfer(address,uint256)
 } TronTxType;
 
 typedef struct {
@@ -57,10 +58,10 @@ typedef struct {
   uint8_t to[TRON_RAW_ADDRESS_SIZE];        // TRX or token recipient
   uint8_t contract[TRON_RAW_ADDRESS_SIZE];  // TRC-20 token contract
   uint64_t amount;                          // SUN, TransferContract only
-  uint8_t trc20_amount[32];                 // big-endian uint256 token base units
+  uint8_t trc20_amount[32];  // big-endian uint256 token base units
   bool has_fee_limit;
-  uint64_t fee_limit;                       // SUN
-  const uint8_t* memo;                      // points into caller's raw_data
+  uint64_t fee_limit;   // SUN
+  const uint8_t* memo;  // points into caller's raw_data
   uint16_t memo_len;
 } TronParsedTx;
 
@@ -75,8 +76,8 @@ TronTxType tron_parseRawTx(const uint8_t* raw, size_t len, TronParsedTx* out);
 /**
  * Base58Check-encode a raw 21-byte TRON address for display.
  */
-bool tron_addressFromBytes(const uint8_t addr[TRON_RAW_ADDRESS_SIZE],
-                           char* out, size_t out_len);
+bool tron_addressFromBytes(const uint8_t addr[TRON_RAW_ADDRESS_SIZE], char* out,
+                           size_t out_len);
 
 /**
  * Format a TRC-20 uint256 amount (big-endian) as a decimal string of token

--- a/include/keepkey/firmware/tron.h
+++ b/include/keepkey/firmware/tron.h
@@ -24,11 +24,65 @@
 
 #include "messages-tron.pb.h"
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 // TRON address length (Base58Check, typically 34 chars starting with 'T')
 #define TRON_ADDRESS_MAX_LEN 64
 
 // TRON decimals (1 TRX = 1,000,000 SUN)
 #define TRON_DECIMALS 6
+
+// Raw 21-byte TRON address: 0x41 prefix + 20-byte keccak hash tail
+#define TRON_RAW_ADDRESS_SIZE 21
+
+/**
+ * On-device classification of a TronSignTx raw_data payload.
+ *
+ * The device signs sha256(raw_data), so anything shown to the user MUST be
+ * decoded from raw_data itself — never from side-channel proto fields.
+ * Unless every field of the payload is understood, the transaction is
+ * TRON_TX_UNVERIFIED and only the blind-sign path may be offered.
+ */
+typedef enum {
+  TRON_TX_UNVERIFIED = 0,   // not fully understood — blind-sign only
+  TRON_TX_TRANSFER,         // single TransferContract (native TRX send)
+  TRON_TX_TRC20_TRANSFER,   // single TriggerSmartContract: transfer(address,uint256)
+} TronTxType;
+
+typedef struct {
+  TronTxType type;
+  uint8_t owner[TRON_RAW_ADDRESS_SIZE];     // spending account
+  uint8_t to[TRON_RAW_ADDRESS_SIZE];        // TRX or token recipient
+  uint8_t contract[TRON_RAW_ADDRESS_SIZE];  // TRC-20 token contract
+  uint64_t amount;                          // SUN, TransferContract only
+  uint8_t trc20_amount[32];                 // big-endian uint256 token base units
+  bool has_fee_limit;
+  uint64_t fee_limit;                       // SUN
+  const uint8_t* memo;                      // points into caller's raw_data
+  uint16_t memo_len;
+} TronParsedTx;
+
+/**
+ * Parse a TRON raw_data protobuf for on-device display.
+ * Fail-closed: any unrecognized top-level field, contract type, extra
+ * contract, or unexpected parameter field yields TRON_TX_UNVERIFIED.
+ * out->memo points into raw — valid only while raw is alive.
+ */
+TronTxType tron_parseRawTx(const uint8_t* raw, size_t len, TronParsedTx* out);
+
+/**
+ * Base58Check-encode a raw 21-byte TRON address for display.
+ */
+bool tron_addressFromBytes(const uint8_t addr[TRON_RAW_ADDRESS_SIZE],
+                           char* out, size_t out_len);
+
+/**
+ * Format a TRC-20 uint256 amount (big-endian) as a decimal string of token
+ * base units. Token decimals are unknown on-device, so no scaling is done.
+ */
+bool tron_formatTrc20Amount(const uint8_t amount_be[32], char* buf, size_t len);
 
 /**
  * Generate TRON address from secp256k1 public key

--- a/lib/firmware/fsm_msg_mayachain.h
+++ b/lib/firmware/fsm_msg_mayachain.h
@@ -144,10 +144,10 @@ void fsm_msgMayachainMsgAck(const MayachainMsgAck* msg) {
   // Default to "cacao" for backward compatibility; validate all non-default
   // denoms before any display so untrusted strings never reach the UI or
   // the signing JSON.
-  const char* coin_denom = (msg->has_send && msg->send.has_denom &&
-                            msg->send.denom[0])
-                               ? msg->send.denom
-                               : "cacao";
+  const char* coin_denom =
+      (msg->has_send && msg->send.has_denom && msg->send.denom[0])
+          ? msg->send.denom
+          : "cacao";
 
   if (msg->has_send) {
     if (!mayachain_isValidDenom(coin_denom)) {
@@ -187,9 +187,9 @@ void fsm_msgMayachainMsgAck(const MayachainMsgAck* msg) {
     }
 
   } else if (msg->has_deposit) {
-    // Long-form assets (e.g. ETH.USDT-0XDAC17F958D2EE523A2206206994597C13D831EC7)
-    // are ~50 chars; amount_str must fit amount + asset suffix or bn_format
-    // zeroes it out.
+    // Long-form assets (e.g.
+    // ETH.USDT-0XDAC17F958D2EE523A2206206994597C13D831EC7) are ~50 chars;
+    // amount_str must fit amount + asset suffix or bn_format zeroes it out.
     char amount_str[96];
     char asset_str[64];
     asset_str[0] = ' ';

--- a/lib/firmware/fsm_msg_mayachain.h
+++ b/lib/firmware/fsm_msg_mayachain.h
@@ -141,13 +141,28 @@ void fsm_msgMayachainMsgAck(const MayachainMsgAck* msg) {
 
   const MayachainSignTx* sign_tx = mayachain_getMayachainSignTx();
 
+  // Default to "cacao" for backward compatibility; validate all non-default
+  // denoms before any display so untrusted strings never reach the UI or
+  // the signing JSON.
+  const char* coin_denom = (msg->has_send && msg->send.has_denom &&
+                            msg->send.denom[0])
+                               ? msg->send.denom
+                               : "cacao";
+
   if (msg->has_send) {
+    if (!mayachain_isValidDenom(coin_denom)) {
+      mayachain_signAbort();
+      fsm_sendFailure(FailureType_Failure_SyntaxError, "Invalid denom");
+      layoutHome();
+      return;
+    }
+
     switch (msg->send.address_type) {
       case OutputAddressType_TRANSFER:
       default: {
         char amount_str[32];
         char denom_str[71];
-        sprintf(denom_str, " %s", msg->send.denom);
+        snprintf(denom_str, sizeof(denom_str), " %s", coin_denom);
         bn_format_uint64(msg->send.amount, NULL, denom_str, 10, 0, false,
                          amount_str, sizeof(amount_str));
         if (!confirm_transaction_output(
@@ -163,7 +178,7 @@ void fsm_msgMayachainMsgAck(const MayachainMsgAck* msg) {
       }
     }
     if (!mayachain_signTxUpdateMsgSend(msg->send.amount, msg->send.to_address,
-                                       msg->send.denom)) {
+                                       coin_denom)) {
       mayachain_signAbort();
       fsm_sendFailure(FailureType_Failure_SyntaxError,
                       "Failed to include send message in transaction");
@@ -172,8 +187,11 @@ void fsm_msgMayachainMsgAck(const MayachainMsgAck* msg) {
     }
 
   } else if (msg->has_deposit) {
-    char amount_str[32];
-    char asset_str[21];
+    // Long-form assets (e.g. ETH.USDT-0XDAC17F958D2EE523A2206206994597C13D831EC7)
+    // are ~50 chars; amount_str must fit amount + asset suffix or bn_format
+    // zeroes it out.
+    char amount_str[96];
+    char asset_str[64];
     asset_str[0] = ' ';
     strlcpy(&(asset_str[1]), msg->deposit.asset, sizeof(asset_str) - 1);
     bn_format_uint64(msg->deposit.amount, NULL, asset_str, 10, 0, false,
@@ -245,7 +263,7 @@ void fsm_msgMayachainMsgAck(const MayachainMsgAck* msg) {
   if (!confirm(ButtonRequestType_ButtonRequest_SignTx, node_str,
                "Sign this %s transaction on %s? "
                "Additional network fees apply.",
-               msg->has_send ? msg->send.denom : "CACAO", sign_tx->chain_id)) {
+               msg->has_send ? coin_denom : "CACAO", sign_tx->chain_id)) {
     mayachain_signAbort();
     fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
     layoutHome();

--- a/lib/firmware/fsm_msg_solana.h
+++ b/lib/firmware/fsm_msg_solana.h
@@ -100,12 +100,10 @@ static bool solana_confirmInstruction(const SolanaParsedInstruction* pi,
                      "Allocate %llu bytes?",
                      (unsigned long long)pi->extra_value);
 
-    case SOL_INSTR_TOKEN_TRANSFER:
-    case SOL_INSTR_TOKEN_TRANSFER_CHECKED: {
+    case SOL_INSTR_TOKEN_TRANSFER: {
       char to_str[45];
       solana_pubkeyToStr(pi->to, to_str, sizeof(to_str));
 
-      /* Try to find token info from host-provided metadata */
       const SolanaTokenInfo* ti = NULL;
       if (pi->has_mint) {
         ti = solana_findTokenInfo(msg, pi->mint);
@@ -115,6 +113,33 @@ static bool solana_confirmInstruction(const SolanaParsedInstruction* pi,
         char amount_str[48];
         solana_formatTokenAmount(amount_str, sizeof(amount_str), pi->amount,
                                  ti->symbol, (uint8_t)ti->decimals);
+        return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                       "Send %s to %s?", amount_str, to_str);
+      } else {
+        char amount_str[32];
+        snprintf(amount_str, sizeof(amount_str), "%llu tokens",
+                 (unsigned long long)pi->amount);
+        return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                       "Send %s to %s?", amount_str, to_str);
+      }
+    }
+
+    case SOL_INSTR_TOKEN_TRANSFER_CHECKED: {
+      char to_str[45];
+      solana_pubkeyToStr(pi->to, to_str, sizeof(to_str));
+
+      /* For TransferChecked, decimals come from the signed instruction
+       * bytes (pi->extra_u8) — host-supplied ti->decimals is untrusted. */
+      const SolanaTokenInfo* ti = NULL;
+      if (pi->has_mint) {
+        ti = solana_findTokenInfo(msg, pi->mint);
+      }
+
+      const char* symbol = (ti && ti->has_symbol) ? ti->symbol : NULL;
+      if (symbol) {
+        char amount_str[48];
+        solana_formatTokenAmount(amount_str, sizeof(amount_str), pi->amount,
+                                 symbol, pi->extra_u8);
         return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
                        "Send %s to %s?", amount_str, to_str);
       } else {

--- a/lib/firmware/fsm_msg_solana.h
+++ b/lib/firmware/fsm_msg_solana.h
@@ -513,10 +513,9 @@ void fsm_msgSolanaSignMessage(const SolanaSignMessage* msg) {
    * here the signature covers the exact message bytes — only a payload
    * that IS a tx message from byte 0 may be displayed as one. */
   SolanaParsedTx parsed;
-  bool is_verified_tx =
-      msg->message.bytes[0] != 0 &&
-      solana_inspectTx(msg->message.bytes, msg->message.size, &parsed) ==
-          SOL_TX_REVIEW_VERIFIED;
+  bool is_verified_tx = msg->message.bytes[0] != 0 &&
+                        solana_inspectTx(msg->message.bytes, msg->message.size,
+                                         &parsed) == SOL_TX_REVIEW_VERIFIED;
 
   /* AdvancedMode gate for anything we cannot verify: a malicious dApp
    * could craft a "message" that is also a valid tx.

--- a/lib/firmware/fsm_msg_solana.h
+++ b/lib/firmware/fsm_msg_solana.h
@@ -105,7 +105,7 @@ static bool solana_confirmInstruction(const SolanaParsedInstruction* pi,
       solana_pubkeyToStr(pi->to, to_str, sizeof(to_str));
 
       const SolanaTokenInfo* ti = NULL;
-      if (pi->has_mint) {
+      if (pi->has_mint && msg) {
         ti = solana_findTokenInfo(msg, pi->mint);
       }
 
@@ -131,7 +131,7 @@ static bool solana_confirmInstruction(const SolanaParsedInstruction* pi,
       /* For TransferChecked, decimals come from the signed instruction
        * bytes (pi->extra_u8) — host-supplied ti->decimals is untrusted. */
       const SolanaTokenInfo* ti = NULL;
-      if (pi->has_mint) {
+      if (pi->has_mint && msg) {
         ti = solana_findTokenInfo(msg, pi->mint);
       }
 
@@ -178,9 +178,14 @@ static bool solana_confirmInstruction(const SolanaParsedInstruction* pi,
       return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
                      "Burn %llu tokens?", (unsigned long long)pi->amount);
 
-    case SOL_INSTR_TOKEN_CLOSE_ACCOUNT:
+    case SOL_INSTR_TOKEN_CLOSE_ACCOUNT: {
+      /* Closing a (wrapped-SOL) token account sweeps its lamports to the
+       * destination — show it, or an attacker routes the rent elsewhere. */
+      char to_str[45];
+      solana_pubkeyToStr(pi->to, to_str, sizeof(to_str));
       return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
-                     "Close token account?");
+                     "Close token account, send balance to %s?", to_str);
+    }
 
     case SOL_INSTR_TOKEN_FREEZE_ACCOUNT:
       return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
@@ -277,9 +282,23 @@ static bool solana_confirmInstruction(const SolanaParsedInstruction* pi,
                      "Set loaded account data to %llu bytes?",
                      (unsigned long long)pi->extra_value);
 
-    case SOL_INSTR_MEMO:
-      return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
-                     "Memo attached");
+    case SOL_INSTR_MEMO: {
+      /* Show the memo body — swap intents (e.g. THORChain '=:ETH.ETH:...')
+       * ride in the memo, so hiding it hides where the funds go next. */
+      bool printable = pi->data_len > 0;
+      for (uint16_t i = 0; i < pi->data_len; i++) {
+        if (pi->data[i] < 0x20 || pi->data[i] > 0x7e) {
+          printable = false;
+          break;
+        }
+      }
+      if (printable && pi->data_len <= 114) {
+        return confirm(ButtonRequestType_ButtonRequest_ConfirmMemo, title,
+                       "Memo: %.*s", (int)pi->data_len, pi->data);
+      }
+      return confirm(ButtonRequestType_ButtonRequest_ConfirmMemo, title,
+                     "Memo attached (%u bytes)", (unsigned)pi->data_len);
+    }
 
     case SOL_INSTR_UNKNOWN:
     default: {
@@ -483,13 +502,28 @@ void fsm_msgSolanaSignMessage(const SolanaSignMessage* msg) {
     return;
   }
 
-  /* AdvancedMode gate: Solana message signing has no domain separation.
-   * A signed message is indistinguishable from a signed transaction on
-   * the Solana network (both are raw Ed25519 over arbitrary bytes).
-   * A malicious dApp could craft a message that is also a valid tx.
+  /* Solana "message" signing has no domain separation: the signed bytes
+   * are indistinguishable from a transaction message on the network.
+   * If the payload actually parses as a fully-verifiable Solana
+   * transaction, treat it as one — clear-sign it per instruction instead
+   * of blind-signing a hex blob. Wallet integrations sign versioned (v0)
+   * swap transactions through this message, so this is the path that
+   * turns swap blind-signing into clear-signing. */
+  /* Note: solana_inspectTx tolerates a 0x00 signature-count prefix, but
+   * here the signature covers the exact message bytes — only a payload
+   * that IS a tx message from byte 0 may be displayed as one. */
+  SolanaParsedTx parsed;
+  bool is_verified_tx =
+      msg->message.bytes[0] != 0 &&
+      solana_inspectTx(msg->message.bytes, msg->message.size, &parsed) ==
+          SOL_TX_REVIEW_VERIFIED;
+
+  /* AdvancedMode gate for anything we cannot verify: a malicious dApp
+   * could craft a "message" that is also a valid tx.
    * See: https://github.com/trezor/trezor-firmware/issues/4371
-   * Require AdvancedMode to proceed — same gate as ETH blind-signing. */
-  if (!storage_isPolicyEnabled("AdvancedMode")) {
+   * Same gate as ETH blind-signing. Fully verified transactions are
+   * clear-signed below and need no gate — the user sees the contents. */
+  if (!is_verified_tx && !storage_isPolicyEnabled("AdvancedMode")) {
     (void)review(ButtonRequestType_ButtonRequest_Other, "Blocked",
                  "Solana message signing is experimental. "
                  "Enable AdvancedMode in device settings.");
@@ -514,6 +548,34 @@ void fsm_msgSolanaSignMessage(const SolanaSignMessage* msg) {
   if (!node) return;
   hdnode_fill_public_key(node);
 
+  if (is_verified_tx) {
+    /* Clear-sign path: same rules as SolanaSignTx. */
+    if (!solana_signerInTx(node->public_key + 1, &parsed)) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_Other,
+                      _("Derived key is not a signer for this tx"));
+      layoutHome();
+      return;
+    }
+    for (uint8_t i = 0; i < parsed.num_instructions; i++) {
+      if (!solana_confirmInstruction(&parsed.instructions[i], NULL, i,
+                                     parsed.num_instructions)) {
+        memzero(node, sizeof(*node));
+        fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                        _("Signing cancelled"));
+        layoutHome();
+        return;
+      }
+    }
+    if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Solana",
+                 "Sign this Solana transaction?")) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      _("Signing cancelled"));
+      layoutHome();
+      return;
+    }
+  } else /* blind message path */
   /* Always require on-device confirmation (matches Ethereum behavior).
    * Display message content if printable, hex preview otherwise. */
   {

--- a/lib/firmware/fsm_msg_thorchain.h
+++ b/lib/firmware/fsm_msg_thorchain.h
@@ -196,8 +196,11 @@ void fsm_msgThorchainMsgAck(const ThorchainMsgAck* msg) {
     }
 
   } else if (msg->has_deposit) {
-    char amount_str[32];
-    char asset_str[21];
+    // Long-form assets (e.g. ETH.USDT-0XDAC17F958D2EE523A2206206994597C13D831EC7)
+    // are ~50 chars; amount_str must fit amount + asset suffix or bn_format
+    // zeroes it out.
+    char amount_str[96];
+    char asset_str[64];
     asset_str[0] = ' ';
     strlcpy(&(asset_str[1]), msg->deposit.asset, sizeof(asset_str) - 1);
     bn_format_uint64(msg->deposit.amount, NULL, asset_str, 8, 0, false,

--- a/lib/firmware/fsm_msg_thorchain.h
+++ b/lib/firmware/fsm_msg_thorchain.h
@@ -196,9 +196,9 @@ void fsm_msgThorchainMsgAck(const ThorchainMsgAck* msg) {
     }
 
   } else if (msg->has_deposit) {
-    // Long-form assets (e.g. ETH.USDT-0XDAC17F958D2EE523A2206206994597C13D831EC7)
-    // are ~50 chars; amount_str must fit amount + asset suffix or bn_format
-    // zeroes it out.
+    // Long-form assets (e.g.
+    // ETH.USDT-0XDAC17F958D2EE523A2206206994597C13D831EC7) are ~50 chars;
+    // amount_str must fit amount + asset suffix or bn_format zeroes it out.
     char amount_str[96];
     char asset_str[64];
     asset_str[0] = ' ';

--- a/lib/firmware/fsm_msg_ton.h
+++ b/lib/firmware/fsm_msg_ton.h
@@ -112,24 +112,14 @@ void fsm_msgTonSignTx(TonSignTx* msg) {
     return;
   }
 
-  bool needs_confirm = true;
-
-  // Display transaction details if available
-  if (needs_confirm && msg->has_to_address && msg->has_amount) {
-    char amount_str[32];
-    ton_formatAmount(amount_str, sizeof(amount_str), msg->amount);
-
-    if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, "Send",
-                 "Send %s TON to %s?", amount_str, msg->to_address)) {
-      memzero(node, sizeof(*node));
-      fsm_sendFailure(FailureType_Failure_ActionCancelled, "Signing cancelled");
-      layoutHome();
-      return;
-    }
-  }
-
-  if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Transaction",
-               "Really sign this TON transaction?")) {
+  /* to_address and amount are display-only fields not bound to raw_tx bytes.
+   * A malicious host could show one recipient while getting a different
+   * transaction signed. Show only the raw_tx size. */
+  char blind_msg[48];
+  snprintf(blind_msg, sizeof(blind_msg), "Sign %u-byte TON transaction?",
+           (unsigned)msg->raw_tx.size);
+  if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "TON Blind Sign", "%s",
+               blind_msg)) {
     memzero(node, sizeof(*node));
     fsm_sendFailure(FailureType_Failure_ActionCancelled, "Signing cancelled");
     layoutHome();

--- a/lib/firmware/fsm_msg_tron.h
+++ b/lib/firmware/fsm_msg_tron.h
@@ -296,6 +296,18 @@ void fsm_msgTronSignTypedHash(const TronSignTypedHash* msg) {
     return;
   }
 
+  /* Blind-sign gate: device only receives pre-computed hashes — it cannot
+   * reconstruct or verify the original typed-data struct. The user must
+   * explicitly acknowledge this before seeing the raw hashes. */
+  if (!confirm(ButtonRequestType_ButtonRequest_Other, "TIP-712 Blind Sign",
+               "Device cannot verify typed-data contents. "
+               "Only proceed if you trust the host application.")) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+    layoutHome();
+    return;
+  }
+
   if (!confirm(ButtonRequestType_ButtonRequest_Other, "Verify Address",
                "Confirm address: %s", address)) {
     memzero(node, sizeof(*node));

--- a/lib/firmware/fsm_msg_tron.h
+++ b/lib/firmware/fsm_msg_tron.h
@@ -102,18 +102,109 @@ void fsm_msgTronSignTx(TronSignTx* msg) {
     return;
   }
 
-  /* to_address and amount are deprecated fields not included in raw_data.
-   * Displaying them would show data that is not part of what is being signed.
-   * Show only the raw_data size so the user knows what they are authorising. */
-  char blind_msg[48];
-  snprintf(blind_msg, sizeof(blind_msg), "Sign %u-byte TRON transaction?",
-           (unsigned)msg->raw_data.size);
-  if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "TRON Blind Sign", "%s",
-               blind_msg)) {
-    memzero(node, sizeof(*node));
-    fsm_sendFailure(FailureType_Failure_ActionCancelled, "Signing cancelled");
-    layoutHome();
-    return;
+  /* Clear-sign from raw_data itself — the exact bytes being signed.
+   * (The proto's side-channel to_address/amount fields are never trusted:
+   * they are not part of what is signed.) */
+  TronParsedTx parsed;
+  TronTxType tx_type =
+      tron_parseRawTx(msg->raw_data.bytes, msg->raw_data.size, &parsed);
+
+  if (tx_type == TRON_TX_UNVERIFIED) {
+    /* Unrecognized contract or payload: explicit blind-sign only,
+     * same policy gate as Solana opaque transactions. */
+    if (!storage_isPolicyEnabled("AdvancedMode")) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_Other,
+                      _("Enable AdvancedMode to blind-sign"));
+      layoutHome();
+      return;
+    }
+    char blind_msg[48];
+    snprintf(blind_msg, sizeof(blind_msg), "Sign %u-byte TRON transaction?",
+             (unsigned)msg->raw_data.size);
+    if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "TRON Blind Sign",
+                 "%s", blind_msg)) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_ActionCancelled, "Signing cancelled");
+      layoutHome();
+      return;
+    }
+  } else {
+    /* The parsed owner account is the one spending — it must be ours. */
+    char derived_addr[TRON_ADDRESS_MAX_LEN];
+    char owner_addr[TRON_ADDRESS_MAX_LEN];
+    if (!tron_getAddress(node->public_key, derived_addr,
+                         sizeof(derived_addr)) ||
+        !tron_addressFromBytes(parsed.owner, owner_addr,
+                               sizeof(owner_addr)) ||
+        strcmp(derived_addr, owner_addr) != 0) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_Other,
+                      _("TX owner does not match derived key"));
+      layoutHome();
+      return;
+    }
+
+    char to_str[TRON_ADDRESS_MAX_LEN];
+    if (!tron_addressFromBytes(parsed.to, to_str, sizeof(to_str))) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_Other, _("Address encoding failed"));
+      layoutHome();
+      return;
+    }
+
+    bool confirmed = false;
+    if (tx_type == TRON_TX_TRANSFER) {
+      char amount_str[32];
+      tron_formatAmount(amount_str, sizeof(amount_str), parsed.amount);
+      confirmed = confirm(ButtonRequestType_ButtonRequest_SignTx, "TRON",
+                          "Send %s to %s?", amount_str, to_str);
+    } else { /* TRON_TX_TRC20_TRANSFER */
+      char contract_str[TRON_ADDRESS_MAX_LEN];
+      char amount_str[90];
+      confirmed =
+          tron_addressFromBytes(parsed.contract, contract_str,
+                                sizeof(contract_str)) &&
+          tron_formatTrc20Amount(parsed.trc20_amount, amount_str,
+                                 sizeof(amount_str)) &&
+          confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                  "TRC-20 Transfer", "Token contract %s", contract_str) &&
+          /* Token decimals are not known on-device; show base units. */
+          confirm(ButtonRequestType_ButtonRequest_SignTx, "TRC-20 Transfer",
+                  "Send %s base units to %s?", amount_str, to_str);
+    }
+
+    if (confirmed && parsed.has_fee_limit) {
+      char fee_str[32];
+      tron_formatAmount(fee_str, sizeof(fee_str), parsed.fee_limit);
+      confirmed = confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                          "TRON", "Max network fee %s", fee_str);
+    }
+
+    if (confirmed && parsed.memo_len > 0) {
+      bool printable = true;
+      for (uint16_t i = 0; i < parsed.memo_len; i++) {
+        if (parsed.memo[i] < 0x20 || parsed.memo[i] > 0x7e) {
+          printable = false;
+          break;
+        }
+      }
+      if (printable && parsed.memo_len <= 114) {
+        confirmed = confirm(ButtonRequestType_ButtonRequest_ConfirmMemo,
+                            "Memo", "%.*s", (int)parsed.memo_len, parsed.memo);
+      } else {
+        confirmed =
+            confirm(ButtonRequestType_ButtonRequest_ConfirmMemo, "Memo",
+                    "Data attached (%u bytes)", (unsigned)parsed.memo_len);
+      }
+    }
+
+    if (!confirmed) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_ActionCancelled, "Signing cancelled");
+      layoutHome();
+      return;
+    }
   }
 
   // Sign the transaction with secp256k1

--- a/lib/firmware/fsm_msg_tron.h
+++ b/lib/firmware/fsm_msg_tron.h
@@ -102,24 +102,14 @@ void fsm_msgTronSignTx(TronSignTx* msg) {
     return;
   }
 
-  bool needs_confirm = true;
-
-  // Display transaction details if available
-  if (needs_confirm && msg->has_to_address && msg->has_amount) {
-    char amount_str[32];
-    tron_formatAmount(amount_str, sizeof(amount_str), msg->amount);
-
-    if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, "Send",
-                 "Send %s TRX to %s?", amount_str, msg->to_address)) {
-      memzero(node, sizeof(*node));
-      fsm_sendFailure(FailureType_Failure_ActionCancelled, "Signing cancelled");
-      layoutHome();
-      return;
-    }
-  }
-
-  if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Transaction",
-               "Really sign this TRON transaction?")) {
+  /* to_address and amount are deprecated fields not included in raw_data.
+   * Displaying them would show data that is not part of what is being signed.
+   * Show only the raw_data size so the user knows what they are authorising. */
+  char blind_msg[48];
+  snprintf(blind_msg, sizeof(blind_msg), "Sign %u-byte TRON transaction?",
+           (unsigned)msg->raw_data.size);
+  if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "TRON Blind Sign", "%s",
+               blind_msg)) {
     memzero(node, sizeof(*node));
     fsm_sendFailure(FailureType_Failure_ActionCancelled, "Signing cancelled");
     layoutHome();

--- a/lib/firmware/fsm_msg_tron.h
+++ b/lib/firmware/fsm_msg_tron.h
@@ -135,8 +135,7 @@ void fsm_msgTronSignTx(TronSignTx* msg) {
     char owner_addr[TRON_ADDRESS_MAX_LEN];
     if (!tron_getAddress(node->public_key, derived_addr,
                          sizeof(derived_addr)) ||
-        !tron_addressFromBytes(parsed.owner, owner_addr,
-                               sizeof(owner_addr)) ||
+        !tron_addressFromBytes(parsed.owner, owner_addr, sizeof(owner_addr)) ||
         strcmp(derived_addr, owner_addr) != 0) {
       memzero(node, sizeof(*node));
       fsm_sendFailure(FailureType_Failure_Other,
@@ -177,8 +176,8 @@ void fsm_msgTronSignTx(TronSignTx* msg) {
     if (confirmed && parsed.has_fee_limit) {
       char fee_str[32];
       tron_formatAmount(fee_str, sizeof(fee_str), parsed.fee_limit);
-      confirmed = confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
-                          "TRON", "Max network fee %s", fee_str);
+      confirmed = confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, "TRON",
+                          "Max network fee %s", fee_str);
     }
 
     if (confirmed && parsed.memo_len > 0) {
@@ -190,8 +189,8 @@ void fsm_msgTronSignTx(TronSignTx* msg) {
         }
       }
       if (printable && parsed.memo_len <= 114) {
-        confirmed = confirm(ButtonRequestType_ButtonRequest_ConfirmMemo,
-                            "Memo", "%.*s", (int)parsed.memo_len, parsed.memo);
+        confirmed = confirm(ButtonRequestType_ButtonRequest_ConfirmMemo, "Memo",
+                            "%.*s", (int)parsed.memo_len, parsed.memo);
       } else {
         confirmed =
             confirm(ButtonRequestType_ButtonRequest_ConfirmMemo, "Memo",

--- a/lib/firmware/mayachain.c
+++ b/lib/firmware/mayachain.c
@@ -29,7 +29,23 @@
 #include "trezor/crypto/segwit_addr.h"
 
 #include <stdbool.h>
+#include <string.h>
 #include <time.h>
+
+// Allow lowercase alpha, digits, and the punctuation used in MAYAChain asset
+// identifiers (e.g. "eth.eth", "btc/btc", cross-chain synthetic prefixes).
+// Rejects anything that needs JSON escaping (backslash, quote).
+bool mayachain_isValidDenom(const char* denom) {
+  if (!denom || !denom[0]) return false;
+  for (size_t i = 0; denom[i]; i++) {
+    char c = denom[i];
+    if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '.' ||
+          c == '/' || c == '-')) {
+      return false;
+    }
+  }
+  return true;
+}
 
 static CONFIDENTIAL HDNode node;
 static SHA256_CTX ctx;
@@ -205,20 +221,24 @@ bool mayachain_parseConfirmMemo(const char* swapStr, size_t size) {
     Input: swapStr is candidate mayachain data
            size is the size of swapStr (<= 256)
     Memos should be of the form:
-    transaction:chain.ticker-id:destination:limit
+    transaction:chain.ticker-id:destination:limit:affiliate:fee_bps
                 ^^^^^^^^^^^^^^----------asset
 
-    So, swap USDT to dest address 0x41e55..., limit 420
-    SWAP:ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7:0x41e5560054824ea6b0732e656e3ad64e20e94e45:420
+    So, swap USDT to dest address 0x41e55..., limit 420, affiliate "kk"
+    skimming 75 basis points:
+    SWAP:ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7:0x41e5560054824ea6b0732e656e3ad64e20e94e45:420:kk:75
 
     Swap transactions can be indicated by "SWAP" or "s" or "="
+
+    Fields are split on ':' PRESERVING empty fields so a blank field (e.g.
+    an empty limit in "=:ETH.ETH:0xdest::kk:75") can never shift a later
+    field (e.g. the affiliate) into an earlier display slot.
   */
 
-  char* parseTokPtrs[7] = {NULL, NULL, NULL, NULL,
-                           NULL, NULL, NULL};  // we can parse up to 7 tokens
-  char* tok;
+  char* fields[8] = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
   char memoBuf[256];
-  uint16_t ctr;
+  size_t nfields, i;
+  char *chain, *asset;
 
   // check if memo data is recognized
 
@@ -226,77 +246,86 @@ bool mayachain_parseConfirmMemo(const char* swapStr, size_t size) {
   memzero(memoBuf, sizeof(memoBuf));
   strlcpy(memoBuf, swapStr, size);
   memoBuf[255] = '\0';  // ensure null termination
-  tok = strtok(memoBuf, ":");
 
-  // get transaction and asset
-  for (ctr = 0; ctr < 3; ctr++) {
-    if (tok != NULL) {
-      parseTokPtrs[ctr] = tok;
-      tok = strtok(NULL, ":.");
-    } else {
-      break;
+  // Split on ':', keeping empty fields
+  nfields = 0;
+  fields[nfields++] = memoBuf;
+  for (i = 0; memoBuf[i] != '\0' && nfields < 8; i++) {
+    if (memoBuf[i] == ':') {
+      memoBuf[i] = '\0';
+      fields[nfields++] = &memoBuf[i + 1];
     }
   }
 
-  if (ctr != 3) {
-    // Must have three tokens at this point: transaction, chain, asset. If
-    // not, just confirm data
+  if (nfields < 2) {
+    // Must have at least transaction and chain.asset. If not, just confirm
+    // data
     return false;
   }
 
+  // Split chain.asset at the first '.'
+  chain = fields[1];
+  asset = strchr(chain, '.');
+  if (asset == NULL) {
+    // No chain.asset pair; not recognizable mayachain data, just confirm data
+    return false;
+  }
+  *asset = '\0';
+  asset++;
+
   // Check for swap
-  if (strncmp(parseTokPtrs[0], "SWAP", 4) == 0 || *parseTokPtrs[0] == 's' ||
-      *parseTokPtrs[0] == '=') {
+  if (strncmp(fields[0], "SWAP", 4) == 0 || *fields[0] == 's' ||
+      *fields[0] == '=') {
     // This is a swap, set up destination and limit
-    // This is the dest, may be blank which means swap to self
-    parseTokPtrs[3] = "self";
-    parseTokPtrs[4] = "none";
-    if (tok != NULL) {
-      if ((uint32_t)(tok - (parseTokPtrs[2] + strlen(parseTokPtrs[2]))) == 1) {
-        // has dest address
-        parseTokPtrs[3] = tok;
-        tok = strtok(NULL, ":");
-      }
-      if (tok != NULL) {
-        // has limit
-        parseTokPtrs[4] = tok;
-      }
-    }
+    // The dest may be blank which means swap to self
+    const char* dest =
+        (nfields > 2 && fields[2][0] != '\0') ? fields[2] : "self";
+    const char* limit =
+        (nfields > 3 && fields[3][0] != '\0') ? fields[3] : "none";
+    const char* affiliate =
+        (nfields > 4 && fields[4][0] != '\0') ? fields[4] : NULL;
+    const char* fee_bps =
+        (nfields > 5 && fields[5][0] != '\0') ? fields[5] : "0";
 
     if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
                  "Mayachain swap", "Confirm swap asset %s\n on chain %s",
-                 parseTokPtrs[2], parseTokPtrs[1])) {
+                 asset, chain)) {
       return false;
     }
     if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
-                 "Mayachain swap", "Confirm to %s", parseTokPtrs[3])) {
+                 "Mayachain swap", "Confirm to %s", dest)) {
       return false;
     }
     if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
-                 "Mayachain swap", "Confirm limit %s", parseTokPtrs[4])) {
+                 "Mayachain swap", "Confirm limit %s", limit)) {
       return false;
+    }
+    // Never hide the affiliate fee skim from the user
+    if (affiliate != NULL) {
+      if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                   "Mayachain swap", "Affiliate fee %s bps to %s", fee_bps,
+                   affiliate)) {
+        return false;
+      }
     }
     return true;
   }
 
   // Check for add liquidity
-  else if (strncmp(parseTokPtrs[0], "ADD", 3) == 0 || *parseTokPtrs[0] == 'a' ||
-           *parseTokPtrs[0] == '+') {
-    if (tok != NULL) {
-      // add liquidity pool address
-      parseTokPtrs[3] = tok;
-    }
+  else if (strncmp(fields[0], "ADD", 3) == 0 || *fields[0] == 'a' ||
+           *fields[0] == '+') {
+    // add liquidity pool address (optional)
+    const char* pool =
+        (nfields > 2 && fields[2][0] != '\0') ? fields[2] : NULL;
 
     if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
                  "Mayachain add liquidity",
-                 "Confirm add asset %s\n on chain %s pool", parseTokPtrs[2],
-                 parseTokPtrs[1])) {
+                 "Confirm add asset %s\n on chain %s pool", asset, chain)) {
       return false;
     }
-    if (tok != NULL) {
+    if (pool != NULL) {
       if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
-                   "Mayachain add liquidity", "Confirm to %s",
-                   parseTokPtrs[3])) {
+                   "Mayachain add liquidity", "Confirm to %s", pool)) {
         return false;
       }
     }
@@ -304,20 +333,17 @@ bool mayachain_parseConfirmMemo(const char* swapStr, size_t size) {
   }
 
   // Check for withdraw liquidity
-  else if (strncmp(parseTokPtrs[0], "WITHDRAW", 8) == 0 ||
-           strncmp(parseTokPtrs[0], "wd", 2) == 0 || *parseTokPtrs[0] == '-') {
-    if (tok != NULL) {
-      // add liquidity pool address
-      parseTokPtrs[3] = tok;
-    } else {
+  else if (strncmp(fields[0], "WITHDRAW", 8) == 0 ||
+           strncmp(fields[0], "wd", 2) == 0 || *fields[0] == '-') {
+    if (nfields < 3 || fields[2][0] == '\0') {
       return false;  // malformed memo
     }
 
-    float percent = (float)(atoi(parseTokPtrs[3])) / 100;
+    float percent = (float)(atoi(fields[2])) / 100;
     if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
                  "Mayachain withdraw liquidity",
                  "Confirm withdraw %3.2f%% of asset %s on chain %s", percent,
-                 parseTokPtrs[2], parseTokPtrs[1])) {
+                 asset, chain)) {
       return false;
     }
     return true;

--- a/lib/firmware/mayachain.c
+++ b/lib/firmware/mayachain.c
@@ -309,8 +309,8 @@ bool mayachain_parseConfirmMemo(const char* swapStr, size_t size) {
         (nfields > 5 && fields[5][0] != '\0') ? fields[5] : "unspecified";
 
     if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
-                 "Mayachain swap", "Confirm swap asset %s\n on chain %s",
-                 asset, chain)) {
+                 "Mayachain swap", "Confirm swap asset %s\n on chain %s", asset,
+                 chain)) {
       return false;
     }
     if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
@@ -336,8 +336,7 @@ bool mayachain_parseConfirmMemo(const char* swapStr, size_t size) {
   else if (strncmp(fields[0], "ADD", 3) == 0 || *fields[0] == 'a' ||
            *fields[0] == '+') {
     // add liquidity pool address (optional)
-    const char* pool =
-        (nfields > 2 && fields[2][0] != '\0') ? fields[2] : NULL;
+    const char* pool = (nfields > 2 && fields[2][0] != '\0') ? fields[2] : NULL;
 
     if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
                  "Mayachain add liquidity",

--- a/lib/firmware/mayachain.c
+++ b/lib/firmware/mayachain.c
@@ -244,8 +244,15 @@ bool mayachain_parseConfirmMemo(const char* swapStr, size_t size) {
 
   if (size > sizeof(memoBuf)) return false;
   memzero(memoBuf, sizeof(memoBuf));
-  strlcpy(memoBuf, swapStr, size);
-  memoBuf[255] = '\0';  // ensure null termination
+  /* size is a byte count, not necessarily including a NUL: the BTC
+   * OP_RETURN caller passes raw memo bytes with no terminator. strlcpy
+   * would copy only size-1 bytes and silently drop the memo's last
+   * character (turning an affiliate fee of "75" bps into "7"). Copy the
+   * bytes exactly; the zeroed buffer provides termination. */
+  {
+    size_t copyLen = size < sizeof(memoBuf) ? size : sizeof(memoBuf) - 1;
+    memcpy(memoBuf, swapStr, copyLen);
+  }
 
   // Split on ':', keeping empty fields
   nfields = 0;
@@ -285,7 +292,7 @@ bool mayachain_parseConfirmMemo(const char* swapStr, size_t size) {
     const char* affiliate =
         (nfields > 4 && fields[4][0] != '\0') ? fields[4] : NULL;
     const char* fee_bps =
-        (nfields > 5 && fields[5][0] != '\0') ? fields[5] : "0";
+        (nfields > 5 && fields[5][0] != '\0') ? fields[5] : "unspecified";
 
     if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
                  "Mayachain swap", "Confirm swap asset %s\n on chain %s",

--- a/lib/firmware/mayachain.c
+++ b/lib/firmware/mayachain.c
@@ -135,16 +135,27 @@ bool mayachain_signTxUpdateMsgSend(const uint64_t amount,
     return false;
   }
 
+  // Default to "cacao" for backward compatibility; validate all non-default
+  // denoms. Defended here too (not just by the FSM caller) so this signing
+  // path is safe even if called directly or reused elsewhere later.
+  const char* coin_denom = (denom && denom[0]) ? denom : "cacao";
+  if (!mayachain_isValidDenom(coin_denom)) {
+    return false;
+  }
+
   bool success = true;
 
   const char* const prelude = "{\"type\":\"mayachain/MsgSend\",\"value\":{";
   sha256_Update(&ctx, (uint8_t*)prelude, strlen(prelude));
 
-  // 21 + ^20 + 11 + ^69 + 3 = ^124
-  success &= tendermint_snprintf(&ctx, buffer, sizeof(buffer),
-                                 "\"amount\":[{\"amount\":\"%" PRIu64
-                                 "\",\"denom\":\"%s\"}]",
-                                 amount, denom);
+  // Write amount prefix: 21 + ^20 = ^41
+  success &= tendermint_snprintf(
+      &ctx, buffer, sizeof(buffer),
+      "\"amount\":[{\"amount\":\"%" PRIu64 "\",\"denom\":\"", amount);
+  // Use escaping as defense-in-depth; valid denoms have no escapable chars
+  tendermint_sha256UpdateEscaped(&ctx, coin_denom, strlen(coin_denom));
+  // Close coins array: 3 bytes
+  sha256_Update(&ctx, (uint8_t*)"\"}]", 3);
 
   // 17 + 45 + 1 = 63
   success &= tendermint_snprintf(&ctx, buffer, sizeof(buffer),
@@ -236,23 +247,26 @@ bool mayachain_parseConfirmMemo(const char* swapStr, size_t size) {
   */
 
   char* fields[8] = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
-  char memoBuf[256];
+  /* Memos are documented/accepted up to 256 bytes; memoBuf reserves one
+   * extra byte so a full 256-byte memo still leaves a guaranteed NUL
+   * terminator, instead of the copy silently dropping its last byte. */
+  enum { MEMO_MAX = 256 };
+  char memoBuf[MEMO_MAX + 1];
   size_t nfields, i;
   char *chain, *asset;
 
   // check if memo data is recognized
 
-  if (size > sizeof(memoBuf)) return false;
+  if (size > MEMO_MAX) return false;
   memzero(memoBuf, sizeof(memoBuf));
   /* size is a byte count, not necessarily including a NUL: the BTC
    * OP_RETURN caller passes raw memo bytes with no terminator. strlcpy
    * would copy only size-1 bytes and silently drop the memo's last
    * character (turning an affiliate fee of "75" bps into "7"). Copy the
-   * bytes exactly; the zeroed buffer provides termination. */
-  {
-    size_t copyLen = size < sizeof(memoBuf) ? size : sizeof(memoBuf) - 1;
-    memcpy(memoBuf, swapStr, copyLen);
-  }
+   * bytes exactly (size <= MEMO_MAX < sizeof(memoBuf), so this never
+   * overflows and always leaves at least one zeroed terminator byte);
+   * the zeroed buffer provides termination. */
+  memcpy(memoBuf, swapStr, size);
 
   // Split on ':', keeping empty fields
   nfields = 0;

--- a/lib/firmware/solana.c
+++ b/lib/firmware/solana.c
@@ -122,10 +122,17 @@ static void copy_account(uint8_t out[SOL_PUBKEY_SIZE], const SolanaParsedTx* tx,
   }
 }
 
+/* allow_external_indices: versioned (v0) messages may reference accounts
+ * loaded from address lookup tables — indices at or beyond the static
+ * account list. Those accounts are not present in the message, so an
+ * instruction touching them cannot be verified on-device: it is left
+ * SOL_INSTR_UNKNOWN and the whole tx is forced opaque instead of being
+ * rejected as malformed. Legacy messages must never contain such indices. */
 static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
                                      size_t* pos_io, SolanaParsedTx* tx,
                                      uint16_t num_accounts, bool* has_unknown,
-                                     bool* force_opaque) {
+                                     bool* force_opaque,
+                                     bool allow_external_indices) {
   size_t pos = *pos_io;
   uint16_t num_instructions;
   int n = read_compact_u16(raw + pos, raw_len - pos, &num_instructions);
@@ -133,11 +140,10 @@ static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
   pos += n;
 
   if (num_instructions > SOL_MAX_INSTRUCTIONS) {
+    /* Too many to display — opaque. Keep walking the section so the
+     * structural checks (and any trailing sections) stay meaningful. */
     *force_opaque = true;
     tx->num_instructions = 0;
-    /* Don't attempt to parse instruction data — treat as opaque. */
-    *pos_io = raw_len;
-    return 0;
   } else {
     tx->num_instructions = (uint8_t)num_instructions;
   }
@@ -145,7 +151,11 @@ static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
   for (uint16_t i = 0; i < num_instructions; i++) {
     if (pos >= raw_len) return -1;
     uint8_t program_idx = raw[pos++];
-    if (program_idx >= num_accounts) return -1;
+    bool external = false;
+    if (program_idx >= num_accounts) {
+      if (!allow_external_indices) return -1;
+      external = true;
+    }
 
     uint16_t num_acct_indices;
     n = read_compact_u16(raw + pos, raw_len - pos, &num_acct_indices);
@@ -157,7 +167,10 @@ static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
     pos += num_acct_indices;
 
     for (uint16_t j = 0; j < num_acct_indices; j++) {
-      if (acct_indices[j] >= num_accounts) return -1;
+      if (acct_indices[j] >= num_accounts) {
+        if (!allow_external_indices) return -1;
+        external = true;
+      }
     }
 
     uint16_t data_len;
@@ -169,11 +182,19 @@ static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
     const uint8_t* instr_data = raw + pos;
     pos += data_len;
 
-    if (i >= SOL_MAX_INSTRUCTIONS) {
+    if (i >= SOL_MAX_INSTRUCTIONS || tx->num_instructions == 0) {
       continue;
     }
 
     SolanaParsedInstruction* pi = &tx->instructions[i];
+
+    if (external) {
+      /* Accounts resolved via lookup tables: unverifiable on-device. */
+      pi->type = SOL_INSTR_UNKNOWN;
+      *force_opaque = true;
+      continue;
+    }
+
     memcpy(pi->program_id, tx->accounts[program_idx], SOL_PUBKEY_SIZE);
 
     /* Classify and decode */
@@ -438,6 +459,8 @@ static int parse_instruction_section(const uint8_t* raw, size_t raw_len,
       }
     } else if (memcmp(pi->program_id, SOL_MEMO_PROGRAM, SOL_PUBKEY_SIZE) == 0) {
       pi->type = SOL_INSTR_MEMO;
+      pi->data = instr_data;
+      pi->data_len = data_len;
     } else {
       pi->type = SOL_INSTR_UNKNOWN;
       *has_unknown = true;
@@ -487,7 +510,8 @@ static SolanaTxReview solana_parseLegacyTx(const uint8_t* raw, size_t raw_len,
   pos += SOL_PUBKEY_SIZE;
 
   n = parse_instruction_section(raw, raw_len, &pos, tx, num_accounts,
-                                &has_unknown, &force_opaque);
+                                &has_unknown, &force_opaque,
+                                /*allow_external_indices=*/false);
   if (n < 0) return SOL_TX_REVIEW_MALFORMED;
 
   /* Reject if there are unconsumed bytes — prevents hidden trailing data */
@@ -505,7 +529,7 @@ static SolanaTxReview solana_parseVersionedTx(const uint8_t* raw,
   memset(tx, 0, sizeof(*tx));
   size_t pos = 0;
   bool has_unknown = false;
-  bool force_opaque = true;
+  bool force_opaque = false;
 
   if (raw_len < 1) return SOL_TX_REVIEW_MALFORMED;
   uint8_t version_prefix = raw[pos++];
@@ -536,7 +560,8 @@ static SolanaTxReview solana_parseVersionedTx(const uint8_t* raw,
   pos += SOL_PUBKEY_SIZE;
 
   n = parse_instruction_section(raw, raw_len, &pos, tx, num_accounts,
-                                &has_unknown, &force_opaque);
+                                &has_unknown, &force_opaque,
+                                /*allow_external_indices=*/true);
   if (n < 0) return SOL_TX_REVIEW_MALFORMED;
 
   uint16_t lookup_table_count;
@@ -563,7 +588,15 @@ static SolanaTxReview solana_parseVersionedTx(const uint8_t* raw,
   }
 
   if (pos != raw_len) return SOL_TX_REVIEW_MALFORMED;
-  return SOL_TX_REVIEW_OPAQUE;
+
+  /* A v0 message whose instructions only touch static accounts is exactly
+   * as verifiable as a legacy message. Lookup-table sections are allowed
+   * to exist; any instruction actually reaching into them forced opaque
+   * above (external indices). */
+  if (tx->num_instructions == 0 || has_unknown || force_opaque) {
+    return SOL_TX_REVIEW_OPAQUE;
+  }
+  return SOL_TX_REVIEW_VERIFIED;
 }
 
 SolanaTxReview solana_inspectTx(const uint8_t* raw, size_t raw_len,

--- a/lib/firmware/thorchain.c
+++ b/lib/firmware/thorchain.c
@@ -308,8 +308,8 @@ bool thorchain_parseConfirmMemo(const char* swapStr, size_t size) {
         (nfields > 5 && fields[5][0] != '\0') ? fields[5] : "unspecified";
 
     if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
-                 "Thorchain swap", "Confirm swap asset %s\n on chain %s",
-                 asset, chain)) {
+                 "Thorchain swap", "Confirm swap asset %s\n on chain %s", asset,
+                 chain)) {
       return false;
     }
     if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
@@ -335,8 +335,7 @@ bool thorchain_parseConfirmMemo(const char* swapStr, size_t size) {
   else if (strncmp(fields[0], "ADD", 3) == 0 || *fields[0] == 'a' ||
            *fields[0] == '+') {
     // add liquidity pool address (optional)
-    const char* pool =
-        (nfields > 2 && fields[2][0] != '\0') ? fields[2] : NULL;
+    const char* pool = (nfields > 2 && fields[2][0] != '\0') ? fields[2] : NULL;
 
     if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
                  "Thorchain add liquidity",

--- a/lib/firmware/thorchain.c
+++ b/lib/firmware/thorchain.c
@@ -254,8 +254,15 @@ bool thorchain_parseConfirmMemo(const char* swapStr, size_t size) {
 
   if (size > sizeof(memoBuf)) return false;
   memzero(memoBuf, sizeof(memoBuf));
-  strlcpy(memoBuf, swapStr, size);
-  memoBuf[255] = '\0';  // ensure null termination
+  /* size is a byte count, not necessarily including a NUL: the BTC
+   * OP_RETURN caller passes raw memo bytes with no terminator. strlcpy
+   * would copy only size-1 bytes and silently drop the memo's last
+   * character (turning an affiliate fee of "75" bps into "7"). Copy the
+   * bytes exactly; the zeroed buffer provides termination. */
+  {
+    size_t copyLen = size < sizeof(memoBuf) ? size : sizeof(memoBuf) - 1;
+    memcpy(memoBuf, swapStr, copyLen);
+  }
 
   // Split on ':', keeping empty fields
   nfields = 0;
@@ -295,7 +302,7 @@ bool thorchain_parseConfirmMemo(const char* swapStr, size_t size) {
     const char* affiliate =
         (nfields > 4 && fields[4][0] != '\0') ? fields[4] : NULL;
     const char* fee_bps =
-        (nfields > 5 && fields[5][0] != '\0') ? fields[5] : "0";
+        (nfields > 5 && fields[5][0] != '\0') ? fields[5] : "unspecified";
 
     if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
                  "Thorchain swap", "Confirm swap asset %s\n on chain %s",

--- a/lib/firmware/thorchain.c
+++ b/lib/firmware/thorchain.c
@@ -246,23 +246,26 @@ bool thorchain_parseConfirmMemo(const char* swapStr, size_t size) {
   */
 
   char* fields[8] = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
-  char memoBuf[256];
+  /* Memos are documented/accepted up to 256 bytes; memoBuf reserves one
+   * extra byte so a full 256-byte memo still leaves a guaranteed NUL
+   * terminator, instead of the copy silently dropping its last byte. */
+  enum { MEMO_MAX = 256 };
+  char memoBuf[MEMO_MAX + 1];
   size_t nfields, i;
   char *chain, *asset;
 
   // check if memo data is recognized
 
-  if (size > sizeof(memoBuf)) return false;
+  if (size > MEMO_MAX) return false;
   memzero(memoBuf, sizeof(memoBuf));
   /* size is a byte count, not necessarily including a NUL: the BTC
    * OP_RETURN caller passes raw memo bytes with no terminator. strlcpy
    * would copy only size-1 bytes and silently drop the memo's last
    * character (turning an affiliate fee of "75" bps into "7"). Copy the
-   * bytes exactly; the zeroed buffer provides termination. */
-  {
-    size_t copyLen = size < sizeof(memoBuf) ? size : sizeof(memoBuf) - 1;
-    memcpy(memoBuf, swapStr, copyLen);
-  }
+   * bytes exactly (size <= MEMO_MAX < sizeof(memoBuf), so this never
+   * overflows and always leaves at least one zeroed terminator byte);
+   * the zeroed buffer provides termination. */
+  memcpy(memoBuf, swapStr, size);
 
   // Split on ':', keeping empty fields
   nfields = 0;

--- a/lib/firmware/thorchain.c
+++ b/lib/firmware/thorchain.c
@@ -231,20 +231,24 @@ bool thorchain_parseConfirmMemo(const char* swapStr, size_t size) {
     Input: swapStr is candidate thorchain data
            size is the size of swapStr (<= 256)
     Memos should be of the form:
-    transaction:chain.ticker-id:destination:limit
+    transaction:chain.ticker-id:destination:limit:affiliate:fee_bps
                 ^^^^^^^^^^^^^^----------asset
 
-    So, swap USDT to dest address 0x41e55..., limit 420
-    SWAP:ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7:0x41e5560054824ea6b0732e656e3ad64e20e94e45:420
+    So, swap USDT to dest address 0x41e55..., limit 420, affiliate "kk"
+    skimming 75 basis points:
+    SWAP:ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7:0x41e5560054824ea6b0732e656e3ad64e20e94e45:420:kk:75
 
     Swap transactions can be indicated by "SWAP" or "s" or "="
+
+    Fields are split on ':' PRESERVING empty fields so a blank field (e.g.
+    an empty limit in "=:ETH.ETH:0xdest::kk:75") can never shift a later
+    field (e.g. the affiliate) into an earlier display slot.
   */
 
-  char* parseTokPtrs[7] = {NULL, NULL, NULL, NULL,
-                           NULL, NULL, NULL};  // we can parse up to 7 tokens
-  char* tok;
+  char* fields[8] = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
   char memoBuf[256];
-  uint16_t ctr;
+  size_t nfields, i;
+  char *chain, *asset;
 
   // check if memo data is recognized
 
@@ -252,77 +256,86 @@ bool thorchain_parseConfirmMemo(const char* swapStr, size_t size) {
   memzero(memoBuf, sizeof(memoBuf));
   strlcpy(memoBuf, swapStr, size);
   memoBuf[255] = '\0';  // ensure null termination
-  tok = strtok(memoBuf, ":");
 
-  // get transaction and asset
-  for (ctr = 0; ctr < 3; ctr++) {
-    if (tok != NULL) {
-      parseTokPtrs[ctr] = tok;
-      tok = strtok(NULL, ":.");
-    } else {
-      break;
+  // Split on ':', keeping empty fields
+  nfields = 0;
+  fields[nfields++] = memoBuf;
+  for (i = 0; memoBuf[i] != '\0' && nfields < 8; i++) {
+    if (memoBuf[i] == ':') {
+      memoBuf[i] = '\0';
+      fields[nfields++] = &memoBuf[i + 1];
     }
   }
 
-  if (ctr != 3) {
-    // Must have three tokens at this point: transaction, chain, asset. If
-    // not, just confirm data
+  if (nfields < 2) {
+    // Must have at least transaction and chain.asset. If not, just confirm
+    // data
     return false;
   }
 
+  // Split chain.asset at the first '.'
+  chain = fields[1];
+  asset = strchr(chain, '.');
+  if (asset == NULL) {
+    // No chain.asset pair; not recognizable thorchain data, just confirm data
+    return false;
+  }
+  *asset = '\0';
+  asset++;
+
   // Check for swap
-  if (strncmp(parseTokPtrs[0], "SWAP", 4) == 0 || *parseTokPtrs[0] == 's' ||
-      *parseTokPtrs[0] == '=') {
+  if (strncmp(fields[0], "SWAP", 4) == 0 || *fields[0] == 's' ||
+      *fields[0] == '=') {
     // This is a swap, set up destination and limit
-    // This is the dest, may be blank which means swap to self
-    parseTokPtrs[3] = "self";
-    parseTokPtrs[4] = "none";
-    if (tok != NULL) {
-      if ((uint32_t)(tok - (parseTokPtrs[2] + strlen(parseTokPtrs[2]))) == 1) {
-        // has dest address
-        parseTokPtrs[3] = tok;
-        tok = strtok(NULL, ":");
-      }
-      if (tok != NULL) {
-        // has limit
-        parseTokPtrs[4] = tok;
-      }
-    }
+    // The dest may be blank which means swap to self
+    const char* dest =
+        (nfields > 2 && fields[2][0] != '\0') ? fields[2] : "self";
+    const char* limit =
+        (nfields > 3 && fields[3][0] != '\0') ? fields[3] : "none";
+    const char* affiliate =
+        (nfields > 4 && fields[4][0] != '\0') ? fields[4] : NULL;
+    const char* fee_bps =
+        (nfields > 5 && fields[5][0] != '\0') ? fields[5] : "0";
 
     if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
                  "Thorchain swap", "Confirm swap asset %s\n on chain %s",
-                 parseTokPtrs[2], parseTokPtrs[1])) {
+                 asset, chain)) {
       return false;
     }
     if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
-                 "Thorchain swap", "Confirm to %s", parseTokPtrs[3])) {
+                 "Thorchain swap", "Confirm to %s", dest)) {
       return false;
     }
     if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
-                 "Thorchain swap", "Confirm limit %s", parseTokPtrs[4])) {
+                 "Thorchain swap", "Confirm limit %s", limit)) {
       return false;
+    }
+    // Never hide the affiliate fee skim from the user
+    if (affiliate != NULL) {
+      if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                   "Thorchain swap", "Affiliate fee %s bps to %s", fee_bps,
+                   affiliate)) {
+        return false;
+      }
     }
     return true;
   }
 
   // Check for add liquidity
-  else if (strncmp(parseTokPtrs[0], "ADD", 3) == 0 || *parseTokPtrs[0] == 'a' ||
-           *parseTokPtrs[0] == '+') {
-    if (tok != NULL) {
-      // add liquidity pool address
-      parseTokPtrs[3] = tok;
-    }
+  else if (strncmp(fields[0], "ADD", 3) == 0 || *fields[0] == 'a' ||
+           *fields[0] == '+') {
+    // add liquidity pool address (optional)
+    const char* pool =
+        (nfields > 2 && fields[2][0] != '\0') ? fields[2] : NULL;
 
     if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
                  "Thorchain add liquidity",
-                 "Confirm add asset %s\n on chain %s pool", parseTokPtrs[2],
-                 parseTokPtrs[1])) {
+                 "Confirm add asset %s\n on chain %s pool", asset, chain)) {
       return false;
     }
-    if (tok != NULL) {
+    if (pool != NULL) {
       if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
-                   "Thorchain add liquidity", "Confirm to %s",
-                   parseTokPtrs[3])) {
+                   "Thorchain add liquidity", "Confirm to %s", pool)) {
         return false;
       }
     }
@@ -330,20 +343,17 @@ bool thorchain_parseConfirmMemo(const char* swapStr, size_t size) {
   }
 
   // Check for withdraw liquidity
-  else if (strncmp(parseTokPtrs[0], "WITHDRAW", 8) == 0 ||
-           strncmp(parseTokPtrs[0], "wd", 2) == 0 || *parseTokPtrs[0] == '-') {
-    if (tok != NULL) {
-      // add liquidity pool address
-      parseTokPtrs[3] = tok;
-    } else {
+  else if (strncmp(fields[0], "WITHDRAW", 8) == 0 ||
+           strncmp(fields[0], "wd", 2) == 0 || *fields[0] == '-') {
+    if (nfields < 3 || fields[2][0] == '\0') {
       return false;  // malformed memo
     }
 
-    float percent = (float)(atoi(parseTokPtrs[3])) / 100;
+    float percent = (float)(atoi(fields[2])) / 100;
     if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
                  "Thorchain withdraw liquidity",
                  "Confirm withdraw %3.2f%% of asset %s on chain %s", percent,
-                 parseTokPtrs[2], parseTokPtrs[1])) {
+                 asset, chain)) {
       return false;
     }
     return true;

--- a/lib/firmware/tron.c
+++ b/lib/firmware/tron.c
@@ -21,11 +21,13 @@
 
 #include "keepkey/crypto/curves.h"
 #include "trezor/crypto/base58.h"
+#include "trezor/crypto/bignum.h"
 #include "trezor/crypto/ecdsa.h"
 #include "trezor/crypto/memzero.h"
 #include "trezor/crypto/secp256k1.h"
 #include "trezor/crypto/sha3.h"
 
+#include <stdint.h>
 #include <string.h>
 
 #define TRON_ADDRESS_PREFIX 0x41  // Mainnet addresses start with 'T'
@@ -78,6 +80,356 @@ void tron_formatAmount(char* buf, size_t len, uint64_t amount) {
   bignum256 val;
   bn_read_uint64(amount, &val);
   bn_format(&val, NULL, " TRX", TRON_DECIMALS, 0, false, buf, len);
+}
+
+bool tron_addressFromBytes(const uint8_t addr[TRON_RAW_ADDRESS_SIZE],
+                           char* out, size_t out_len) {
+  return base58_encode_check(addr, TRON_RAW_ADDRESS_SIZE, HASHER_SHA2D, out,
+                             out_len);
+}
+
+bool tron_formatTrc20Amount(const uint8_t amount_be[32], char* buf,
+                            size_t len) {
+  bignum256 val;
+  bn_read_be(amount_be, &val);
+  return bn_format(&val, NULL, NULL, 0, 0, false, buf, len);
+}
+
+/* ------------------------------------------------------------------ */
+/*  raw_data protobuf parser                                           */
+/*                                                                     */
+/*  The device signs sha256(raw_data), so display decisions are made   */
+/*  from these exact bytes. Minimal protobuf wire-format reader —      */
+/*  fail-closed: anything not fully understood ends TRON_TX_UNVERIFIED */
+/* ------------------------------------------------------------------ */
+
+/* TRON protocol.Transaction.raw field numbers */
+#define TRON_RAW_REF_BLOCK_BYTES 1
+#define TRON_RAW_REF_BLOCK_NUM 3
+#define TRON_RAW_REF_BLOCK_HASH 4
+#define TRON_RAW_EXPIRATION 8
+#define TRON_RAW_DATA 10 /* memo */
+#define TRON_RAW_CONTRACT 11
+#define TRON_RAW_TIMESTAMP 14
+#define TRON_RAW_FEE_LIMIT 18
+
+/* protocol.Transaction.Contract */
+#define TRON_CONTRACT_TYPE 1
+#define TRON_CONTRACT_PARAMETER 2
+
+/* google.protobuf.Any */
+#define TRON_ANY_TYPE_URL 1
+#define TRON_ANY_VALUE 2
+
+/* protocol.Transaction.Contract.ContractType enum values */
+#define TRON_CT_TRANSFER_CONTRACT 1
+#define TRON_CT_TRIGGER_SMART_CONTRACT 31
+
+/* TRC-20 transfer(address,uint256) selector */
+static const uint8_t TRC20_TRANSFER_SELECTOR[4] = {0xa9, 0x05, 0x9c, 0xbb};
+
+static bool pb_read_varint(const uint8_t* buf, size_t len, size_t* pos,
+                           uint64_t* out) {
+  uint64_t val = 0;
+  for (unsigned shift = 0; shift < 64; shift += 7) {
+    if (*pos >= len) return false;
+    uint8_t b = buf[(*pos)++];
+    val |= (uint64_t)(b & 0x7f) << shift;
+    if (!(b & 0x80)) {
+      *out = val;
+      return true;
+    }
+  }
+  return false; /* varint too long / overflows 64 bits */
+}
+
+static bool pb_read_key(const uint8_t* buf, size_t len, size_t* pos,
+                        uint32_t* field, uint8_t* wire) {
+  uint64_t key;
+  if (!pb_read_varint(buf, len, pos, &key)) return false;
+  *wire = (uint8_t)(key & 0x7);
+  if ((key >> 3) > UINT32_MAX) return false;
+  *field = (uint32_t)(key >> 3);
+  return *field != 0;
+}
+
+static bool pb_read_bytes(const uint8_t* buf, size_t len, size_t* pos,
+                          const uint8_t** out, size_t* out_len) {
+  uint64_t blen;
+  if (!pb_read_varint(buf, len, pos, &blen)) return false;
+  if (blen > len - *pos) return false;
+  *out = buf + *pos;
+  *out_len = (size_t)blen;
+  *pos += (size_t)blen;
+  return true;
+}
+
+static bool pb_skip(const uint8_t* buf, size_t len, size_t* pos,
+                    uint8_t wire) {
+  uint64_t dummy;
+  const uint8_t* bp;
+  size_t bl;
+  switch (wire) {
+    case 0: /* varint */
+      return pb_read_varint(buf, len, pos, &dummy);
+    case 1: /* fixed64 */
+      if (len - *pos < 8) return false;
+      *pos += 8;
+      return true;
+    case 2: /* length-delimited */
+      return pb_read_bytes(buf, len, pos, &bp, &bl);
+    case 5: /* fixed32 */
+      if (len - *pos < 4) return false;
+      *pos += 4;
+      return true;
+    default:
+      return false;
+  }
+}
+
+static bool tron_isRawAddress(const uint8_t* p, size_t len) {
+  return len == TRON_RAW_ADDRESS_SIZE && p[0] == TRON_ADDRESS_PREFIX;
+}
+
+/* Parse protocol.TransferContract { owner_address=1, to_address=2, amount=3 } */
+static bool tron_parseTransferContract(const uint8_t* buf, size_t len,
+                                       TronParsedTx* out) {
+  size_t pos = 0;
+  bool has_owner = false, has_to = false, has_amount = false;
+  while (pos < len) {
+    uint32_t field;
+    uint8_t wire;
+    if (!pb_read_key(buf, len, &pos, &field, &wire)) return false;
+    const uint8_t* bp;
+    size_t bl;
+    uint64_t v;
+    if (field == 1 && wire == 2) {
+      if (!pb_read_bytes(buf, len, &pos, &bp, &bl)) return false;
+      if (!tron_isRawAddress(bp, bl) || has_owner) return false;
+      memcpy(out->owner, bp, TRON_RAW_ADDRESS_SIZE);
+      has_owner = true;
+    } else if (field == 2 && wire == 2) {
+      if (!pb_read_bytes(buf, len, &pos, &bp, &bl)) return false;
+      if (!tron_isRawAddress(bp, bl) || has_to) return false;
+      memcpy(out->to, bp, TRON_RAW_ADDRESS_SIZE);
+      has_to = true;
+    } else if (field == 3 && wire == 0) {
+      if (!pb_read_varint(buf, len, &pos, &v) || has_amount) return false;
+      if (v > INT64_MAX) return false;
+      out->amount = v;
+      has_amount = true;
+    } else {
+      /* Unknown field in a value-moving payload: refuse to summarize. */
+      return false;
+    }
+  }
+  return has_owner && has_to && has_amount;
+}
+
+/* Parse protocol.TriggerSmartContract:
+ *   owner_address=1, contract_address=2, call_value=3, data=4,
+ *   call_token_value=5, token_id=6
+ * Only a plain TRC-20 transfer(address,uint256) with zero call_value and
+ * no TRC-10 tokens attached is considered verified. */
+static bool tron_parseTriggerSmartContract(const uint8_t* buf, size_t len,
+                                           TronParsedTx* out) {
+  size_t pos = 0;
+  bool has_owner = false, has_contract = false, has_data = false;
+  const uint8_t* data = NULL;
+  size_t data_len = 0;
+  while (pos < len) {
+    uint32_t field;
+    uint8_t wire;
+    if (!pb_read_key(buf, len, &pos, &field, &wire)) return false;
+    const uint8_t* bp;
+    size_t bl;
+    uint64_t v;
+    if (field == 1 && wire == 2) {
+      if (!pb_read_bytes(buf, len, &pos, &bp, &bl)) return false;
+      if (!tron_isRawAddress(bp, bl) || has_owner) return false;
+      memcpy(out->owner, bp, TRON_RAW_ADDRESS_SIZE);
+      has_owner = true;
+    } else if (field == 2 && wire == 2) {
+      if (!pb_read_bytes(buf, len, &pos, &bp, &bl)) return false;
+      if (!tron_isRawAddress(bp, bl) || has_contract) return false;
+      memcpy(out->contract, bp, TRON_RAW_ADDRESS_SIZE);
+      has_contract = true;
+    } else if (field == 3 && wire == 0) {
+      /* call_value: transfer(address,uint256) is non-payable — any TRX
+       * attached to the call is something we can't explain to the user. */
+      if (!pb_read_varint(buf, len, &pos, &v)) return false;
+      if (v != 0) return false;
+    } else if (field == 4 && wire == 2) {
+      if (!pb_read_bytes(buf, len, &pos, &data, &data_len) || has_data)
+        return false;
+      has_data = true;
+    } else {
+      /* token_id / call_token_value / anything else: refuse. */
+      return false;
+    }
+  }
+  if (!has_owner || !has_contract || !has_data) return false;
+
+  /* data must be exactly selector + address word + amount word */
+  if (data_len != 4 + 32 + 32) return false;
+  if (memcmp(data, TRC20_TRANSFER_SELECTOR, 4) != 0) return false;
+
+  /* Address word: 12 zero bytes then the 20-byte address. TRON tooling
+   * sometimes writes the 0x41 network prefix at byte 11; the TVM decodes
+   * only the low 160 bits, so accept 0x41 there and nothing else. */
+  const uint8_t* word = data + 4;
+  for (int i = 0; i < 11; i++) {
+    if (word[i] != 0) return false;
+  }
+  if (word[11] != 0 && word[11] != TRON_ADDRESS_PREFIX) return false;
+
+  out->to[0] = TRON_ADDRESS_PREFIX;
+  memcpy(out->to + 1, word + 12, 20);
+  memcpy(out->trc20_amount, data + 4 + 32, 32);
+  return true;
+}
+
+/* Parse Contract { type=1, parameter=2 (Any) }; enum type and the Any
+ * type_url must agree, otherwise refuse. */
+static TronTxType tron_parseContract(const uint8_t* buf, size_t len,
+                                     TronParsedTx* out) {
+  size_t pos = 0;
+  uint64_t ctype = 0;
+  bool has_type = false;
+  const uint8_t* value = NULL;
+  size_t value_len = 0;
+  const uint8_t* type_url = NULL;
+  size_t type_url_len = 0;
+
+  while (pos < len) {
+    uint32_t field;
+    uint8_t wire;
+    if (!pb_read_key(buf, len, &pos, &field, &wire))
+      return TRON_TX_UNVERIFIED;
+    if (field == TRON_CONTRACT_TYPE && wire == 0) {
+      if (!pb_read_varint(buf, len, &pos, &ctype) || has_type)
+        return TRON_TX_UNVERIFIED;
+      has_type = true;
+    } else if (field == TRON_CONTRACT_PARAMETER && wire == 2) {
+      const uint8_t* any;
+      size_t any_len;
+      if (!pb_read_bytes(buf, len, &pos, &any, &any_len) || value)
+        return TRON_TX_UNVERIFIED;
+      size_t apos = 0;
+      while (apos < any_len) {
+        uint32_t afield;
+        uint8_t awire;
+        if (!pb_read_key(any, any_len, &apos, &afield, &awire))
+          return TRON_TX_UNVERIFIED;
+        if (afield == TRON_ANY_TYPE_URL && awire == 2) {
+          if (type_url ||
+              !pb_read_bytes(any, any_len, &apos, &type_url, &type_url_len))
+            return TRON_TX_UNVERIFIED;
+        } else if (afield == TRON_ANY_VALUE && awire == 2) {
+          if (value ||
+              !pb_read_bytes(any, any_len, &apos, &value, &value_len))
+            return TRON_TX_UNVERIFIED;
+        } else {
+          return TRON_TX_UNVERIFIED;
+        }
+      }
+      if (!value) return TRON_TX_UNVERIFIED;
+    } else {
+      /* Permission_id (multisig), provider, ContractName, unknown: refuse. */
+      return TRON_TX_UNVERIFIED;
+    }
+  }
+  if (!has_type || !value || !type_url) return TRON_TX_UNVERIFIED;
+
+  /* type_url ends with "/protocol.<Name>"; require agreement with enum */
+  const char* expect_suffix;
+  if (ctype == TRON_CT_TRANSFER_CONTRACT) {
+    expect_suffix = "/protocol.TransferContract";
+  } else if (ctype == TRON_CT_TRIGGER_SMART_CONTRACT) {
+    expect_suffix = "/protocol.TriggerSmartContract";
+  } else {
+    return TRON_TX_UNVERIFIED;
+  }
+  size_t suffix_len = strlen(expect_suffix);
+  if (type_url_len < suffix_len ||
+      memcmp(type_url + type_url_len - suffix_len, expect_suffix,
+             suffix_len) != 0) {
+    return TRON_TX_UNVERIFIED;
+  }
+
+  if (ctype == TRON_CT_TRANSFER_CONTRACT) {
+    return tron_parseTransferContract(value, value_len, out)
+               ? TRON_TX_TRANSFER
+               : TRON_TX_UNVERIFIED;
+  }
+  return tron_parseTriggerSmartContract(value, value_len, out)
+             ? TRON_TX_TRC20_TRANSFER
+             : TRON_TX_UNVERIFIED;
+}
+
+TronTxType tron_parseRawTx(const uint8_t* raw, size_t len, TronParsedTx* out) {
+  memset(out, 0, sizeof(*out));
+  if (!raw || len == 0) return TRON_TX_UNVERIFIED;
+
+  size_t pos = 0;
+  const uint8_t* contract = NULL;
+  size_t contract_len = 0;
+
+  while (pos < len) {
+    uint32_t field;
+    uint8_t wire;
+    if (!pb_read_key(raw, len, &pos, &field, &wire)) goto unverified;
+    switch (field) {
+      case TRON_RAW_REF_BLOCK_BYTES:
+      case TRON_RAW_REF_BLOCK_HASH:
+        if (wire != 2 || !pb_skip(raw, len, &pos, wire)) goto unverified;
+        break;
+      case TRON_RAW_REF_BLOCK_NUM:
+      case TRON_RAW_EXPIRATION:
+      case TRON_RAW_TIMESTAMP:
+        if (wire != 0 || !pb_skip(raw, len, &pos, wire)) goto unverified;
+        break;
+      case TRON_RAW_DATA: {
+        const uint8_t* bp;
+        size_t bl;
+        if (wire != 2 || out->memo ||
+            !pb_read_bytes(raw, len, &pos, &bp, &bl) || bl > UINT16_MAX)
+          goto unverified;
+        out->memo = bp;
+        out->memo_len = (uint16_t)bl;
+        break;
+      }
+      case TRON_RAW_CONTRACT:
+        /* exactly one contract may be displayed truthfully */
+        if (wire != 2 || contract ||
+            !pb_read_bytes(raw, len, &pos, &contract, &contract_len))
+          goto unverified;
+        break;
+      case TRON_RAW_FEE_LIMIT: {
+        uint64_t v;
+        if (wire != 0 || out->has_fee_limit ||
+            !pb_read_varint(raw, len, &pos, &v) || v > INT64_MAX)
+          goto unverified;
+        out->fee_limit = v;
+        out->has_fee_limit = true;
+        break;
+      }
+      default:
+        /* auths, scripts, future fields: can change meaning — refuse. */
+        goto unverified;
+    }
+  }
+
+  if (!contract) goto unverified;
+  out->type = tron_parseContract(contract, contract_len, out);
+  if (out->type == TRON_TX_UNVERIFIED) goto unverified;
+  return out->type;
+
+unverified:
+  /* Preserve nothing from a failed parse except the classification. */
+  memset(out, 0, sizeof(*out));
+  out->type = TRON_TX_UNVERIFIED;
+  return TRON_TX_UNVERIFIED;
 }
 
 /**

--- a/lib/firmware/tron.c
+++ b/lib/firmware/tron.c
@@ -134,7 +134,17 @@ static bool pb_read_varint(const uint8_t* buf, size_t len, size_t* pos,
   for (unsigned shift = 0; shift < 64; shift += 7) {
     if (*pos >= len) return false;
     uint8_t b = buf[(*pos)++];
-    val |= (uint64_t)(b & 0x7f) << shift;
+    uint8_t payload = b & 0x7f;
+    if (shift == 63 && payload > 1) {
+      /* The 10th byte can only contribute bit 63 to a 64-bit value
+       * (63 + 7 > 64); any payload bit above bit 0 here claims more
+       * precision than 64 bits hold. The shift below would silently
+       * drop those bits rather than reject them, letting a malformed
+       * key/length/amount/fee varint parse as if it were well-formed
+       * — reject instead of truncating. */
+      return false;
+    }
+    val |= (uint64_t)payload << shift;
     if (!(b & 0x80)) {
       *out = val;
       return true;

--- a/lib/firmware/tron.c
+++ b/lib/firmware/tron.c
@@ -82,8 +82,8 @@ void tron_formatAmount(char* buf, size_t len, uint64_t amount) {
   bn_format(&val, NULL, " TRX", TRON_DECIMALS, 0, false, buf, len);
 }
 
-bool tron_addressFromBytes(const uint8_t addr[TRON_RAW_ADDRESS_SIZE],
-                           char* out, size_t out_len) {
+bool tron_addressFromBytes(const uint8_t addr[TRON_RAW_ADDRESS_SIZE], char* out,
+                           size_t out_len) {
   return base58_encode_check(addr, TRON_RAW_ADDRESS_SIZE, HASHER_SHA2D, out,
                              out_len);
 }
@@ -174,8 +174,7 @@ static bool pb_read_bytes(const uint8_t* buf, size_t len, size_t* pos,
   return true;
 }
 
-static bool pb_skip(const uint8_t* buf, size_t len, size_t* pos,
-                    uint8_t wire) {
+static bool pb_skip(const uint8_t* buf, size_t len, size_t* pos, uint8_t wire) {
   uint64_t dummy;
   const uint8_t* bp;
   size_t bl;
@@ -201,7 +200,8 @@ static bool tron_isRawAddress(const uint8_t* p, size_t len) {
   return len == TRON_RAW_ADDRESS_SIZE && p[0] == TRON_ADDRESS_PREFIX;
 }
 
-/* Parse protocol.TransferContract { owner_address=1, to_address=2, amount=3 } */
+/* Parse protocol.TransferContract { owner_address=1, to_address=2, amount=3 }
+ */
 static bool tron_parseTransferContract(const uint8_t* buf, size_t len,
                                        TronParsedTx* out) {
   size_t pos = 0;
@@ -314,8 +314,7 @@ static TronTxType tron_parseContract(const uint8_t* buf, size_t len,
   while (pos < len) {
     uint32_t field;
     uint8_t wire;
-    if (!pb_read_key(buf, len, &pos, &field, &wire))
-      return TRON_TX_UNVERIFIED;
+    if (!pb_read_key(buf, len, &pos, &field, &wire)) return TRON_TX_UNVERIFIED;
     if (field == TRON_CONTRACT_TYPE && wire == 0) {
       if (!pb_read_varint(buf, len, &pos, &ctype) || has_type)
         return TRON_TX_UNVERIFIED;
@@ -336,8 +335,7 @@ static TronTxType tron_parseContract(const uint8_t* buf, size_t len,
               !pb_read_bytes(any, any_len, &apos, &type_url, &type_url_len))
             return TRON_TX_UNVERIFIED;
         } else if (afield == TRON_ANY_VALUE && awire == 2) {
-          if (value ||
-              !pb_read_bytes(any, any_len, &apos, &value, &value_len))
+          if (value || !pb_read_bytes(any, any_len, &apos, &value, &value_len))
             return TRON_TX_UNVERIFIED;
         } else {
           return TRON_TX_UNVERIFIED;
@@ -361,9 +359,8 @@ static TronTxType tron_parseContract(const uint8_t* buf, size_t len,
     return TRON_TX_UNVERIFIED;
   }
   size_t suffix_len = strlen(expect_suffix);
-  if (type_url_len < suffix_len ||
-      memcmp(type_url + type_url_len - suffix_len, expect_suffix,
-             suffix_len) != 0) {
+  if (type_url_len < suffix_len || memcmp(type_url + type_url_len - suffix_len,
+                                          expect_suffix, suffix_len) != 0) {
     return TRON_TX_UNVERIFIED;
   }
 

--- a/unittests/firmware/CMakeLists.txt
+++ b/unittests/firmware/CMakeLists.txt
@@ -11,6 +11,7 @@ set(sources
     thorchain.cpp
     usb_rx.cpp
     mayachain.cpp
+    solana.cpp
     tron.cpp
     u2f.cpp
     zcash.cpp)

--- a/unittests/firmware/CMakeLists.txt
+++ b/unittests/firmware/CMakeLists.txt
@@ -10,6 +10,7 @@ set(sources
     storage.cpp
     thorchain.cpp
     usb_rx.cpp
+    mayachain.cpp
     tron.cpp
     u2f.cpp
     zcash.cpp)

--- a/unittests/firmware/CMakeLists.txt
+++ b/unittests/firmware/CMakeLists.txt
@@ -10,6 +10,7 @@ set(sources
     storage.cpp
     thorchain.cpp
     usb_rx.cpp
+    tron.cpp
     u2f.cpp
     zcash.cpp)
 

--- a/unittests/firmware/mayachain.cpp
+++ b/unittests/firmware/mayachain.cpp
@@ -8,6 +8,12 @@ extern "C" {
 #include "gtest/gtest.h"
 #include <cstring>
 
+// confirm() auto-accept driver, defined in thorchain.cpp (same binary).
+// kkconfirm_preload(nYes, nNo) queues nYes accepted confirm screens then
+// nNo rejected ones; kkconfirm_drain() == 0 proves the exact screen count.
+bool kkconfirm_preload(int nYes, int nNo);
+int kkconfirm_drain(void);
+
 TEST(Mayachain, MayachainGetAddress) {
   HDNode node = {
       0,
@@ -56,19 +62,112 @@ TEST(Mayachain, MayachainSignTx) {
   ASSERT_TRUE(mayachain_signTxInit(&node, &msg));
 
   ASSERT_TRUE(mayachain_signTxUpdateMsgSend(
-      100, "maya1g9el7lzjwh9yun2c4jjzhy09j98vkhfxfqkl5k"));
+      100, "maya1g9el7lzjwh9yun2c4jjzhy09j98vkhfxfqkl5k", "cacao"));
 
   uint8_t public_key[33];
   uint8_t signature[64];
 
   ASSERT_TRUE(mayachain_signTxFinalize(public_key, signature));
 
+  // Expected value recomputed independently (python-ecdsa, RFC6979/secp256k1,
+  // low-s) over the exact sign-doc JSON this fixture produces:
+  //   {"account_number":"6359","chain_id":"mayachain-mainnet-v1","fee":
+  //   {"amount":[{"amount":"3000","denom":"cacao"}],"gas":"200000"},"memo":
+  //   "","msgs":[{"type":"mayachain/MsgSend","value":{"amount":[{"amount":
+  //   "100","denom":"cacao"}],"from_address":
+  //   "maya1ls33ayg26kmltw7jjy55p32ghjna09zp7z4etj","to_address":
+  //   "maya1g9el7lzjwh9yun2c4jjzhy09j98vkhfxfqkl5k"}}],"sequence":"19"}
+  // The bytes recorded when this file was written never matched: the file
+  // was not in the unit build (see 28c74a0e) so the vector was never
+  // validated, and it did not verify against this fixture's key/JSON.
   EXPECT_TRUE(
       memcmp(signature,
-             (uint8_t *)"\x8a\x91\x43\x54\xca\xe7\x45\x30\x0e\xfb\x88\xee\xdd"
-                        "\xac\xc0\xb5\xa3\x3d\x18\xb1\xe6\x54\x26\x70\x8f\x93"
-                        "\x69\x67\xd5\x21\x84\xbb\x6b\x58\x3d\xe3\x21\xd0\x3e"
-                        "\x26\xb2\xd8\x00\x7d\x81\x84\x34\x82\x5a\xfa\xa2\x80"
-                        "\x54\x88\x90\xc6\xec\xf0\x3b\xf5\x33\x0f\x3e\x9a",
+             (uint8_t *)"\xdf\x2f\x66\x37\x03\x08\x32\xd2\xce\x87\xfe\x47\x8d"
+                        "\xdf\xe6\xd8\x21\xd2\x6b\x03\x8b\x44\xfa\xc8\x98\xe6"
+                        "\xdf\x79\xe3\xfd\x10\x5d\x40\x3f\x05\x0d\x00\xad\xf9"
+                        "\x7d\x3e\xd3\xa7\x3d\xa6\x9b\x19\x74\x0c\x6a\xbc\xf6"
+                        "\x94\x09\x57\x29\xa3\xf0\xc3\x62\xc9\xf0\xfa\x71",
              64) == 0);
+}
+
+// Denom validation: only [a-z0-9./\-] is allowed; anything else is rejected
+TEST(Mayachain, MayachainDenomValidation) {
+  EXPECT_TRUE(mayachain_isValidDenom("cacao"));
+  EXPECT_TRUE(mayachain_isValidDenom("maya"));
+  EXPECT_TRUE(mayachain_isValidDenom("eth.eth"));
+  EXPECT_TRUE(mayachain_isValidDenom("btc/btc"));
+  EXPECT_TRUE(mayachain_isValidDenom("cross-chain"));
+
+  EXPECT_FALSE(mayachain_isValidDenom(""));         // empty → caller "cacao"
+  EXPECT_FALSE(mayachain_isValidDenom("CACAO"));    // uppercase rejected
+  EXPECT_FALSE(mayachain_isValidDenom("cacao\""));  // quote injection
+  EXPECT_FALSE(mayachain_isValidDenom("cacao\\n"));  // backslash injection
+  EXPECT_FALSE(mayachain_isValidDenom(" cacao"));    // leading space
+  EXPECT_FALSE(mayachain_isValidDenom("ca cao"));    // embedded space
+}
+
+/* ===================================================================== *
+ *  mayachain_parseConfirmMemo — swap-memo clear-signing.
+ *  Mirrors the thorchain.cpp memo tests; see kkconfirm_preload docs there.
+ * ===================================================================== */
+
+static bool parseMayaMemo(const char *memo, size_t size) {
+  return mayachain_parseConfirmMemo(memo, size);
+}
+static bool parseMayaMemo(const char *memo) {
+  return parseMayaMemo(memo, strlen(memo) + 1);
+}
+
+// Classic full-form swap memo = 4 screens (4th is the affiliate fee screen)
+TEST(Mayachain, MemoSwapFullFormShowsAffiliate) {
+  ASSERT_TRUE(kkconfirm_preload(4, 0));
+  EXPECT_TRUE(parseMayaMemo(
+      "SWAP:ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7:"
+      "0x41e5560054824ea6b0732e656e3ad64e20e94e45:420:kk:75"));
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+// No '.' in the asset field (no chain.asset pair): raw-memo fallback
+TEST(Mayachain, MemoSwapNoChainAssetPair) {
+  ASSERT_TRUE(kkconfirm_preload(0, 0));
+  EXPECT_FALSE(parseMayaMemo("=:e:0xdest:0/1/0:kk:75"));
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+// Empty limit must NOT shift the affiliate into the limit slot: 4 screens
+TEST(Mayachain, MemoSwapEmptyLimitDoesNotShift) {
+  ASSERT_TRUE(kkconfirm_preload(4, 0));
+  EXPECT_TRUE(parseMayaMemo("=:ETH.ETH:0xdest::kk:75"));
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+// No affiliate: exactly the 3 historical screens
+TEST(Mayachain, MemoSwapNoAffiliate) {
+  ASSERT_TRUE(kkconfirm_preload(3, 0));
+  EXPECT_TRUE(parseMayaMemo("SWAP:ETH.ETH:0xdest:420"));
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+// ADD with a pool address: 2 screens (unchanged behavior)
+TEST(Mayachain, MemoAddWithPool) {
+  ASSERT_TRUE(kkconfirm_preload(2, 0));
+  EXPECT_TRUE(
+      parseMayaMemo("ADD:BTC.BTC:maya1g9el7lzjwh9yun2c4jjzhy09j98vkhfxfqkl5k"));
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+// WITHDRAW with basis points: 1 screen; without: malformed
+TEST(Mayachain, MemoWithdraw) {
+  ASSERT_TRUE(kkconfirm_preload(1, 0));
+  EXPECT_TRUE(parseMayaMemo("WITHDRAW:BTC.BTC:5000"));
+  EXPECT_FALSE(parseMayaMemo("wd:BTC.BTC"));
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+// Garbage / oversized memos fall back to raw-memo confirmation
+TEST(Mayachain, MemoGarbageAndOversized) {
+  ASSERT_TRUE(kkconfirm_preload(0, 0));
+  EXPECT_FALSE(parseMayaMemo("hello world"));
+  EXPECT_FALSE(parseMayaMemo("SWAP:ETH.ETH:0xdest:420", 257));
+  EXPECT_EQ(0, kkconfirm_drain());
 }

--- a/unittests/firmware/mayachain.cpp
+++ b/unittests/firmware/mayachain.cpp
@@ -7,6 +7,7 @@ extern "C" {
 
 #include "gtest/gtest.h"
 #include <cstring>
+#include <string>
 
 // confirm() auto-accept driver, defined in thorchain.cpp (same binary).
 // kkconfirm_preload(nYes, nNo) queues nYes accepted confirm screens then
@@ -106,6 +107,44 @@ TEST(Mayachain, MayachainDenomValidation) {
   EXPECT_FALSE(mayachain_isValidDenom("ca cao"));    // embedded space
 }
 
+// The signer function itself must reject an invalid denom — not merely
+// rely on the FSM caller to pre-validate — so it stays safe if reused or
+// called directly. Empty denom must still default to "cacao" and succeed.
+TEST(Mayachain, MayachainSignTxUpdateMsgSendRejectsInvalidDenom) {
+  HDNode node = {
+      0,
+      0,
+      {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+      {0xb9, 0x9a, 0x39, 0x3a, 0x5a, 0x53, 0x0d, 0x90, 0xef, 0x6e, 0x46,
+       0x4e, 0x8e, 0x2f, 0x2b, 0x8b, 0x5c, 0x64, 0xa7, 0x97, 0x29, 0xcd,
+       0x60, 0x3b, 0x1f, 0xba, 0x33, 0x81, 0x7d, 0x1a, 0x75, 0xa1},
+      {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+      {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+      &secp256k1_info};
+  hdnode_fill_public_key(&node);
+
+  const MayachainSignTx msg = {
+      5,    {0x80000000 | 44, 0x80000000 | 931, 0x80000000, 0, 0},
+      true, 6359,
+      true, "mayachain-mainnet-v1",
+      true, 3000,
+      true, 200000,
+      true, "",
+      true, 19,
+      true, 1};
+
+  ASSERT_TRUE(mayachain_signTxInit(&node, &msg));
+  EXPECT_FALSE(mayachain_signTxUpdateMsgSend(
+      100, "maya1g9el7lzjwh9yun2c4jjzhy09j98vkhfxfqkl5k", "cacao\""));
+
+  ASSERT_TRUE(mayachain_signTxInit(&node, &msg));
+  EXPECT_TRUE(mayachain_signTxUpdateMsgSend(
+      100, "maya1g9el7lzjwh9yun2c4jjzhy09j98vkhfxfqkl5k", ""));
+}
+
 /* ===================================================================== *
  *  mayachain_parseConfirmMemo — swap-memo clear-signing.
  *  Mirrors the thorchain.cpp memo tests; see kkconfirm_preload docs there.
@@ -172,6 +211,22 @@ TEST(Mayachain, MemoRawBytesNoNulKeepsLastChar) {
   ASSERT_TRUE(kkconfirm_preload(4, 0));
   const char raw[] = "=:ETH.ETH:0xdest:420:k";
   EXPECT_TRUE(parseMayaMemo(raw, sizeof(raw) - 1)); /* no NUL counted */
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+// A raw memo that fills the internal buffer's entire documented capacity
+// (size == 256, the parser's own <=256 contract) must ALSO keep its last
+// byte — this is the boundary the copy-length clamp missed.
+TEST(Mayachain, MemoExactBufferCapacityKeepsLastChar) {
+  const std::string prefix = "=:ETH.ETH:0x";
+  const std::string suffix = ":420:k"; // 1-char affiliate as the last byte
+  std::string memo = prefix + std::string(256 - prefix.size() - suffix.size(),
+                                          'd') +
+                     suffix;
+  ASSERT_EQ(memo.size(), 256u);
+
+  ASSERT_TRUE(kkconfirm_preload(4, 0));
+  EXPECT_TRUE(parseMayaMemo(memo.c_str(), memo.size())); /* no NUL counted */
   EXPECT_EQ(0, kkconfirm_drain());
 }
 

--- a/unittests/firmware/mayachain.cpp
+++ b/unittests/firmware/mayachain.cpp
@@ -165,6 +165,16 @@ TEST(Mayachain, MemoWithdraw) {
 }
 
 // Garbage / oversized memos fall back to raw-memo confirmation
+// BTC OP_RETURN passes RAW memo bytes with no NUL and size = byte count.
+// Every byte must survive the copy — the historical off-by-one dropped
+// the last char (1-char affiliate vanished: 3 screens instead of 4).
+TEST(Mayachain, MemoRawBytesNoNulKeepsLastChar) {
+  ASSERT_TRUE(kkconfirm_preload(4, 0));
+  const char raw[] = "=:ETH.ETH:0xdest:420:k";
+  EXPECT_TRUE(parseMayaMemo(raw, sizeof(raw) - 1)); /* no NUL counted */
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
 TEST(Mayachain, MemoGarbageAndOversized) {
   ASSERT_TRUE(kkconfirm_preload(0, 0));
   EXPECT_FALSE(parseMayaMemo("hello world"));

--- a/unittests/firmware/solana.cpp
+++ b/unittests/firmware/solana.cpp
@@ -480,15 +480,27 @@ TEST(Solana, RejectsExcessInstructions) {
   memset(raw + pos, 0xBB, 32);
   pos += 32;
 
-  /* 9 instructions (exceeds limit of 8) */
+  /* 9 instructions (exceeds limit of 8), each minimal but well-formed:
+   * program_idx + zero account indices + zero data bytes */
   raw[pos++] = 9;
+  for (int i = 0; i < 9; i++) {
+    raw[pos++] = 1; /* program = account 1 */
+    raw[pos++] = 0; /* no account indices */
+    raw[pos++] = 0; /* no data */
+  }
 
   SolanaParsedTx tx;
   EXPECT_EQ(solana_inspectTx(raw, pos, &tx), SOL_TX_REVIEW_OPAQUE);
   EXPECT_FALSE(solana_parseTx(raw, pos, &tx));
+
+  /* A claimed instruction count with truncated bodies is malformed */
+  uint8_t truncated[256];
+  memcpy(truncated, raw, pos - 27);
+  EXPECT_EQ(solana_inspectTx(truncated, pos - 27, &tx),
+            SOL_TX_REVIEW_MALFORMED);
 }
 
-TEST(Solana, VersionedMessageIsOpaque) {
+TEST(Solana, VersionedMessageNoLookupTablesIsVerified) {
   uint8_t raw[256];
   size_t pos = 0;
 
@@ -529,12 +541,20 @@ TEST(Solana, VersionedMessageIsOpaque) {
 
   raw[pos++] = 0; /* zero lookup tables */
 
+  /* A v0 message whose instructions touch only static accounts is as
+   * verifiable as a legacy message — swap providers build these. */
   SolanaParsedTx tx;
-  EXPECT_EQ(solana_inspectTx(raw, pos, &tx), SOL_TX_REVIEW_OPAQUE);
-  EXPECT_FALSE(solana_parseTx(raw, pos, &tx));
+  EXPECT_EQ(solana_inspectTx(raw, pos, &tx), SOL_TX_REVIEW_VERIFIED);
+  EXPECT_TRUE(solana_parseTx(raw, pos, &tx));
+  ASSERT_EQ(tx.num_instructions, 1);
+  EXPECT_EQ(tx.instructions[0].type, SOL_INSTR_SYSTEM_TRANSFER);
+  EXPECT_EQ(tx.instructions[0].lamports, 1000000000ULL);
+  uint8_t expected_to[32];
+  memset(expected_to, 0x22, 32);
+  EXPECT_EQ(memcmp(tx.instructions[0].to, expected_to, 32), 0);
 }
 
-TEST(Solana, VersionedMessageWithLookupTableIsOpaque) {
+TEST(Solana, VersionedMessageWithUnreferencedLookupTableIsVerified) {
   uint8_t raw[256];
   size_t pos = 0;
 
@@ -582,9 +602,125 @@ TEST(Solana, VersionedMessageWithLookupTableIsOpaque) {
   raw[pos++] = 1;
   raw[pos++] = 2;
 
+  /* Table attached but no instruction reaches into it: every displayed
+   * field is decoded from static accounts, so it stays verifiable. */
+  SolanaParsedTx tx;
+  EXPECT_EQ(solana_inspectTx(raw, pos, &tx), SOL_TX_REVIEW_VERIFIED);
+  EXPECT_TRUE(solana_parseTx(raw, pos, &tx));
+}
+
+TEST(Solana, VersionedInstructionUsingLookupAccountIsOpaque) {
+  uint8_t raw[256];
+  size_t pos = 0;
+
+  raw[pos++] = 0x80; /* v0 prefix */
+  raw[pos++] = 1;
+  raw[pos++] = 0;
+  raw[pos++] = 1;
+
+  raw[pos++] = 3; /* static accounts */
+  memset(raw + pos, 0x11, 32);
+  pos += 32;
+  memset(raw + pos, 0x22, 32);
+  pos += 32;
+  memset(raw + pos, 0x00, 32);
+  pos += 32;
+
+  memset(raw + pos, 0xBB, 32);
+  pos += 32;
+
+  raw[pos++] = 1; /* instructions */
+  raw[pos++] = 2; /* program = system (static) */
+  raw[pos++] = 2;
+  raw[pos++] = 0;
+  raw[pos++] = 3; /* index 3 = first lookup-table account */
+  raw[pos++] = 12;
+  raw[pos++] = 2;
+  raw[pos++] = 0;
+  raw[pos++] = 0;
+  raw[pos++] = 0;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0xCA;
+  raw[pos++] = 0x9A;
+  raw[pos++] = 0x3B;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+
+  raw[pos++] = 1; /* one lookup table */
+  memset(raw + pos, 0x55, 32);
+  pos += 32;
+  raw[pos++] = 1;
+  raw[pos++] = 0;
+  raw[pos++] = 0;
+
+  /* The recipient lives in a lookup table the device cannot resolve —
+   * must be opaque (blind-signable under AdvancedMode), NOT malformed,
+   * and NEVER verified. */
   SolanaParsedTx tx;
   EXPECT_EQ(solana_inspectTx(raw, pos, &tx), SOL_TX_REVIEW_OPAQUE);
   EXPECT_FALSE(solana_parseTx(raw, pos, &tx));
+}
+
+TEST(Solana, MemoBodyCaptured) {
+  /* Legacy tx: system transfer + memo instruction (THORChain-style swap
+   * memo). The parser must expose the memo bytes for display. */
+  const char* memo = "=:ETH.ETH:0x1234:0/1/0:kk:75";
+  uint8_t raw[512];
+  size_t pos = 0;
+
+  raw[pos++] = 1;
+  raw[pos++] = 0;
+  raw[pos++] = 2; /* system + memo programs readonly */
+
+  raw[pos++] = 4; /* accounts: sender, recipient, system, memo */
+  memset(raw + pos, 0x11, 32);
+  pos += 32;
+  memset(raw + pos, 0x22, 32);
+  pos += 32;
+  memset(raw + pos, 0x00, 32); /* system program */
+  pos += 32;
+  memcpy(raw + pos, SOL_MEMO_PROGRAM, 32);
+  pos += 32;
+
+  memset(raw + pos, 0xBB, 32); /* blockhash */
+  pos += 32;
+
+  raw[pos++] = 2; /* two instructions */
+
+  /* transfer */
+  raw[pos++] = 2;
+  raw[pos++] = 2;
+  raw[pos++] = 0;
+  raw[pos++] = 1;
+  raw[pos++] = 12;
+  raw[pos++] = 2;
+  raw[pos++] = 0;
+  raw[pos++] = 0;
+  raw[pos++] = 0;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0xCA;
+  raw[pos++] = 0x9A;
+  raw[pos++] = 0x3B;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+  raw[pos++] = 0x00;
+
+  /* memo */
+  raw[pos++] = 3; /* program = memo */
+  raw[pos++] = 0; /* no accounts */
+  raw[pos++] = (uint8_t)strlen(memo);
+  memcpy(raw + pos, memo, strlen(memo));
+  pos += strlen(memo);
+
+  SolanaParsedTx tx;
+  EXPECT_EQ(solana_inspectTx(raw, pos, &tx), SOL_TX_REVIEW_VERIFIED);
+  ASSERT_EQ(tx.num_instructions, 2);
+  EXPECT_EQ(tx.instructions[1].type, SOL_INSTR_MEMO);
+  ASSERT_EQ(tx.instructions[1].data_len, strlen(memo));
+  EXPECT_EQ(memcmp(tx.instructions[1].data, memo, strlen(memo)), 0);
 }
 
 TEST(Solana, MalformedVersionedLookupTableRejects) {

--- a/unittests/firmware/thorchain.cpp
+++ b/unittests/firmware/thorchain.cpp
@@ -383,6 +383,18 @@ TEST(Thorchain, MemoGarbage) {
   EXPECT_EQ(0, kkconfirm_drain());
 }
 
+// BTC OP_RETURN passes RAW memo bytes with no NUL and size = byte count
+// (transaction.c). Every byte must survive the copy: dropping the last
+// character turns affiliate "kk" into "k" — or a fee of 75 bps into 7.
+// This memo's affiliate is 1 char, so the historical off-by-one would
+// lose it entirely and show only 3 screens instead of 4.
+TEST(Thorchain, MemoRawBytesNoNulKeepsLastChar) {
+  ASSERT_TRUE(kkconfirm_preload(4, 0));
+  const char raw[] = "=:ETH.ETH:0xdest:420:k";
+  EXPECT_TRUE(parseMemo(raw, sizeof(raw) - 1)); /* no NUL counted */
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
 // Oversized input (> 256) is rejected outright
 TEST(Thorchain, MemoOversized) {
   ASSERT_TRUE(kkconfirm_preload(0, 0));

--- a/unittests/firmware/thorchain.cpp
+++ b/unittests/firmware/thorchain.cpp
@@ -14,6 +14,7 @@ void kk_board_init(void);
 
 #include "gtest/gtest.h"
 #include <cstring>
+#include <string>
 
 #include <arpa/inet.h>
 #include <netinet/in.h>
@@ -392,6 +393,22 @@ TEST(Thorchain, MemoRawBytesNoNulKeepsLastChar) {
   ASSERT_TRUE(kkconfirm_preload(4, 0));
   const char raw[] = "=:ETH.ETH:0xdest:420:k";
   EXPECT_TRUE(parseMemo(raw, sizeof(raw) - 1)); /* no NUL counted */
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+// A raw memo that fills the internal buffer's entire documented capacity
+// (size == 256, the parser's own <=256 contract) must ALSO keep its last
+// byte — this is the boundary the copy-length clamp missed.
+TEST(Thorchain, MemoExactBufferCapacityKeepsLastChar) {
+  const std::string prefix = "=:ETH.ETH:0x";
+  const std::string suffix = ":420:k"; // 1-char affiliate as the last byte
+  std::string memo = prefix + std::string(256 - prefix.size() - suffix.size(),
+                                          'd') +
+                     suffix;
+  ASSERT_EQ(memo.size(), 256u);
+
+  ASSERT_TRUE(kkconfirm_preload(4, 0));
+  EXPECT_TRUE(parseMemo(memo.c_str(), memo.size())); /* no NUL counted */
   EXPECT_EQ(0, kkconfirm_drain());
 }
 

--- a/unittests/firmware/thorchain.cpp
+++ b/unittests/firmware/thorchain.cpp
@@ -1,12 +1,101 @@
 extern "C" {
+#include "keepkey/board/messages.h"
+#include "keepkey/board/usb.h"
 #include "keepkey/firmware/coins.h"
+#include "keepkey/firmware/fsm.h"
 #include "keepkey/firmware/thorchain.h"
 #include "keepkey/firmware/tendermint.h"
 #include "trezor/crypto/secp256k1.h"
+
+// From keepkey_board.h, which we can't include here: its shutdown(void)
+// declaration clashes with sys/socket.h's shutdown(int, int).
+void kk_board_init(void);
 }
 
 #include "gtest/gtest.h"
 #include <cstring>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+/*
+ * confirm() auto-accept driver for unit tests.
+ *
+ * In the emulator/unittest build (always DEBUG_LINK), confirm_helper()
+ * busy-polls the emulator's UDP "usb" port for tiny messages and returns
+ * once it has seen a ButtonAck plus a DebugLinkDecision. Each confirm
+ * screen therefore consumes exactly one ButtonAck + one DebugLinkDecision
+ * from the socket queue. Preloading exactly N accept pairs before invoking
+ * the code under test auto-accepts exactly N screens, and
+ * kkconfirm_drain() == 0 afterwards proves exactly N screens were shown
+ * (fewer screens leave packets queued; more screens would hang the test).
+ *
+ * These helpers have external linkage so mayachain.cpp can share the
+ * one-time board/usb initialization.
+ */
+
+static bool kkconfirm_sendTiny(uint16_t msgId, const uint8_t *payload,
+                               uint8_t len) {
+  static int fd = -1;
+  if (fd < 0) fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+  if (fd < 0) return false;
+
+  uint8_t frame[64] = {0};
+  frame[0] = '?';
+  frame[1] = '#';
+  frame[2] = '#';
+  frame[3] = msgId >> 8;
+  frame[4] = msgId & 0xff;
+  frame[8] = len;  // bytes 5..7 are the high bits of the big-endian size
+  if (len) memcpy(&frame[9], payload, len);
+
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(11044);  // emulator main "usb" port
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  return sendto(fd, frame, sizeof(frame), 0, (struct sockaddr *)&addr,
+                sizeof(addr)) == (ssize_t)sizeof(frame);
+}
+
+// Queue nYes accepted screens followed by nNo rejected screens.
+bool kkconfirm_preload(int nYes, int nNo) {
+  static bool initialized = false;
+  if (!initialized) {
+    kk_board_init();  // canvas + runnable queues for confirm's draw path
+    fsm_init();       // registers the usb rx callback + message maps
+    usbInit("");      // binds the emulator UDP ports
+    initialized = true;
+  }
+
+  static const uint8_t yes[] = {0x08, 0x01};  // DebugLinkDecision.yes_no
+  static const uint8_t no[] = {0x08, 0x00};
+  for (int i = 0; i < nYes + nNo; i++) {
+    if (!kkconfirm_sendTiny(MessageType_MessageType_ButtonAck, NULL, 0))
+      return false;
+    const uint8_t *decision = (i < nYes) ? yes : no;
+    if (!kkconfirm_sendTiny(MessageType_MessageType_DebugLinkDecision,
+                            decision, 2))
+      return false;
+  }
+  return true;
+}
+
+// Consume and count any tiny messages left in the queue.
+int kkconfirm_drain(void) {
+  uint8_t buf[MSG_TINY_BFR_SZ];
+  int n = 0;
+  for (;;) {
+    // volatile: 0xFFFF (MSG_TINY_TYPE_ERROR) is outside the MessageType
+    // enum range, so an unguarded comparison is a tautology the compiler
+    // may fold away.
+    volatile uint16_t id = (uint16_t)check_for_tiny_msg(buf);
+    if (id == MSG_TINY_TYPE_ERROR) break;
+    n++;
+  }
+  return n;
+}
 
 // Vectors computed with the trezor-crypto library directly (see
 // unittests/firmware/thorchain.cpp notes). The test file was previously
@@ -185,4 +274,118 @@ TEST(Thorchain, ThorchainSignTxInvalidDenom) {
   EXPECT_FALSE(thorchain_signTxUpdateMsgSend(100000, kToAddr,
                                              "rune\",\"from_address\":\"evil"));
   thorchain_signAbort();
+}
+
+/* ===================================================================== *
+ *  thorchain_parseConfirmMemo — swap-memo clear-signing.
+ *  Screen counts are asserted exactly: kkconfirm_preload(N, 0) accepts N
+ *  screens and kkconfirm_drain() == 0 proves N screens were shown.
+ * ===================================================================== */
+
+static bool parseMemo(const char *memo, size_t size) {
+  return thorchain_parseConfirmMemo(memo, size);
+}
+static bool parseMemo(const char *memo) {
+  return parseMemo(memo, strlen(memo) + 1);
+}
+
+// Classic full-form swap memo: asset + dest + limit + affiliate + fee bps
+// = 4 screens (the 4th is the new affiliate fee screen)
+TEST(Thorchain, MemoSwapFullFormShowsAffiliate) {
+  ASSERT_TRUE(kkconfirm_preload(4, 0));
+  EXPECT_TRUE(
+      parseMemo("SWAP:ETH.USDT-0xdac17f958d2ee523a2206206994597c13d831ec7:"
+                "0x41e5560054824ea6b0732e656e3ad64e20e94e45:420:kk:75"));
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+// Abbreviated asset with no '.' (no chain.asset pair) is not parseable
+// thorchain data: raw-memo fallback
+TEST(Thorchain, MemoSwapNoChainAssetPair) {
+  ASSERT_TRUE(kkconfirm_preload(0, 0));
+  EXPECT_FALSE(parseMemo("=:e:0xdest:0/1/0:kk:75"));
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+// Empty limit field must NOT shift the affiliate into the limit slot: it
+// must still take 4 screens (limit "none" + separate affiliate screen).
+// The old strtok tokenizer collapsed the empty field and displayed the
+// affiliate ("kk") as the limit in 3 screens.
+TEST(Thorchain, MemoSwapEmptyLimitDoesNotShift) {
+  ASSERT_TRUE(kkconfirm_preload(4, 0));
+  EXPECT_TRUE(parseMemo("=:ETH.ETH:0xdest::kk:75"));
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+// No affiliate: exactly the 3 historical screens, no affiliate screen
+TEST(Thorchain, MemoSwapNoAffiliate) {
+  ASSERT_TRUE(kkconfirm_preload(3, 0));
+  EXPECT_TRUE(parseMemo("SWAP:ETH.ETH:0xdest:420"));
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+// Affiliate present but fee absent: affiliate screen still shows (fee "0")
+TEST(Thorchain, MemoSwapAffiliateNoFee) {
+  ASSERT_TRUE(kkconfirm_preload(4, 0));
+  EXPECT_TRUE(parseMemo("SWAP:ETH.ETH:0xdest:420:kk"));
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+// Missing dest and limit: still 3 screens ("self" / "none")
+TEST(Thorchain, MemoSwapMinimal) {
+  ASSERT_TRUE(kkconfirm_preload(3, 0));
+  EXPECT_TRUE(parseMemo("SWAP:ETH.ETH"));
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+// Rejecting a screen aborts the whole confirmation
+TEST(Thorchain, MemoSwapRejectPropagates) {
+  ASSERT_TRUE(kkconfirm_preload(2, 1));
+  EXPECT_FALSE(parseMemo("SWAP:ETH.ETH:0xdest:420"));
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+// ADD with a pool address: 2 screens (unchanged behavior)
+TEST(Thorchain, MemoAddWithPool) {
+  ASSERT_TRUE(kkconfirm_preload(2, 0));
+  EXPECT_TRUE(
+      parseMemo("ADD:BTC.BTC:thor18vhdczjut44gpsy804crfhnd5nq003nz0nf20v"));
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+// ADD without a pool address: 1 screen (unchanged behavior)
+TEST(Thorchain, MemoAddWithoutPool) {
+  ASSERT_TRUE(kkconfirm_preload(1, 0));
+  EXPECT_TRUE(parseMemo("+:BTC.BTC"));
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+// WITHDRAW with basis points: 1 screen (unchanged behavior)
+TEST(Thorchain, MemoWithdraw) {
+  ASSERT_TRUE(kkconfirm_preload(1, 0));
+  EXPECT_TRUE(parseMemo("WITHDRAW:BTC.BTC:5000"));
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+// WITHDRAW without basis points is malformed (unchanged behavior)
+TEST(Thorchain, MemoWithdrawMissingBps) {
+  ASSERT_TRUE(kkconfirm_preload(0, 0));
+  EXPECT_FALSE(parseMemo("wd:BTC.BTC"));
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+// Garbage memos fall back to raw-memo confirmation
+TEST(Thorchain, MemoGarbage) {
+  ASSERT_TRUE(kkconfirm_preload(0, 0));
+  EXPECT_FALSE(parseMemo("hello world"));
+  EXPECT_FALSE(parseMemo("NOTATHING:ETH.ETH:0xdest"));
+  EXPECT_FALSE(parseMemo(""));
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+// Oversized input (> 256) is rejected outright
+TEST(Thorchain, MemoOversized) {
+  ASSERT_TRUE(kkconfirm_preload(0, 0));
+  EXPECT_FALSE(parseMemo("SWAP:ETH.ETH:0xdest:420", 257));
+  EXPECT_EQ(0, kkconfirm_drain());
 }

--- a/unittests/firmware/tron.cpp
+++ b/unittests/firmware/tron.cpp
@@ -1,0 +1,430 @@
+extern "C" {
+#include "keepkey/firmware/tron.h"
+}
+
+#include "gtest/gtest.h"
+#include <cstring>
+#include <vector>
+
+/* ------------------------------------------------------------------ */
+/*  Minimal protobuf wire-format writer for building raw_data vectors  */
+/* ------------------------------------------------------------------ */
+
+namespace {
+
+void putVarint(std::vector<uint8_t>& out, uint64_t v) {
+  while (v >= 0x80) {
+    out.push_back(static_cast<uint8_t>(v) | 0x80);
+    v >>= 7;
+  }
+  out.push_back(static_cast<uint8_t>(v));
+}
+
+void putKey(std::vector<uint8_t>& out, uint32_t field, uint8_t wire) {
+  putVarint(out, (static_cast<uint64_t>(field) << 3) | wire);
+}
+
+void putVarintField(std::vector<uint8_t>& out, uint32_t field, uint64_t v) {
+  putKey(out, field, 0);
+  putVarint(out, v);
+}
+
+void putBytesField(std::vector<uint8_t>& out, uint32_t field,
+                   const std::vector<uint8_t>& bytes) {
+  putKey(out, field, 2);
+  putVarint(out, bytes.size());
+  out.insert(out.end(), bytes.begin(), bytes.end());
+}
+
+void putStringField(std::vector<uint8_t>& out, uint32_t field,
+                    const char* str) {
+  putBytesField(out, field,
+                std::vector<uint8_t>(str, str + strlen(str)));
+}
+
+std::vector<uint8_t> tronAddr(uint8_t fill) {
+  std::vector<uint8_t> a(21, fill);
+  a[0] = 0x41;
+  return a;
+}
+
+/* protocol.TransferContract { owner=1, to=2, amount=3 } */
+std::vector<uint8_t> transferContractValue(const std::vector<uint8_t>& owner,
+                                           const std::vector<uint8_t>& to,
+                                           uint64_t amount) {
+  std::vector<uint8_t> v;
+  putBytesField(v, 1, owner);
+  putBytesField(v, 2, to);
+  putVarintField(v, 3, amount);
+  return v;
+}
+
+/* TRC-20 transfer(address,uint256) calldata */
+std::vector<uint8_t> trc20Calldata(const std::vector<uint8_t>& to21,
+                                   uint64_t amount, bool tronStylePrefix) {
+  std::vector<uint8_t> d = {0xa9, 0x05, 0x9c, 0xbb};
+  /* address word */
+  for (int i = 0; i < 11; i++) d.push_back(0);
+  d.push_back(tronStylePrefix ? 0x41 : 0x00);
+  d.insert(d.end(), to21.begin() + 1, to21.end()); /* low 20 bytes */
+  /* amount word: big-endian uint256 */
+  for (int i = 0; i < 24; i++) d.push_back(0);
+  for (int i = 7; i >= 0; i--)
+    d.push_back(static_cast<uint8_t>(amount >> (8 * i)));
+  return d;
+}
+
+/* protocol.TriggerSmartContract { owner=1, contract=2, call_value=3, data=4 } */
+std::vector<uint8_t> triggerContractValue(const std::vector<uint8_t>& owner,
+                                          const std::vector<uint8_t>& contract,
+                                          const std::vector<uint8_t>& data) {
+  std::vector<uint8_t> v;
+  putBytesField(v, 1, owner);
+  putBytesField(v, 2, contract);
+  putBytesField(v, 4, data);
+  return v;
+}
+
+/* Transaction.Contract { type=1, parameter=2 (Any{type_url=1, value=2}) } */
+std::vector<uint8_t> contractMsg(uint64_t type, const char* type_url,
+                                 const std::vector<uint8_t>& value) {
+  std::vector<uint8_t> any;
+  putStringField(any, 1, type_url);
+  putBytesField(any, 2, value);
+
+  std::vector<uint8_t> c;
+  putVarintField(c, 1, type);
+  putBytesField(c, 2, any);
+  return c;
+}
+
+/* Transaction.raw with typical TronGrid framing */
+std::vector<uint8_t> rawTx(const std::vector<uint8_t>& contract,
+                           const char* memo, uint64_t fee_limit) {
+  std::vector<uint8_t> raw;
+  putBytesField(raw, 1, {0xab, 0xcd});                     /* ref_block_bytes */
+  putBytesField(raw, 4, std::vector<uint8_t>(8, 0x5a));    /* ref_block_hash */
+  putVarintField(raw, 8, 1750000000000ULL);                /* expiration */
+  if (memo) putStringField(raw, 10, memo);
+  putBytesField(raw, 11, contract);
+  putVarintField(raw, 14, 1749999000000ULL);               /* timestamp */
+  if (fee_limit) putVarintField(raw, 18, fee_limit);
+  return raw;
+}
+
+const char* TRANSFER_URL = "type.googleapis.com/protocol.TransferContract";
+const char* TRIGGER_URL = "type.googleapis.com/protocol.TriggerSmartContract";
+
+}  // namespace
+
+TEST(Tron, ParseNativeTransfer) {
+  auto owner = tronAddr(0x11);
+  auto to = tronAddr(0x22);
+  auto raw = rawTx(contractMsg(1, TRANSFER_URL,
+                               transferContractValue(owner, to, 1000000)),
+                   nullptr, 0);
+
+  TronParsedTx parsed;
+  EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),
+            TRON_TX_TRANSFER);
+  EXPECT_EQ(memcmp(parsed.owner, owner.data(), 21), 0);
+  EXPECT_EQ(memcmp(parsed.to, to.data(), 21), 0);
+  EXPECT_EQ(parsed.amount, 1000000u);
+  EXPECT_FALSE(parsed.has_fee_limit);
+  EXPECT_EQ(parsed.memo_len, 0);
+}
+
+TEST(Tron, ParseNativeTransferWithSwapMemo) {
+  const char* memo = "=:ETH.ETH:0x41e5560054824ea6b0732e656e3ad64e20e94e45:0/1/0:kk:75";
+  auto raw = rawTx(contractMsg(1, TRANSFER_URL,
+                               transferContractValue(tronAddr(0x11),
+                                                     tronAddr(0x22), 5000000)),
+                   memo, 0);
+
+  TronParsedTx parsed;
+  EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),
+            TRON_TX_TRANSFER);
+  ASSERT_EQ(parsed.memo_len, strlen(memo));
+  EXPECT_EQ(memcmp(parsed.memo, memo, parsed.memo_len), 0);
+}
+
+TEST(Tron, ParseTrc20Transfer) {
+  auto owner = tronAddr(0x11);
+  auto to = tronAddr(0x22);
+  auto token = tronAddr(0x33);
+  for (bool tronStyle : {false, true}) {
+    auto raw = rawTx(
+        contractMsg(31, TRIGGER_URL,
+                    triggerContractValue(
+                        owner, token, trc20Calldata(to, 123456789, tronStyle))),
+        nullptr, 100000000 /* 100 TRX fee_limit */);
+
+    TronParsedTx parsed;
+    EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),
+              TRON_TX_TRC20_TRANSFER);
+    EXPECT_EQ(memcmp(parsed.owner, owner.data(), 21), 0);
+    EXPECT_EQ(memcmp(parsed.to, to.data(), 21), 0);
+    EXPECT_EQ(memcmp(parsed.contract, token.data(), 21), 0);
+    EXPECT_TRUE(parsed.has_fee_limit);
+    EXPECT_EQ(parsed.fee_limit, 100000000u);
+
+    char amount[90];
+    ASSERT_TRUE(tron_formatTrc20Amount(parsed.trc20_amount, amount,
+                                       sizeof(amount)));
+    EXPECT_STREQ(amount, "123456789");
+  }
+}
+
+TEST(Tron, ParseTrc20TransferWithMemo) {
+  /* Vault splices THORChain swap memos into raw_data.data for TRC-20 swaps */
+  const char* memo = "=:e:0x1234:0:kk:75";
+  auto raw = rawTx(contractMsg(31, TRIGGER_URL,
+                               triggerContractValue(
+                                   tronAddr(0x11), tronAddr(0x33),
+                                   trc20Calldata(tronAddr(0x22), 42, false))),
+                   memo, 30000000);
+
+  TronParsedTx parsed;
+  EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),
+            TRON_TX_TRC20_TRANSFER);
+  ASSERT_EQ(parsed.memo_len, strlen(memo));
+  EXPECT_EQ(memcmp(parsed.memo, memo, parsed.memo_len), 0);
+}
+
+TEST(Tron, RejectWrongSelector) {
+  auto data = trc20Calldata(tronAddr(0x22), 42, false);
+  data[0] = 0x09; /* approve(address,uint256) = 0x095ea7b3... not transfer */
+  auto raw = rawTx(contractMsg(31, TRIGGER_URL,
+                               triggerContractValue(tronAddr(0x11),
+                                                    tronAddr(0x33), data)),
+                   nullptr, 0);
+
+  TronParsedTx parsed;
+  EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),
+            TRON_TX_UNVERIFIED);
+}
+
+TEST(Tron, RejectDirtyAddressWord) {
+  auto data = trc20Calldata(tronAddr(0x22), 42, false);
+  data[4 + 3] = 0x01; /* junk in the high bytes of the address word */
+  auto raw = rawTx(contractMsg(31, TRIGGER_URL,
+                               triggerContractValue(tronAddr(0x11),
+                                                    tronAddr(0x33), data)),
+                   nullptr, 0);
+
+  TronParsedTx parsed;
+  EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),
+            TRON_TX_UNVERIFIED);
+}
+
+TEST(Tron, RejectCalldataLengthMismatch) {
+  auto data = trc20Calldata(tronAddr(0x22), 42, false);
+  data.push_back(0x00); /* trailing byte — could smuggle params */
+  auto raw = rawTx(contractMsg(31, TRIGGER_URL,
+                               triggerContractValue(tronAddr(0x11),
+                                                    tronAddr(0x33), data)),
+                   nullptr, 0);
+
+  TronParsedTx parsed;
+  EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),
+            TRON_TX_UNVERIFIED);
+}
+
+TEST(Tron, RejectNonzeroCallValue) {
+  auto value = triggerContractValue(tronAddr(0x11), tronAddr(0x33),
+                                    trc20Calldata(tronAddr(0x22), 42, false));
+  std::vector<uint8_t> withCallValue;
+  putBytesField(withCallValue, 1, tronAddr(0x11));
+  putBytesField(withCallValue, 2, tronAddr(0x33));
+  putVarintField(withCallValue, 3, 7 /* nonzero TRX attached */);
+  putBytesField(withCallValue, 4, trc20Calldata(tronAddr(0x22), 42, false));
+  auto raw = rawTx(contractMsg(31, TRIGGER_URL, withCallValue), nullptr, 0);
+
+  TronParsedTx parsed;
+  EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),
+            TRON_TX_UNVERIFIED);
+
+  /* zero call_value explicitly present is fine */
+  std::vector<uint8_t> zeroCallValue;
+  putBytesField(zeroCallValue, 1, tronAddr(0x11));
+  putBytesField(zeroCallValue, 2, tronAddr(0x33));
+  putVarintField(zeroCallValue, 3, 0);
+  putBytesField(zeroCallValue, 4, trc20Calldata(tronAddr(0x22), 42, false));
+  raw = rawTx(contractMsg(31, TRIGGER_URL, zeroCallValue), nullptr, 0);
+  EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),
+            TRON_TX_TRC20_TRANSFER);
+}
+
+TEST(Tron, RejectTrc10Fields) {
+  std::vector<uint8_t> v;
+  putBytesField(v, 1, tronAddr(0x11));
+  putBytesField(v, 2, tronAddr(0x33));
+  putBytesField(v, 4, trc20Calldata(tronAddr(0x22), 42, false));
+  putVarintField(v, 5, 1000001); /* call_token_value / token_id territory */
+  auto raw = rawTx(contractMsg(31, TRIGGER_URL, v), nullptr, 0);
+
+  TronParsedTx parsed;
+  EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),
+            TRON_TX_UNVERIFIED);
+}
+
+TEST(Tron, RejectMultipleContracts) {
+  auto contract = contractMsg(
+      1, TRANSFER_URL,
+      transferContractValue(tronAddr(0x11), tronAddr(0x22), 1));
+  std::vector<uint8_t> raw;
+  putBytesField(raw, 11, contract);
+  putBytesField(raw, 11, contract);
+
+  TronParsedTx parsed;
+  EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),
+            TRON_TX_UNVERIFIED);
+}
+
+TEST(Tron, RejectUnknownTopLevelField) {
+  auto raw = rawTx(contractMsg(1, TRANSFER_URL,
+                               transferContractValue(tronAddr(0x11),
+                                                     tronAddr(0x22), 1)),
+                   nullptr, 0);
+  putBytesField(raw, 9, {0x01}); /* auths — permission delegation */
+
+  TronParsedTx parsed;
+  EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),
+            TRON_TX_UNVERIFIED);
+}
+
+TEST(Tron, RejectExtraFieldInTransferContract) {
+  auto value = transferContractValue(tronAddr(0x11), tronAddr(0x22), 1);
+  putVarintField(value, 4, 99);
+  auto raw = rawTx(contractMsg(1, TRANSFER_URL, value), nullptr, 0);
+
+  TronParsedTx parsed;
+  EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),
+            TRON_TX_UNVERIFIED);
+}
+
+TEST(Tron, RejectPermissionId) {
+  std::vector<uint8_t> any;
+  putStringField(any, 1, TRANSFER_URL);
+  putBytesField(any, 2,
+                transferContractValue(tronAddr(0x11), tronAddr(0x22), 1));
+  std::vector<uint8_t> c;
+  putVarintField(c, 1, 1);
+  putBytesField(c, 2, any);
+  putVarintField(c, 5, 2); /* Permission_id — multisig account slot */
+  auto raw = rawTx(c, nullptr, 0);
+
+  TronParsedTx parsed;
+  EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),
+            TRON_TX_UNVERIFIED);
+}
+
+TEST(Tron, RejectDuplicateAnyFields) {
+  /* Two type_urls in the Any wrapper — last-wins ambiguity, refuse. */
+  std::vector<uint8_t> any;
+  putStringField(any, 1, TRIGGER_URL);
+  putStringField(any, 1, TRANSFER_URL);
+  putBytesField(any, 2,
+                transferContractValue(tronAddr(0x11), tronAddr(0x22), 1));
+  std::vector<uint8_t> c;
+  putVarintField(c, 1, 1);
+  putBytesField(c, 2, any);
+  auto raw = rawTx(c, nullptr, 0);
+
+  TronParsedTx parsed;
+  EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),
+            TRON_TX_UNVERIFIED);
+
+  /* Two value fields likewise */
+  std::vector<uint8_t> any2;
+  putStringField(any2, 1, TRANSFER_URL);
+  putBytesField(any2, 2,
+                transferContractValue(tronAddr(0x11), tronAddr(0x22), 1));
+  putBytesField(any2, 2,
+                transferContractValue(tronAddr(0x11), tronAddr(0x33), 2));
+  std::vector<uint8_t> c2;
+  putVarintField(c2, 1, 1);
+  putBytesField(c2, 2, any2);
+  raw = rawTx(c2, nullptr, 0);
+  EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),
+            TRON_TX_UNVERIFIED);
+}
+
+TEST(Tron, RejectTypeUrlEnumMismatch) {
+  /* enum says TransferContract, Any says TriggerSmartContract */
+  auto raw = rawTx(contractMsg(1, TRIGGER_URL,
+                               transferContractValue(tronAddr(0x11),
+                                                     tronAddr(0x22), 1)),
+                   nullptr, 0);
+
+  TronParsedTx parsed;
+  EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),
+            TRON_TX_UNVERIFIED);
+}
+
+TEST(Tron, RejectBadOwnerAddress) {
+  auto owner = tronAddr(0x11);
+  owner[0] = 0x42; /* wrong network prefix */
+  auto raw = rawTx(contractMsg(1, TRANSFER_URL,
+                               transferContractValue(owner, tronAddr(0x22), 1)),
+                   nullptr, 0);
+
+  TronParsedTx parsed;
+  EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),
+            TRON_TX_UNVERIFIED);
+}
+
+TEST(Tron, RejectTruncated) {
+  /* Build with the contract as the LAST field: any truncation then either
+   * cuts into a field (parse failure) or drops the contract entirely —
+   * both must be UNVERIFIED. (Truncation at a field boundary that only
+   * drops benign trailing fields like timestamp is legal protobuf and
+   * stays verified — that case is exercised by the parse tests above.) */
+  std::vector<uint8_t> raw;
+  putBytesField(raw, 1, {0xab, 0xcd});
+  putVarintField(raw, 8, 1750000000000ULL);
+  putBytesField(raw, 11,
+                contractMsg(1, TRANSFER_URL,
+                            transferContractValue(tronAddr(0x11),
+                                                  tronAddr(0x22), 1000000)));
+  TronParsedTx sanity;
+  ASSERT_EQ(tron_parseRawTx(raw.data(), raw.size(), &sanity),
+            TRON_TX_TRANSFER);
+
+  for (size_t cut = 1; cut < raw.size(); cut++) {
+    TronParsedTx parsed;
+    EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size() - cut, &parsed),
+              TRON_TX_UNVERIFIED)
+        << "cut=" << cut;
+  }
+
+  TronParsedTx parsed;
+  EXPECT_EQ(tron_parseRawTx(nullptr, 0, &parsed), TRON_TX_UNVERIFIED);
+}
+
+TEST(Tron, FormatTrc20AmountUint256) {
+  uint8_t amount[32] = {0};
+  amount[31] = 0x01;
+  char buf[90];
+  ASSERT_TRUE(tron_formatTrc20Amount(amount, buf, sizeof(buf)));
+  EXPECT_STREQ(buf, "1");
+
+  /* 10^18 — an 18-decimals token unit */
+  uint8_t big[32] = {0};
+  const uint64_t e18 = 1000000000000000000ULL;
+  for (int i = 0; i < 8; i++)
+    big[24 + i] = static_cast<uint8_t>(e18 >> (8 * (7 - i)));
+  ASSERT_TRUE(tron_formatTrc20Amount(big, buf, sizeof(buf)));
+  EXPECT_STREQ(buf, "1000000000000000000");
+}
+
+TEST(Tron, AddressFromBytes) {
+  /* Base58Check of 41 + 20 bytes must round-trip through the display helper */
+  uint8_t addr[21];
+  memset(addr, 0x11, sizeof(addr));
+  addr[0] = 0x41;
+  char out[64];
+  ASSERT_TRUE(tron_addressFromBytes(addr, out, sizeof(out)));
+  EXPECT_EQ(out[0], 'T'); /* mainnet addresses render as T... */
+  EXPECT_GE(strlen(out), 33u);
+}

--- a/unittests/firmware/tron.cpp
+++ b/unittests/firmware/tron.cpp
@@ -42,6 +42,21 @@ void putStringField(std::vector<uint8_t>& out, uint32_t field,
                 std::vector<uint8_t>(str, str + strlen(str)));
 }
 
+/* A 10-byte varint whose final byte's payload has bits above bit 0 set.
+ * Bytes 1-9 are all-zero-payload continuations, so the "value" this would
+ * decode to (if truncation were allowed) is 2 << 63, silently dropped by
+ * a naive shift. A correct reader must reject this outright rather than
+ * accept some truncated value. */
+void putOverlongVarintValue(std::vector<uint8_t>& out) {
+  for (int i = 0; i < 9; i++) out.push_back(0x80);
+  out.push_back(0x02);
+}
+
+void putOverlongVarintField(std::vector<uint8_t>& out, uint32_t field) {
+  putKey(out, field, 0);
+  putOverlongVarintValue(out);
+}
+
 std::vector<uint8_t> tronAddr(uint8_t fill) {
   std::vector<uint8_t> a(21, fill);
   a[0] = 0x41;
@@ -368,6 +383,56 @@ TEST(Tron, RejectBadOwnerAddress) {
   auto raw = rawTx(contractMsg(1, TRANSFER_URL,
                                transferContractValue(owner, tronAddr(0x22), 1)),
                    nullptr, 0);
+
+  TronParsedTx parsed;
+  EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),
+            TRON_TX_UNVERIFIED);
+}
+
+TEST(Tron, RejectOverlongKeyVarint) {
+  /* The very first varint of raw_data is a field key. An overlong
+   * (overflowing) key varint must not be silently truncated into some
+   * other field number. */
+  std::vector<uint8_t> raw;
+  putOverlongVarintValue(raw);
+
+  TronParsedTx parsed;
+  EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),
+            TRON_TX_UNVERIFIED);
+}
+
+TEST(Tron, RejectOverlongLengthVarint) {
+  /* A valid key (field 11, length-delimited) followed by an overlong
+   * length varint — must not be truncated into some in-bounds length. */
+  std::vector<uint8_t> raw;
+  putKey(raw, 11, 2);
+  putOverlongVarintValue(raw);
+
+  TronParsedTx parsed;
+  EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),
+            TRON_TX_UNVERIFIED);
+}
+
+TEST(Tron, RejectOverlongAmountVarint) {
+  /* TransferContract.amount (field 3) encoded as an overlong varint. */
+  std::vector<uint8_t> value;
+  putBytesField(value, 1, tronAddr(0x11));
+  putBytesField(value, 2, tronAddr(0x22));
+  putOverlongVarintField(value, 3);
+  auto raw = rawTx(contractMsg(1, TRANSFER_URL, value), nullptr, 0);
+
+  TronParsedTx parsed;
+  EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),
+            TRON_TX_UNVERIFIED);
+}
+
+TEST(Tron, RejectOverlongFeeLimitVarint) {
+  /* Top-level fee_limit (field 18) encoded as an overlong varint. */
+  auto raw = rawTx(contractMsg(1, TRANSFER_URL,
+                               transferContractValue(tronAddr(0x11),
+                                                     tronAddr(0x22), 1)),
+                   nullptr, 0);
+  putOverlongVarintField(raw, 18);
 
   TronParsedTx parsed;
   EXPECT_EQ(tron_parseRawTx(raw.data(), raw.size(), &parsed),


### PR DESCRIPTION
**7.15 PR 4 of 5** (stacks on 3/5). Applies metadata/blind-sign gating to each non-EVM family (no thortx — owned by 1/5). 52 per-chain unit tests. Pins: device-protocol `up/release-protocol@33521a8`, python-keepkey `reconcile/upstream-sync@1674346` (keepkey upstream branches). Reconstituted + build-verified (kkemu + firmware-unit green); the 5-PR stack reproduces the 7.15 line byte-for-byte.