### PR TITLE
7.15 (2/5): New chains — Hive, Zcash Orchard, Ripple memos, THORChain any-denom

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,15 @@ add_definitions(-DBIP39_WORDLIST_PADDED=1)
 
 add_definitions(-DAES_128=1)
 
+# The Zcash Orchard engine (added in this PR) pulls the Pallas curve
+# arithmetic into the image, and the per-chain clear-sign code stacked on top
+# leaves it over the STM32 flash budget with the fast FOUR_TABLES AES. Shrink
+# the Gladman AES lookup tables from 4 KB to 1 KB each (-15,360 bytes ROM, a
+# modest AES cycle cost) so the whole 7.15 feature set links. The variant
+# split in a later PR removes Zcash (and this constraint) from the default
+# image, where FOUR_TABLES is restored.
+add_definitions(-DAES_SMALL_TABLES)
+
 if(${KK_DEBUG_LINK})
   add_definitions(-DDEBUG_LINK=1)
 else()

--- a/deps/crypto/CMakeLists.txt
+++ b/deps/crypto/CMakeLists.txt
@@ -55,7 +55,12 @@ set(sources
     trezor-firmware/crypto/aes/aescrypt.c
     trezor-firmware/crypto/aes/aes_modes.c
     #trezor-firmware/crypto/aes/aestst.c
-    trezor-firmware/crypto/aes/aestab.c)
+    trezor-firmware/crypto/aes/aestab.c
+    trezor-firmware/crypto/pallas.c
+    trezor-firmware/crypto/pallas_sinsemilla.c
+    trezor-firmware/crypto/pallas_swu.c
+    trezor-firmware/crypto/redpallas.c
+    trezor-firmware/crypto/zcash_zip316.c)
 
     # Clang 5.0 in the docker image (kktech/firmware:v7) is missing
     # <xmmintrin.h>, which breaks these. Until they're needed, we'll just elide

--- a/docs/firmware/reviews/7.15.0-review-round2-remediation.md
+++ b/docs/firmware/reviews/7.15.0-review-round2-remediation.md
@@ -23,8 +23,8 @@ bonus. All numbers below reference the reviewer's file:line.
 | B5 | #446 | `recovery_cipher.c:483` per-word BIP-39 validation reads `decoded_word` that `recovery_delete_character` never clears → backspace-fix wipes a real recovery | ☐ |
 | B6 | #446 | `recovery_cipher.c:379` "previous word" indicator snapshots every keystroke → shows current partial word mislabeled | ☐ |
 | B7 | #446 | `keepkey_main.c:189` replaced `signatures_ok()` (sha256+ecdsa) with spoofable sig-index presence check → forged metadata reads SIG_OK | ☑ (fixed pre-review as task #5) |
-| B8 | #445 | `hive.c:194` `ecdsa_sign_digest(..., NULL)` — no canonical callback; Graphene rejects ~50% of sigs. Fix: reuse `eos_is_canonic` (eos.c:488) | ☐ |
-| B9 | #445 | `fsm_msg_hive.h:147` confirm hardcodes `amount/1000` (3 dp) while serializer signs `msg->decimals` → shows 1000× wrong amount | ☐ |
+| B8 | #445 | `hive.c:194` `ecdsa_sign_digest(..., NULL)` — no canonical callback; Graphene rejects ~50% of sigs. Fix: reuse `eos_is_canonic` (eos.c:488) | ☑ added `hive_is_canonic` (same Graphene rule) and passed it to `ecdsa_sign_digest` |
+| B9 | #445 | `fsm_msg_hive.h:147` confirm hardcodes `amount/1000` (3 dp) while serializer signs `msg->decimals` → shows 1000× wrong amount | ☑ display now uses serializer's precision via `bn_format_uint64`; rejects precision > 18 |
 | B10 | #444 | `thortx.h:41` `MAYA_ROUTER` pinned to dead `0xd89dce…` (no code on mainnet); real router `0xe3985E6b…` → Maya swaps blocked, deposit-selector tx to code-less addr gets trusted UX, ETH lost | ☑ set to `e3985e6b…46d` (Etherscan-verified Maya ETH Router v4) |
 
 ## Medium — should fix
@@ -36,12 +36,12 @@ bonus. All numbers below reference the reviewer's file:line.
 | M3 | #444 | `messages-ripple.options:9` enables `RippleSignTx.memo` but no reader at this head → memo silently dropped, XRP→THOR deposits strand | ✔ resolved-in-stack: pr447 ripple.c:230 serializes `tx->memo`. Artifact of per-PR-head review; release ships the reader |
 | M4 | #444 | `ThorchainMsgSend.denom` enabled while `thorchain.c` still hardcodes "rune" | ✔ resolved-in-stack: pr447 THOR/Maya send path consumes `send.denom` |
 | M5 | #444 | `signed_metadata.c:370` dup of `bn_from_bytes`; `thortx.c:45` 20× snprintf+strncmp router compare instead of `memcmp` on 20 bytes (mixed-case EIP-55 never matches) | ⊘ quality-only: router constants are lowercase literals + `to.bytes` rendered lowercase, so compare is exact today; no signed-byte/security impact. Next round |
-| M6 | #445 | Zcash `fsm_msg_zcash.h:68` ~5.7 KB always-on .bss, no build gate | ⊘ (see notes) |
-| M7 | #445 | Zcash `:91` hardcoded `[16]` instead of `ZCASH_MAX_ACTIONS` → OOB if raised | ☐ |
-| M8 | #445 | Zcash `:646` `SignPCZT` re-inits without `zcash_signing_abort()` → prior session's transparent sigs can leak | ☐ |
-| M9 | #445 | Zcash `:1208` wire flow diverges from documented proto sequence | ⊘ (see notes) |
-| M10 | #445 | Zcash `:756` account-resolution+fingerprint copy-pasted across 3 handlers | ⊘ (see notes) |
-| M11 | #445 | `fsm_msg_hive.h:45` export label from untrusted display-only role field, not path | ☐ |
+| M6 | #445 | Zcash `fsm_msg_zcash.h:68` ~5.7 KB always-on .bss, no build gate | ⊘ code-size hygiene; the zcash-privacy build variant already gates the feature at CI level, mainstream ROM budget handled by B1. Next round: `#if ZCASH_PRIVACY` the .bss |
+| M7 | #445 | Zcash `:91` hardcoded `[16]` instead of `ZCASH_MAX_ACTIONS` → OOB if raised | ☑ `signatures[ZCASH_MAX_ACTIONS][64]` |
+| M8 | #445 | Zcash `:646` `SignPCZT` re-inits without `zcash_signing_abort()` → prior session's transparent sigs can leak | ☑ `zcash_signing_abort()` before key derivation / state init |
+| M9 | #445 | Zcash `:1208` wire flow diverges from documented proto sequence | ⊘ doc-vs-impl reconciliation, no signed-byte impact; tracked for next round |
+| M10 | #445 | Zcash `:756` account-resolution+fingerprint copy-pasted across 3 handlers | ⊘ refactor-only (extract shared `zcash_resolve_account`); no behavior change. Next round |
+| M11 | #445 | `fsm_msg_hive.h:45` export label from untrusted display-only role field, not path | ☑ label now derived from `address_n[2]` (path role), not `msg->role` |
 | M12 | #447 | `fsm_msg_ton.h:121` TON raw_tx blind-sign skips AdvancedMode gate | ☑ (fixed task #4) |
 | M13 | #447 | `fsm_msg_tron.h:392` TRON TIP-712 typed-hash blind-sign skips AdvancedMode gate | ☐ |
 | M14 | #447 | `fsm_msg_mayachain.h:166` amount+long-denom overflows `amount_str[32]` → blank amount shown, real value signed | ☐ |

--- a/include/keepkey/firmware/app_confirm.h
+++ b/include/keepkey/firmware/app_confirm.h
@@ -50,6 +50,7 @@ bool confirm_cosmos_address(const char* desc, const char* address);
 bool confirm_osmosis_address(const char* desc, const char* address);
 bool confirm_ethereum_address(const char* desc, const char* address);
 bool confirm_nano_address(const char* desc, const char* address);
+bool confirm_zcash_address(const char* desc, const char* address);
 bool confirm_omni(ButtonRequestType button_request, const char* title,
                   const uint8_t* data, uint32_t size);
 bool confirm_data(ButtonRequestType button_request, const char* title,

--- a/include/keepkey/firmware/app_layout.h
+++ b/include/keepkey/firmware/app_layout.h
@@ -118,6 +118,11 @@ void layout_ethereum_address_notification(const char* desc, const char* address,
                                           NotificationType type);
 void layout_nano_address_notification(const char* desc, const char* address,
                                       NotificationType type);
+void layout_zcash_address_notification(const char* desc, const char* address,
+                                       NotificationType type);
+void layout_zcash_address_text_notification(const char* desc,
+                                            const char* address,
+                                            NotificationType type);
 void layout_pin(const char* str, char* pin);
 void layout_cipher(const char* current_word, const char* cipher);
 void layout_address(const char* address, QRSize qr_size);

--- a/include/keepkey/firmware/fsm.h
+++ b/include/keepkey/firmware/fsm.h
@@ -133,6 +133,18 @@ void fsm_msgSolanaSignTx(const SolanaSignTx* msg);
 void fsm_msgSolanaSignMessage(const SolanaSignMessage* msg);
 void fsm_msgSolanaSignOffchainMessage(const SolanaSignOffchainMessage* msg);
 
+void fsm_msgHiveGetPublicKey(const HiveGetPublicKey* msg);
+void fsm_msgHiveGetPublicKeys(const HiveGetPublicKeys* msg);
+void fsm_msgHiveSignTx(const HiveSignTx* msg);
+void fsm_msgHiveSignAccountCreate(const HiveSignAccountCreate* msg);
+void fsm_msgHiveSignAccountUpdate(const HiveSignAccountUpdate* msg);
+void fsm_msgZcashSignPCZT(const ZcashSignPCZT* msg);
+void fsm_msgZcashPCZTAction(const ZcashPCZTAction* msg);
+void fsm_msgZcashGetOrchardFVK(const ZcashGetOrchardFVK* msg);
+void fsm_msgZcashTransparentOutput(const ZcashTransparentOutput* msg);
+void fsm_msgZcashTransparentInput(const ZcashTransparentInput* msg);
+void fsm_msgZcashDisplayAddress(const ZcashDisplayAddress* msg);
+
 #if DEBUG_LINK
 // void fsm_msgDebugLinkDecision(DebugLinkDecision *msg);
 void fsm_msgDebugLinkGetState(DebugLinkGetState* msg);

--- a/include/keepkey/firmware/hive.h
+++ b/include/keepkey/firmware/hive.h
@@ -1,0 +1,98 @@
+#ifndef KEEPKEY_FIRMWARE_HIVE_H
+#define KEEPKEY_FIRMWARE_HIVE_H
+
+#include "trezor/crypto/bip32.h"
+#include "messages-hive.pb.h"
+
+// ── Hive mainnet chain ID ─────────────────────────────────────────────────
+// Hive mainnet chain ID
+#define HIVE_CHAIN_ID                                \
+  "\xbe\xea\xb0\xde\x00\x00\x00\x00\x00\x00\x00\x00" \
+  "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" \
+  "\x00\x00\x00\x00\x00\x00\x00\x00"
+
+#define HIVE_CHAIN_ID_LEN 32
+
+// ── STM public key prefix (Hive inherited from Steem / Graphene) ──────────
+#define HIVE_PUBKEY_PREFIX "STM"
+
+// ── SLIP-0048 derivation constants (all hardened) ─────────────────────────
+// Path: m/48'/13'/role'/account_index'/0'
+#define HIVE_SLIP48_PURPOSE (0x80000030u)  // 48'
+#define HIVE_SLIP48_NETWORK (0x8000000Du)  // 13' — Hive SLIP-0048 network ID
+#define HIVE_ROLE_OWNER \
+  (0x80000000u)  // 0'  — account recovery, authority changes
+#define HIVE_ROLE_ACTIVE (0x80000001u)   // 1'  — transfers, staking
+#define HIVE_ROLE_MEMO (0x80000003u)     // 3'  — memo field encryption
+#define HIVE_ROLE_POSTING (0x80000004u)  // 4'  — votes, posts, follows
+
+// ── Graphene operation type IDs ───────────────────────────────────────────
+#define HIVE_OP_TRANSFER 2
+#define HIVE_OP_ACCOUNT_CREATE 9
+#define HIVE_OP_ACCOUNT_UPDATE 10
+
+// ── Protocol limits ───────────────────────────────────────────────────────
+#define HIVE_MAX_ACCOUNT_LEN 16  // max Hive username length
+#define HIVE_DECIMALS 3          // HIVE and HBD both use 3 decimal places
+
+// ── Public API ────────────────────────────────────────────────────────────
+/**
+ * Encode a 33-byte compressed public key in Hive/Steem STM-prefix base58
+ * format. Uses RIPEMD checksum (Graphene convention, not SHA256d).
+ */
+bool hive_getPublicKey(const uint8_t public_key[33], char* out, size_t out_len);
+
+/**
+ * Derive one SLIP-0048 role key for a given account index to raw 33 bytes.
+ * role_hardened: HIVE_ROLE_OWNER | HIVE_ROLE_ACTIVE | HIVE_ROLE_MEMO |
+ * HIVE_ROLE_POSTING account_index_hardened: account_index | 0x80000000u Returns
+ * false if derivation fails.
+ */
+bool hive_deriveRawKey(const HDNode* root, uint32_t role_hardened,
+                       uint32_t account_index_hardened, uint8_t out[33]);
+
+/**
+ * Derive all four SLIP-0048 role keys for a given account index and encode
+ * each as an STM-prefixed string. All output buffers must be >= 64 bytes.
+ * Returns false if any derivation or encoding step fails.
+ */
+bool hive_getPublicKeys(const HDNode* root, uint32_t account_index,
+                        char* owner_out, size_t owner_len, char* active_out,
+                        size_t active_len, char* memo_out, size_t memo_len,
+                        char* posting_out, size_t posting_len);
+
+/**
+ * Sign a Hive transfer transaction (op type 2).
+ * Rejects memos longer than HIVE_MAX_MEMO_LEN (440 bytes).
+ */
+void hive_signTx(const HDNode* node, const HiveSignTx* msg, HiveSignedTx* resp);
+
+/**
+ * Sign a Hive account_create transaction (op type 9).
+ * owner/active/posting/memo_raw must be device-derived 33-byte compressed keys.
+ * The firmware uses these directly; host-supplied key strings in msg are
+ * ignored.
+ */
+void hive_signAccountCreate(const HDNode* signing_node,
+                            const HiveSignAccountCreate* msg,
+                            const uint8_t owner_raw[33],
+                            const uint8_t active_raw[33],
+                            const uint8_t posting_raw[33],
+                            const uint8_t memo_raw[33],
+                            HiveSignedAccountCreate* resp);
+
+/**
+ * Sign a Hive account_update transaction (op type 10).
+ * owner/active/posting/memo_raw must be device-derived 33-byte compressed keys.
+ * The firmware uses these directly; host-supplied new_*_key strings in msg are
+ * ignored.
+ */
+void hive_signAccountUpdate(const HDNode* signing_node,
+                            const HiveSignAccountUpdate* msg,
+                            const uint8_t owner_raw[33],
+                            const uint8_t active_raw[33],
+                            const uint8_t posting_raw[33],
+                            const uint8_t memo_raw[33],
+                            HiveSignedAccountUpdate* resp);
+
+#endif  // KEEPKEY_FIRMWARE_HIVE_H

--- a/include/keepkey/firmware/thorchain.h
+++ b/include/keepkey/firmware/thorchain.h
@@ -10,9 +10,13 @@
 typedef struct _ThorchainSignTx ThorchainSignTx;
 typedef struct _ThorchainMsgDeposit ThorchainMsgDeposit;
 
+// Returns true iff denom contains only chars safe in JSON without escaping.
+// Valid: [a-z0-9./\-]. Rejects empty string, quotes, backslashes, whitespace.
+bool thorchain_isValidDenom(const char* denom);
+
 bool thorchain_signTxInit(const HDNode* _node, const ThorchainSignTx* _msg);
 bool thorchain_signTxUpdateMsgSend(const uint64_t amount,
-                                   const char* to_address);
+                                   const char* to_address, const char* denom);
 bool thorchain_signTxUpdateMsgDeposit(const ThorchainMsgDeposit* depmsg);
 bool thorchain_signTxFinalize(uint8_t* public_key, uint8_t* signature);
 bool thorchain_signingIsInited(void);

--- a/include/keepkey/firmware/zcash.h
+++ b/include/keepkey/firmware/zcash.h
@@ -1,0 +1,400 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2025 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KEEPKEY_FIRMWARE_ZCASH_H
+#define KEEPKEY_FIRMWARE_ZCASH_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* Orchard spending keys derived via ZIP-32.
+ * cppcheck doesn't see these used because the consumers live in
+ * fsm_msg_zcash.h which is #include'd into fsm.c rather than compiled
+ * separately, so the struct members appear "unused" in this TU. */
+typedef struct {
+  // cppcheck-suppress unusedStructMember
+  uint8_t sk[32]; /* Spending key (master secret at this level) */
+  // cppcheck-suppress unusedStructMember
+  uint8_t ask[32]; /* Spend authorizing key (scalar) */
+  // cppcheck-suppress unusedStructMember
+  uint8_t nk[32]; /* Nullifier deriving key */
+  // cppcheck-suppress unusedStructMember
+  uint8_t rivk[32]; /* Commitment randomness key */
+  // cppcheck-suppress unusedStructMember
+  uint8_t dk[32]; /* Diversifier key */
+} ZcashOrchardKeys;
+
+typedef struct {
+  bool has_header_digest;
+  size_t header_digest_size;
+  bool has_transparent_digest;
+  size_t transparent_digest_size;
+  bool has_sapling_digest;
+  size_t sapling_digest_size;
+  bool has_orchard_digest;
+  size_t orchard_digest_size;
+  bool has_orchard_flags;
+  uint32_t orchard_flags;
+  bool has_orchard_value_balance;
+  bool has_orchard_anchor;
+  size_t orchard_anchor_size;
+  bool has_header_fields;
+  uint32_t n_transparent_inputs;
+  uint32_t n_transparent_outputs;
+} ZcashPCZTSigningRequestMeta;
+
+typedef enum {
+  ZCASH_PCZT_SIGNING_REQUEST_OK = 0,
+  ZCASH_PCZT_SIGNING_REQUEST_MISSING_TX_DIGESTS,
+  ZCASH_PCZT_SIGNING_REQUEST_INVALID_DIGEST_SIZE,
+  ZCASH_PCZT_SIGNING_REQUEST_MISSING_HEADER_FIELDS,
+  ZCASH_PCZT_SIGNING_REQUEST_UNSUPPORTED_SAPLING_COMPONENT,
+  ZCASH_PCZT_SIGNING_REQUEST_MISSING_ORCHARD_METADATA,
+  ZCASH_PCZT_SIGNING_REQUEST_MISSING_TRANSPARENT_DIGEST,
+} ZcashPCZTSigningRequestStatus;
+
+typedef struct {
+  const uint8_t* prevout_txid;
+  uint32_t prevout_index;
+  uint32_t sequence;
+  uint64_t value;
+  const uint8_t* script_pubkey;
+  size_t script_pubkey_size;
+} ZcashTransparentInputDigestInfo;
+
+typedef struct {
+  uint64_t value;
+  const uint8_t* script_pubkey;
+  size_t script_pubkey_size;
+} ZcashTransparentOutputDigestInfo;
+
+#define ZCASH_ORCHARD_RAW_RECEIVER_SIZE 43
+#define ZCASH_ORCHARD_UNIFIED_ADDRESS_SIZE 128
+
+/**
+ * Validate the clear-signing metadata required before Orchard signatures.
+ *
+ * This rejects the legacy flow where the host supplied only a per-action
+ * sighash. The firmware must assemble the ZIP-244 sighash from transaction
+ * component digests and verify the Orchard digest against streamed action data
+ * before returning signatures.
+ */
+ZcashPCZTSigningRequestStatus zcash_pczt_signing_request_status(
+    const ZcashPCZTSigningRequestMeta* meta);
+
+bool zcash_pczt_signing_request_is_clear(
+    const ZcashPCZTSigningRequestMeta* meta);
+
+/**
+ * Derive Orchard spending keys from the device seed via ZIP-32.
+ * Path: m_orchard / 32' / 133' / account'
+ *
+ * Uses BLAKE2b with personalization "ZcashIP32Orchard" for key derivation.
+ *
+ * @param seed       BIP-39 master seed
+ * @param seed_len   Seed length (typically 64 bytes)
+ * @param account    Account index (0-based, will be hardened)
+ * @param keys       Output: derived Orchard keys
+ * @return true on success
+ */
+bool zcash_derive_orchard_keys(const uint8_t* seed, uint32_t seed_len,
+                               uint32_t account, ZcashOrchardKeys* keys);
+
+/**
+ * Compute the ZIP 244 shielded sighash for Orchard spend authorization.
+ *
+ * For shielded-only transactions, transparent_sig_digest uses the "no inputs"
+ * form. For mixed transactions, transparent data must be provided separately.
+ *
+ * @param header_digest     32-byte pre-computed header digest
+ * @param transparent_digest 32-byte transparent sig digest (or empty hash)
+ * @param sapling_digest    32-byte sapling digest (or empty hash)
+ * @param orchard_digest    32-byte orchard digest
+ * @param branch_id         Consensus branch ID (LE)
+ * @param sighash_out       32-byte output sighash
+ * @return true on success
+ */
+bool zcash_compute_shielded_sighash(const uint8_t header_digest[32],
+                                    const uint8_t transparent_digest[32],
+                                    const uint8_t sapling_digest[32],
+                                    const uint8_t orchard_digest[32],
+                                    uint32_t branch_id,
+                                    uint8_t sighash_out[32]);
+
+/**
+ * Compute ZIP-244 T.1 header_digest from plaintext transaction header fields.
+ */
+bool zcash_compute_header_digest(uint32_t version, uint32_t version_group_id,
+                                 uint32_t branch_id, uint32_t lock_time,
+                                 uint32_t expiry_height,
+                                 uint8_t digest_out[32]);
+
+/**
+ * Compute ZIP-244 T.2 transparent_digest from plaintext transparent data.
+ *
+ * This is the digest mixed into the Orchard/Sapling signing commitment. It is
+ * not the same as the per-input transparent signature digest.
+ */
+bool zcash_compute_transparent_digest(
+    const ZcashTransparentInputDigestInfo* inputs, size_t n_inputs,
+    const ZcashTransparentOutputDigestInfo* outputs, size_t n_outputs,
+    uint8_t digest_out[32]);
+
+/**
+ * Compute ZIP-244 §4.9 transparent_sig_digest for Orchard spend authorization.
+ *
+ * Uses the S.2 form with EMPTY txin_sig_digest when n_inputs > 0 (shield txs),
+ * or falls back to T.1 when n_inputs == 0 (deshield / private-send). This is
+ * what the Zcash consensus node uses to verify Orchard spend auth sigs and the
+ * binding signature in a hybrid (transparent + Orchard) transaction.
+ */
+bool zcash_compute_orchard_transparent_sig_digest(
+    const ZcashTransparentInputDigestInfo* inputs, size_t n_inputs,
+    const ZcashTransparentOutputDigestInfo* outputs, size_t n_outputs,
+    uint8_t digest_out[32]);
+
+/**
+ * Compute ZIP-244 S.2 per-input transparent signature digest.
+ *
+ * This currently accepts SIGHASH_ALL only, matching the existing transparent
+ * signing flow.
+ */
+bool zcash_compute_transparent_sighash_digest(
+    const ZcashTransparentInputDigestInfo* inputs, size_t n_inputs,
+    const ZcashTransparentOutputDigestInfo* outputs, size_t n_outputs,
+    uint32_t signable_input_index, uint8_t sighash_type,
+    uint8_t digest_out[32]);
+
+/**
+ * Encode a raw Orchard receiver (d || pk_d) as an Orchard-only ZIP-316 Unified
+ * Address for display. This is for recipient review; it does not derive or
+ * prove ownership of the receiver.
+ */
+bool zcash_orchard_receiver_to_unified_address(
+    const uint8_t receiver[ZCASH_ORCHARD_RAW_RECEIVER_SIZE], const char* hrp,
+    char* address_out, size_t address_out_len);
+
+/**
+ * Recompute an Orchard output note commitment x-coordinate (cmx).
+ *
+ * cmx = Extract_P(NoteCommit_rcm^Orchard(g_d, pk_d, v, rho, psi))
+ * where receiver = d || pk_d, rho is the action nullifier, and rseed is the
+ * output note seed. This binds the user-displayed receiver/value to the action
+ * commitment before any authorization signature is emitted.
+ */
+bool zcash_orchard_compute_cmx(
+    const uint8_t receiver[ZCASH_ORCHARD_RAW_RECEIVER_SIZE], uint64_t value,
+    const uint8_t rho[32], const uint8_t rseed[32], uint8_t cmx_out[32]);
+
+/**
+ * Derive an Orchard diversifier from a diversifier key and 88-bit index.
+ *
+ * ZIP-32 defines Orchard diversifiers as:
+ *   d_j = FF1-AES256.Encrypt(dk, "", I2LEBSP_88(j))
+ *
+ * Both index_le and diversifier_out are 11-byte LEBS2OSP encodings of the
+ * 88-bit bitstrings.
+ *
+ * @param dk              32-byte Orchard diversifier key
+ * @param index_le        11-byte little-endian diversifier index bitstring
+ * @param diversifier_out 11-byte output diversifier
+ * @return true on success
+ */
+bool zcash_orchard_derive_diversifier(const uint8_t dk[32],
+                                      const uint8_t index_le[11],
+                                      uint8_t diversifier_out[11]);
+
+/**
+ * Compute DiversifyHash^Orchard(d) as a serialized Pallas point.
+ *
+ *   g_d = GroupHash^Pallas("z.cash:Orchard-gd", d)
+ *
+ * If the group hash ever returns the identity, Orchard falls back to hashing
+ * the empty message under the same domain.
+ *
+ * @param diversifier 11-byte Orchard diversifier
+ * @param gd_out      32-byte compressed Pallas point
+ * @return true on success
+ */
+bool zcash_orchard_diversify_hash(const uint8_t diversifier[11],
+                                  uint8_t gd_out[32]);
+
+/**
+ * Derive an Orchard diversified transmission key.
+ *
+ *   g_d  = DiversifyHash^Orchard(d)
+ *   pk_d = KA^Orchard.DerivePublic(ivk, g_d) = [ivk] g_d
+ *
+ * @param ivk         32-byte nonzero Orchard incoming viewing key encoding
+ * @param diversifier 11-byte Orchard diversifier
+ * @param gd_out      optional 32-byte compressed g_d output, may be NULL
+ * @param pkd_out     32-byte compressed diversified transmission key
+ * @return true on success
+ */
+bool zcash_orchard_derive_transmission_key(const uint8_t ivk[32],
+                                           const uint8_t diversifier[11],
+                                           uint8_t gd_out[32],
+                                           uint8_t pkd_out[32]);
+
+/**
+ * Derive the external Orchard incoming viewing key from FVK components.
+ *
+ *   ivk = Commit^ivk.Output(ExtractP(ak), nk, rivk)
+ *
+ * @param ak      32-byte Orchard spend validating key encoding, sign bit clear
+ * @param nk      32-byte Orchard nullifier deriving key
+ * @param rivk    32-byte Orchard IVK commitment randomness
+ * @param ivk_out 32-byte nonzero Orchard incoming viewing key
+ * @return true on success
+ */
+bool zcash_orchard_derive_ivk(const uint8_t ak[32], const uint8_t nk[32],
+                              const uint8_t rivk[32], uint8_t ivk_out[32]);
+
+/**
+ * Derive a raw Orchard receiver from external FVK components and index.
+ *
+ *   d_j   = DiversifierKey(dk).get(j)
+ *   ivk   = Commit^ivk.Output(ExtractP(ak), nk, rivk)
+ *   pk_dj = KA^Orchard.DerivePublic(ivk, DiversifyHash(d_j))
+ *
+ * @param ak           32-byte Orchard spend validating key encoding
+ * @param nk           32-byte Orchard nullifier deriving key
+ * @param rivk         32-byte Orchard IVK commitment randomness
+ * @param dk           32-byte Orchard diversifier key
+ * @param index_le     11-byte little-endian diversifier index bitstring
+ * @param receiver_out 43-byte raw receiver: d_j || pk_dj
+ * @return true on success
+ */
+bool zcash_orchard_derive_receiver(const uint8_t ak[32], const uint8_t nk[32],
+                                   const uint8_t rivk[32], const uint8_t dk[32],
+                                   const uint8_t index_le[11],
+                                   uint8_t receiver_out[43]);
+
+/**
+ * Derive an Orchard-only ZIP-316 Unified Address from derived Orchard keys.
+ *
+ *   ak       = [ask] G_spendauth
+ *   receiver = d_j || pk_dj
+ *   address  = Bech32m(HRP, F4Jumble(Orchard receiver payload))
+ *
+ * @param keys            ZIP-32-derived Orchard key material
+ * @param index_le        11-byte little-endian diversifier index bitstring
+ * @param hrp             ZIP-316 HRP ("u" for mainnet, "utest" for testnet)
+ * @param address_out     NUL-terminated output address
+ * @param address_out_len Size of address_out
+ * @return true on success
+ */
+bool zcash_orchard_derive_unified_address(const ZcashOrchardKeys* keys,
+                                          const uint8_t index_le[11],
+                                          const char* hrp, char* address_out,
+                                          size_t address_out_len);
+
+/**
+ * Derive an Orchard-only ZIP-316 Unified Address directly from seed material.
+ *
+ * Production firmware should continue to access the seed only through the
+ * storage-scoped wrappers below; this composition helper is exposed for
+ * isolated unit tests and storage-owned call sites.
+ *
+ * @param seed            BIP-39 master seed
+ * @param seed_len        Seed length (typically 64 bytes)
+ * @param account         Account index (0-based, will be hardened)
+ * @param index_le        11-byte little-endian diversifier index bitstring
+ * @param hrp             ZIP-316 HRP ("u" for mainnet, "utest" for testnet)
+ * @param address_out     NUL-terminated output address
+ * @param address_out_len Size of address_out
+ * @return true on success
+ */
+bool zcash_derive_orchard_unified_address(const uint8_t* seed,
+                                          uint32_t seed_len, uint32_t account,
+                                          const uint8_t index_le[11],
+                                          const char* hrp, char* address_out,
+                                          size_t address_out_len);
+
+/**
+ * Compute the ZIP-32 §6.1 seed fingerprint.
+ *
+ *   SeedFingerprint := BLAKE2b-256(
+ *     "Zcash_HD_Seed_FP", I2LEBSP_8(len(seed)) || seed)
+ *
+ * The 1-byte length prefix domain-separates seeds of different lengths that
+ * happen to share a prefix.
+ *
+ * 32-byte stable identifier of a seed. Used by host wallets and PCZTs
+ * (zip32_derivation.seed_fingerprint) to confirm which device seed produced
+ * a given key, address, or signature. Trivial seeds (all-zero, all-0xFF)
+ * and seeds outside [32, 252] bytes are rejected per ZIP-32 §6.1.
+ *
+ * @param seed              Seed bytes (BIP-39 seed or BIP-32 master seed)
+ * @param seed_len          Seed length, must be in [32, 252]
+ * @param fingerprint_out   32-byte output fingerprint
+ * @return true on success, false if seed is invalid
+ */
+bool zcash_calculate_seed_fingerprint(const uint8_t* seed, uint32_t seed_len,
+                                      uint8_t fingerprint_out[32]);
+
+/* ── Storage-scoped wrappers ───────────────────────────────────────────
+ *
+ * The two functions below own the seed access. Implementations live in
+ * lib/firmware/storage.c so the raw 64-byte BIP-39 seed never escapes
+ * that translation unit. Callers (FSM handlers) get only the derived
+ * material — Orchard keys or the 32-byte fingerprint — never a pointer
+ * to the seed itself. This is the only sanctioned way for production
+ * firmware code to consume seed-derived Zcash material.
+ *
+ * The bare zcash_derive_orchard_keys() / zcash_calculate_seed_fingerprint()
+ * functions above remain in the header for unit tests, which feed them
+ * known test vectors directly.
+ */
+
+/**
+ * Derive Orchard keys for an account using the device's session seed.
+ *
+ * @param account       Account index (0-based, will be hardened)
+ * @param usePassphrase Whether to apply the passphrase (prompts if needed)
+ * @param keys_out      Output: derived Orchard keys
+ * @return true on success, false if seed unavailable or derivation fails
+ */
+bool storage_zcashOrchardKeys(uint32_t account, bool usePassphrase,
+                              ZcashOrchardKeys* keys_out);
+
+/**
+ * Compute the ZIP-32 §6.1 seed fingerprint for the device's session seed.
+ *
+ * @param usePassphrase    Whether to apply the passphrase (prompts if needed)
+ * @param fingerprint_out  32-byte output fingerprint
+ * @return true on success, false if seed unavailable
+ */
+bool storage_zcashSeedFingerprint(bool usePassphrase,
+                                  uint8_t fingerprint_out[32]);
+
+/**
+ * Tear down any in-progress Zcash signing session.
+ *
+ * Wipes the static signing state (active flag, derived Orchard keys,
+ * accumulated signatures, sub-digest contexts, transparent-input
+ * counters) so a host cannot resume streaming PCZTAction or
+ * TransparentInput messages against a previously-approved session
+ * after Initialize, Cancel, or ClearSession. Safe to call when no
+ * session is active.
+ */
+void zcash_signing_abort(void);
+
+#endif

--- a/include/keepkey/transport/interface.h
+++ b/include/keepkey/transport/interface.h
@@ -38,6 +38,8 @@
 #include "messages-tron.pb.h"
 #include "messages-ton.pb.h"
 #include "messages-solana.pb.h"
+#include "messages-hive.pb.h"
+#include "messages-zcash.pb.h"
 
 #include "types.pb.h"
 #include "trezor_transport.h"

--- a/include/keepkey/transport/messages-hive.options
+++ b/include/keepkey/transport/messages-hive.options
@@ -1,0 +1,46 @@
+HiveGetPublicKey.address_n              max_count:8
+
+HivePublicKey.public_key                max_size:64
+HivePublicKey.raw_public_key            max_size:33
+
+HiveGetPublicKeys.account_index         int_size:IS_32
+
+HivePublicKeys.owner_key                max_size:64
+HivePublicKeys.active_key               max_size:64
+HivePublicKeys.memo_key                 max_size:64
+HivePublicKeys.posting_key              max_size:64
+
+HiveSignTx.address_n                    max_count:8
+HiveSignTx.chain_id                     max_size:32
+HiveSignTx.from                         max_size:16
+HiveSignTx.to                           max_size:16
+HiveSignTx.amount                       int_size:IS_64
+HiveSignTx.asset_symbol                 max_size:10
+HiveSignTx.memo                         max_size:2048
+
+HiveSignedTx.signature                  max_size:65
+HiveSignedTx.serialized_tx              max_size:512
+
+HiveSignAccountCreate.address_n         max_count:8
+HiveSignAccountCreate.chain_id          max_size:32
+HiveSignAccountCreate.creator           max_size:16
+HiveSignAccountCreate.new_account_name  max_size:16
+HiveSignAccountCreate.owner_key         max_size:64
+HiveSignAccountCreate.active_key        max_size:64
+HiveSignAccountCreate.posting_key       max_size:64
+HiveSignAccountCreate.memo_key          max_size:64
+HiveSignAccountCreate.fee_amount        int_size:IS_64
+
+HiveSignedAccountCreate.signature       max_size:65
+HiveSignedAccountCreate.serialized_tx   max_size:512
+
+HiveSignAccountUpdate.address_n         max_count:8
+HiveSignAccountUpdate.chain_id          max_size:32
+HiveSignAccountUpdate.account           max_size:16
+HiveSignAccountUpdate.new_owner_key     max_size:64
+HiveSignAccountUpdate.new_active_key    max_size:64
+HiveSignAccountUpdate.new_posting_key   max_size:64
+HiveSignAccountUpdate.new_memo_key      max_size:64
+
+HiveSignedAccountUpdate.signature       max_size:65
+HiveSignedAccountUpdate.serialized_tx   max_size:512

--- a/include/keepkey/transport/messages-zcash.options
+++ b/include/keepkey/transport/messages-zcash.options
@@ -1,0 +1,54 @@
+ZcashSignPCZT.address_n                             max_count:10
+ZcashSignPCZT.pczt_data                             max_size:0
+ZcashSignPCZT.total_amount                          int_size:IS_64
+ZcashSignPCZT.fee                                   int_size:IS_64
+ZcashSignPCZT.header_digest                         max_size:32
+ZcashSignPCZT.transparent_digest                    max_size:32
+ZcashSignPCZT.sapling_digest                        max_size:32
+ZcashSignPCZT.orchard_digest                        max_size:32
+ZcashSignPCZT.orchard_value_balance                 int_size:IS_64
+ZcashSignPCZT.orchard_anchor                        max_size:32
+ZcashSignPCZT.expected_seed_fingerprint             max_size:32
+
+ZcashPCZTAction.alpha                               max_size:32
+ZcashPCZTAction.sighash                             max_size:32
+ZcashPCZTAction.cv_net                              max_size:32
+ZcashPCZTAction.value                               int_size:IS_64
+ZcashPCZTAction.nullifier                           max_size:32
+ZcashPCZTAction.cmx                                 max_size:32
+ZcashPCZTAction.epk                                 max_size:32
+ZcashPCZTAction.enc_compact                         max_size:52
+ZcashPCZTAction.enc_memo                            max_size:512
+ZcashPCZTAction.enc_noncompact                      max_size:564
+ZcashPCZTAction.rk                                  max_size:32
+ZcashPCZTAction.out_ciphertext                      max_size:80
+ZcashPCZTAction.recipient                           max_size:43
+ZcashPCZTAction.rseed                               max_size:32
+
+ZcashSignedPCZT.signatures                          max_count:16, max_size:64
+ZcashSignedPCZT.txid                                max_size:32
+
+ZcashGetOrchardFVK.address_n                        max_count:10
+
+ZcashOrchardFVK.ak                                  max_size:32
+ZcashOrchardFVK.nk                                  max_size:32
+ZcashOrchardFVK.rivk                                max_size:32
+ZcashOrchardFVK.seed_fingerprint                    max_size:32
+
+ZcashTransparentOutput.amount                       int_size:IS_64
+ZcashTransparentOutput.script_pubkey                max_size:128
+
+ZcashTransparentInput.sighash                       max_size:32
+ZcashTransparentInput.address_n                     max_count:8
+ZcashTransparentInput.amount                        int_size:IS_64
+ZcashTransparentInput.prevout_txid                  max_size:32
+ZcashTransparentInput.script_pubkey                 max_size:128
+
+ZcashTransparentSig.signature                        max_size:73
+ZcashTransparentSigned.signatures                   max_count:8, max_size:73
+
+ZcashDisplayAddress.address_n                       max_count:8
+ZcashDisplayAddress.expected_seed_fingerprint       max_size:32
+
+ZcashAddress.address                                max_size:128
+ZcashAddress.seed_fingerprint                       max_size:32

--- a/lib/firmware/CMakeLists.txt
+++ b/lib/firmware/CMakeLists.txt
@@ -35,12 +35,14 @@ set(sources
     signing.c
     signtx_tendermint.c
     solana.c
+    hive.c
     storage.c
     tron.c
     ton.c
     tendermint.c
     thorchain.c
     tiny-json.c
+    zcash.c
     transaction.c
     txin_check.c
     u2f.c)

--- a/lib/firmware/app_confirm.c
+++ b/lib/firmware/app_confirm.c
@@ -322,6 +322,29 @@ bool confirm_nano_address(const char* desc, const char* address) {
 }
 
 /*
+ * confirm_zcash_address() - Show zcash address confirmation
+ *
+ * INPUT
+ *      - desc: description (title) shown on both screens
+ *      - address: zcash unified address — full text on the first screen,
+ *        QR on the second
+ * OUTPUT
+ *     true/false of confirmation
+ *
+ */
+bool confirm_zcash_address(const char* desc, const char* address) {
+  if (!confirm_with_custom_layout(&layout_zcash_address_text_notification,
+                                  ButtonRequestType_ButtonRequest_Address, desc,
+                                  "%s", address)) {
+    return false;
+  }
+
+  return confirm_with_custom_layout(&layout_zcash_address_notification,
+                                    ButtonRequestType_ButtonRequest_Address,
+                                    desc, "%s", address);
+}
+
+/*
  * confirm_address() - Show address confirmation
  *
  * INPUT

--- a/lib/firmware/app_layout.c
+++ b/lib/firmware/app_layout.c
@@ -598,6 +598,79 @@ void layout_nano_address_notification(const char* desc, const char* address,
 }
 
 /*
+ * layout_zcash_address_notification() - Display zcash unified address QR
+ * with title; the second confirm step in the view-on-device flow.
+ *
+ * INPUT
+ *     - desc: title text (e.g. "Zcash #0 Orchard")
+ *     - address: zcash unified address (rendered as QR only — full text is
+ *       shown on the preceding confirm step)
+ *     - type: notification type
+ * OUTPUT
+ *      none
+ */
+void layout_zcash_address_notification(const char* desc, const char* address,
+                                       NotificationType type) {
+  DrawableParams sp;
+  Canvas* canvas = layout_get_canvas();
+
+  call_leaving_handler();
+  layout_clear();
+
+  if (strcmp(desc, "") != 0) {
+    const Font* title_font = get_title_font();
+    sp.y = TOP_MARGIN_FOR_TWO_LINES;
+    sp.x = LEFT_MARGIN + 65;
+    sp.color = BODY_COLOR;
+    draw_string(canvas, title_font, desc, &sp, TRANSACTION_WIDTH - 2,
+                font_height(title_font) + BODY_FONT_LINE_PADDING);
+  }
+
+  layout_address(address, QR_LARGE);
+  layout_notification_icon(type, &sp);
+}
+
+/*
+ * layout_zcash_address_text_notification() - Display full zcash unified
+ * address text with title; the first confirm step in the view-on-device flow.
+ *
+ * INPUT
+ *     - desc: title text (e.g. "Zcash #0 Orchard")
+ *     - address: zcash unified address to display as text (3 lines)
+ *     - type: notification type
+ * OUTPUT
+ *      none
+ */
+void layout_zcash_address_text_notification(const char* desc,
+                                            const char* address,
+                                            NotificationType type) {
+  DrawableParams sp;
+  Canvas* canvas = layout_get_canvas();
+  const Font* address_font = get_body_font();
+
+  call_leaving_handler();
+  layout_clear();
+
+  if (strcmp(desc, "") != 0) {
+    const Font* title_font = get_title_font();
+    sp.y = TOP_MARGIN_FOR_THREE_LINES;
+    sp.x = LEFT_MARGIN;
+    sp.color = BODY_COLOR;
+    draw_string(canvas, title_font, desc, &sp, TRANSACTION_WIDTH - 2,
+                font_height(title_font) + BODY_FONT_LINE_PADDING);
+  }
+
+  /* Full UA below the title; -25 leaves the right column for confirm icons. */
+  sp.y = TOP_MARGIN_FOR_THREE_LINES + ADDRESS_XPUB_TOP_MARGIN;
+  sp.x = LEFT_MARGIN;
+  sp.color = BODY_COLOR;
+  draw_string(canvas, address_font, address, &sp, TRANSACTION_WIDTH - 25,
+              font_height(address_font) + BODY_FONT_LINE_PADDING);
+
+  layout_notification_icon(type, &sp);
+}
+
+/*
  * layout_address_notification() - Display address notification
  *
  * INPUT

--- a/lib/firmware/fsm.c
+++ b/lib/firmware/fsm.c
@@ -57,6 +57,8 @@
 #include "keepkey/firmware/signtx_tendermint.h"
 #include "keepkey/firmware/signed_metadata.h"
 #include "keepkey/firmware/solana.h"
+#include "keepkey/firmware/hive.h"
+#include "keepkey/firmware/zcash.h"
 #include "keepkey/firmware/storage.h"
 #include "keepkey/firmware/tendermint.h"
 #include "keepkey/firmware/thorchain.h"
@@ -91,6 +93,8 @@
 #include "messages-tron.pb.h"
 #include "messages-ton.pb.h"
 #include "messages-solana.pb.h"
+#include "messages-hive.pb.h"
+#include "messages-zcash.pb.h"
 
 #include <stdio.h>
 
@@ -273,6 +277,7 @@ void fsm_sendFailure(FailureType code, const char* text) {
 
 void fsm_msgClearSession(ClearSession* msg) {
   (void)msg;
+  zcash_signing_abort();
   session_clear(/*clear_pin=*/true);
   fsm_sendSuccess("Session cleared");
 }
@@ -294,3 +299,5 @@ void fsm_msgClearSession(ClearSession* msg) {
 #include "fsm_msg_tron.h"
 #include "fsm_msg_ton.h"
 #include "fsm_msg_solana.h"
+#include "fsm_msg_hive.h"
+#include "fsm_msg_zcash.h"

--- a/lib/firmware/fsm_msg_common.h
+++ b/lib/firmware/fsm_msg_common.h
@@ -5,6 +5,7 @@ void fsm_msgInitialize(Initialize* msg) {
   ethereum_signing_abort();
   tendermint_signAbort();
   eos_signingAbort();
+  zcash_signing_abort();
   session_clear(false);  // do not clear PIN
   layoutHome();
   fsm_msgGetFeatures(0);
@@ -560,6 +561,7 @@ void fsm_msgCancel(Cancel* msg) {
   ethereum_signing_abort();
   tendermint_signAbort();
   eos_signingAbort();
+  zcash_signing_abort();
   fsm_sendFailure(FailureType_Failure_ActionCancelled, "Aborted");
 }
 

--- a/lib/firmware/fsm_msg_hive.h
+++ b/lib/firmware/fsm_msg_hive.h
@@ -1,0 +1,458 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2026 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+// ── HiveGetPublicKey ──────────────────────────────────────────────────────
+// Returns a single STM-prefixed public key for the given SLIP-0048 path.
+// Path format: m/48'/13'/role'/account'/0' (all 5 components hardened).
+
+void fsm_msgHiveGetPublicKey(const HiveGetPublicKey* msg) {
+  RESP_INIT(HivePublicKey);
+
+  CHECK_INITIALIZED
+  CHECK_PIN
+
+  HDNode* node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
+                                    msg->address_n_count, NULL);
+  if (!node) return;
+  hdnode_fill_public_key(node);
+
+  resp->has_raw_public_key = true;
+  resp->raw_public_key.size = 33;
+  memcpy(resp->raw_public_key.bytes, node->public_key, 33);
+
+  resp->has_public_key = true;
+  if (!hive_getPublicKey(node->public_key, resp->public_key,
+                         sizeof(resp->public_key))) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_FirmwareError,
+                    _("Failed to encode Hive public key"));
+    layoutHome();
+    return;
+  }
+
+  if (msg->has_show_display && msg->show_display) {
+    // Determine role label for display
+    const char* role_label = "Hive Public Key";
+    if (msg->has_role) {
+      switch (msg->role) {
+        case 0:
+          role_label = "Hive Owner Key";
+          break;
+        case 1:
+          role_label = "Hive Active Key";
+          break;
+        case 3:
+          role_label = "Hive Memo Key";
+          break;
+        case 4:
+          role_label = "Hive Posting Key";
+          break;
+        default:
+          break;
+      }
+    }
+    if (!confirm_ethereum_address(role_label, resp->public_key)) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_ActionCancelled, _("Cancelled"));
+      layoutHome();
+      return;
+    }
+  }
+
+  memzero(node, sizeof(*node));
+  msg_write(MessageType_MessageType_HivePublicKey, resp);
+  layoutHome();
+}
+
+// ── HiveGetPublicKeys ─────────────────────────────────────────────────────
+// Returns all four SLIP-0048 role keys (owner/active/memo/posting) for a
+// given account index in a single device interaction.
+
+void fsm_msgHiveGetPublicKeys(const HiveGetPublicKeys* msg) {
+  RESP_INIT(HivePublicKeys);
+
+  CHECK_INITIALIZED
+  CHECK_PIN
+
+  uint32_t account_index = msg->has_account_index ? msg->account_index : 0;
+
+  HDNode* root = fsm_getDerivedNode(SECP256K1_NAME, NULL, 0, NULL);
+  if (!root) return;
+
+  resp->has_owner_key = true;
+  resp->has_active_key = true;
+  resp->has_memo_key = true;
+  resp->has_posting_key = true;
+
+  if (!hive_getPublicKeys(root, account_index, resp->owner_key,
+                          sizeof(resp->owner_key), resp->active_key,
+                          sizeof(resp->active_key), resp->memo_key,
+                          sizeof(resp->memo_key), resp->posting_key,
+                          sizeof(resp->posting_key))) {
+    memzero(root, sizeof(*root));
+    fsm_sendFailure(FailureType_Failure_FirmwareError,
+                    _("Failed to derive Hive keys"));
+    layoutHome();
+    return;
+  }
+
+  if (msg->has_show_display && msg->show_display) {
+    if (!confirm(ButtonRequestType_ButtonRequest_Other, "Hive Keys",
+                 "Export all Hive keys for account %u?",
+                 (unsigned int)account_index)) {
+      memzero(root, sizeof(*root));
+      fsm_sendFailure(FailureType_Failure_ActionCancelled, _("Cancelled"));
+      layoutHome();
+      return;
+    }
+  }
+
+  memzero(root, sizeof(*root));
+  msg_write(MessageType_MessageType_HivePublicKeys, resp);
+  layoutHome();
+}
+
+// ── HiveSignTx (transfer) ─────────────────────────────────────────────────
+
+void fsm_msgHiveSignTx(const HiveSignTx* msg) {
+  RESP_INIT(HiveSignedTx);
+
+  CHECK_INITIALIZED
+  CHECK_PIN
+
+  if (!msg->has_from || !msg->has_to || !msg->has_amount ||
+      !msg->has_ref_block_num || !msg->has_ref_block_prefix ||
+      !msg->has_expiration) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Missing required Hive transaction fields"));
+    layoutHome();
+    return;
+  }
+
+  HDNode* node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
+                                    msg->address_n_count, NULL);
+  if (!node) return;
+  hdnode_fill_public_key(node);
+
+  const char* symbol = msg->has_asset_symbol ? msg->asset_symbol : "HIVE";
+  char amount_str[32];
+  snprintf(amount_str, sizeof(amount_str), "%" PRIu64 ".%03" PRIu64 " %s",
+           msg->amount / 1000, msg->amount % 1000, symbol);
+
+  if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, "Send Hive",
+               "Send %s to @%s?", amount_str, msg->to)) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+    layoutHome();
+    return;
+  }
+
+  if (msg->has_memo && strlen(msg->memo) > 0) {
+    if (!confirm(ButtonRequestType_ButtonRequest_ConfirmMemo, "Memo", "%s",
+                 msg->memo)) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+      layoutHome();
+      return;
+    }
+  }
+
+  if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Sign Transaction",
+               "Sign Hive transaction from @%s?", msg->from)) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+    layoutHome();
+    return;
+  }
+
+  hive_signTx(node, msg, resp);
+  memzero(node, sizeof(*node));
+
+  if (!resp->has_signature) {
+    fsm_sendFailure(FailureType_Failure_FirmwareError,
+                    _("Hive signing failed"));
+    layoutHome();
+    return;
+  }
+
+  msg_write(MessageType_MessageType_HiveSignedTx, resp);
+  layoutHome();
+}
+
+// ── HiveSignAccountCreate ─────────────────────────────────────────────────
+// Signs a Graphene account_create operation.
+// Device derives all four role keys internally; host-supplied key strings
+// are informational only (displayed for confirmation) and never used for
+// the actual transaction. KeepKey is the sole root of trust from genesis.
+
+void fsm_msgHiveSignAccountCreate(const HiveSignAccountCreate* msg) {
+  RESP_INIT(HiveSignedAccountCreate);
+
+  CHECK_INITIALIZED
+  CHECK_PIN
+
+  if (!msg->has_new_account_name || !msg->has_creator ||
+      !msg->has_ref_block_num || !msg->has_ref_block_prefix ||
+      !msg->has_expiration) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Missing required account_create fields"));
+    layoutHome();
+    return;
+  }
+
+  // Path must have at least 4 components so we can extract account_index.
+  // Expected: m/48'/13'/0'/account_index'/0' (count = 5)
+  if (msg->address_n_count < 4) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError, _("Hive path too short"));
+    layoutHome();
+    return;
+  }
+  uint32_t account_index = msg->address_n[3] & 0x7FFFFFFFu;
+
+  // Derive all four role keys from the device root.
+  // Do this BEFORE fetching the signing node so the root static buffer
+  // is not clobbered by the second fsm_getDerivedNode call.
+  const HDNode* root = fsm_getDerivedNode(SECP256K1_NAME, NULL, 0, NULL);
+  if (!root) return;
+
+  uint8_t owner_raw[33], active_raw[33], posting_raw[33], memo_raw[33];
+  uint32_t acc_hardened = account_index | 0x80000000u;
+  bool keys_ok =
+      hive_deriveRawKey(root, HIVE_ROLE_OWNER, acc_hardened, owner_raw) &&
+      hive_deriveRawKey(root, HIVE_ROLE_ACTIVE, acc_hardened, active_raw) &&
+      hive_deriveRawKey(root, HIVE_ROLE_POSTING, acc_hardened, posting_raw) &&
+      hive_deriveRawKey(root, HIVE_ROLE_MEMO, acc_hardened, memo_raw);
+  // root static buffer is done with; signing node derivation may overwrite it.
+
+  if (!keys_ok) {
+    memzero(owner_raw, sizeof(owner_raw));
+    memzero(active_raw, sizeof(active_raw));
+    memzero(posting_raw, sizeof(posting_raw));
+    memzero(memo_raw, sizeof(memo_raw));
+    fsm_sendFailure(FailureType_Failure_FirmwareError,
+                    _("Failed to derive Hive keys"));
+    layoutHome();
+    return;
+  }
+
+  // Now get the signing node (owner key, overwrites root static buffer).
+  HDNode* node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
+                                    msg->address_n_count, NULL);
+  if (!node) {
+    memzero(owner_raw, sizeof(owner_raw));
+    memzero(active_raw, sizeof(active_raw));
+    memzero(posting_raw, sizeof(posting_raw));
+    memzero(memo_raw, sizeof(memo_raw));
+    return;
+  }
+  hdnode_fill_public_key(node);
+
+  // Encode the device-derived owner key for display confirmation.
+  char owner_stm[64];
+  if (!hive_getPublicKey(owner_raw, owner_stm, sizeof(owner_stm))) {
+    memzero(node, sizeof(*node));
+    memzero(owner_raw, sizeof(owner_raw));
+    memzero(active_raw, sizeof(active_raw));
+    memzero(posting_raw, sizeof(posting_raw));
+    memzero(memo_raw, sizeof(memo_raw));
+    fsm_sendFailure(FailureType_Failure_FirmwareError,
+                    _("Failed to encode Hive owner key"));
+    layoutHome();
+    return;
+  }
+
+  // Primary confirmation: show the new username prominently.
+  if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+               "Create Hive Account",
+               "Create @%s secured by KeepKey?\n\nAll keys from your device.",
+               msg->new_account_name)) {
+    memzero(node, sizeof(*node));
+    memzero(owner_raw, sizeof(owner_raw));
+    memzero(active_raw, sizeof(active_raw));
+    memzero(posting_raw, sizeof(posting_raw));
+    memzero(memo_raw, sizeof(memo_raw));
+    fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+    layoutHome();
+    return;
+  }
+
+  // Secondary confirmation: show device-derived owner key so user can verify.
+  if (!confirm(ButtonRequestType_ButtonRequest_Other, "Owner Key", "%s",
+               owner_stm)) {
+    memzero(node, sizeof(*node));
+    memzero(owner_raw, sizeof(owner_raw));
+    memzero(active_raw, sizeof(active_raw));
+    memzero(posting_raw, sizeof(posting_raw));
+    memzero(memo_raw, sizeof(memo_raw));
+    fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+    layoutHome();
+    return;
+  }
+
+  // Tertiary confirmation: show sponsor + fee.
+  char fee_str[32];
+  uint64_t fee = msg->has_fee_amount ? msg->fee_amount : 3000;
+  snprintf(fee_str, sizeof(fee_str), "%" PRIu64 ".%03" PRIu64 " HIVE",
+           fee / 1000, fee % 1000);
+  if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Creation Fee",
+               "Fee: %s paid by @%s", fee_str, msg->creator)) {
+    memzero(node, sizeof(*node));
+    memzero(owner_raw, sizeof(owner_raw));
+    memzero(active_raw, sizeof(active_raw));
+    memzero(posting_raw, sizeof(posting_raw));
+    memzero(memo_raw, sizeof(memo_raw));
+    fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+    layoutHome();
+    return;
+  }
+
+  hive_signAccountCreate(node, msg, owner_raw, active_raw, posting_raw,
+                         memo_raw, resp);
+  memzero(node, sizeof(*node));
+  memzero(owner_raw, sizeof(owner_raw));
+  memzero(active_raw, sizeof(active_raw));
+  memzero(posting_raw, sizeof(posting_raw));
+  memzero(memo_raw, sizeof(memo_raw));
+
+  if (!resp->has_signature) {
+    fsm_sendFailure(FailureType_Failure_FirmwareError,
+                    _("Hive account_create signing failed"));
+    layoutHome();
+    return;
+  }
+
+  msg_write(MessageType_MessageType_HiveSignedAccountCreate, resp);
+  layoutHome();
+}
+
+// ── HiveSignAccountUpdate ─────────────────────────────────────────────────
+// Signs a Graphene account_update operation.
+// Device derives all four new role keys internally; host-supplied new_*_key
+// strings are not used for signing. The device-derived owner key is shown
+// so the user can verify it matches their device before replacing all keys.
+
+void fsm_msgHiveSignAccountUpdate(const HiveSignAccountUpdate* msg) {
+  RESP_INIT(HiveSignedAccountUpdate);
+
+  CHECK_INITIALIZED
+  CHECK_PIN
+
+  if (!msg->has_account || !msg->has_ref_block_num ||
+      !msg->has_ref_block_prefix || !msg->has_expiration) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Missing required account_update fields"));
+    layoutHome();
+    return;
+  }
+
+  if (msg->address_n_count < 4) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError, _("Hive path too short"));
+    layoutHome();
+    return;
+  }
+  uint32_t account_index = msg->address_n[3] & 0x7FFFFFFFu;
+
+  // Derive all four role keys before fetching the signing node.
+  const HDNode* root = fsm_getDerivedNode(SECP256K1_NAME, NULL, 0, NULL);
+  if (!root) return;
+
+  uint8_t owner_raw[33], active_raw[33], posting_raw[33], memo_raw[33];
+  uint32_t acc_hardened = account_index | 0x80000000u;
+  bool keys_ok =
+      hive_deriveRawKey(root, HIVE_ROLE_OWNER, acc_hardened, owner_raw) &&
+      hive_deriveRawKey(root, HIVE_ROLE_ACTIVE, acc_hardened, active_raw) &&
+      hive_deriveRawKey(root, HIVE_ROLE_POSTING, acc_hardened, posting_raw) &&
+      hive_deriveRawKey(root, HIVE_ROLE_MEMO, acc_hardened, memo_raw);
+
+  if (!keys_ok) {
+    memzero(owner_raw, sizeof(owner_raw));
+    memzero(active_raw, sizeof(active_raw));
+    memzero(posting_raw, sizeof(posting_raw));
+    memzero(memo_raw, sizeof(memo_raw));
+    fsm_sendFailure(FailureType_Failure_FirmwareError,
+                    _("Failed to derive Hive keys"));
+    layoutHome();
+    return;
+  }
+
+  // Signing node (overwrites root static buffer).
+  HDNode* node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
+                                    msg->address_n_count, NULL);
+  if (!node) {
+    memzero(owner_raw, sizeof(owner_raw));
+    memzero(active_raw, sizeof(active_raw));
+    memzero(posting_raw, sizeof(posting_raw));
+    memzero(memo_raw, sizeof(memo_raw));
+    return;
+  }
+  hdnode_fill_public_key(node);
+
+  // Encode device-derived owner key for display.
+  char owner_stm[64];
+  if (!hive_getPublicKey(owner_raw, owner_stm, sizeof(owner_stm))) {
+    memzero(node, sizeof(*node));
+    memzero(owner_raw, sizeof(owner_raw));
+    memzero(active_raw, sizeof(active_raw));
+    memzero(posting_raw, sizeof(posting_raw));
+    memzero(memo_raw, sizeof(memo_raw));
+    fsm_sendFailure(FailureType_Failure_FirmwareError,
+                    _("Failed to encode Hive owner key"));
+    layoutHome();
+    return;
+  }
+
+  // Warning: this replaces all existing keys.
+  if (!confirm(ButtonRequestType_ButtonRequest_ProtectCall,
+               "Secure Hive Account",
+               "Replace ALL keys for @%s with KeepKey keys?\n\nOld keys will "
+               "be retired.",
+               msg->account)) {
+    memzero(node, sizeof(*node));
+    memzero(owner_raw, sizeof(owner_raw));
+    memzero(active_raw, sizeof(active_raw));
+    memzero(posting_raw, sizeof(posting_raw));
+    memzero(memo_raw, sizeof(memo_raw));
+    fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+    layoutHome();
+    return;
+  }
+
+  // Show device-derived owner key so user can verify it's their device.
+  if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "New Owner Key", "%s",
+               owner_stm)) {
+    memzero(node, sizeof(*node));
+    memzero(owner_raw, sizeof(owner_raw));
+    memzero(active_raw, sizeof(active_raw));
+    memzero(posting_raw, sizeof(posting_raw));
+    memzero(memo_raw, sizeof(memo_raw));
+    fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+    layoutHome();
+    return;
+  }
+
+  hive_signAccountUpdate(node, msg, owner_raw, active_raw, posting_raw,
+                         memo_raw, resp);
+  memzero(node, sizeof(*node));
+  memzero(owner_raw, sizeof(owner_raw));
+  memzero(active_raw, sizeof(active_raw));
+  memzero(posting_raw, sizeof(posting_raw));
+  memzero(memo_raw, sizeof(memo_raw));
+
+  if (!resp->has_signature) {
+    fsm_sendFailure(FailureType_Failure_FirmwareError,
+                    _("Hive account_update signing failed"));
+    layoutHome();
+    return;
+  }
+
+  msg_write(MessageType_MessageType_HiveSignedAccountUpdate, resp);
+  layoutHome();
+}

--- a/lib/firmware/fsm_msg_hive.h
+++ b/lib/firmware/fsm_msg_hive.h
@@ -187,6 +187,24 @@ void fsm_msgHiveSignTx(const HiveSignTx* msg) {
   layoutHome();
 }
 
+// ── SLIP-0048 path validation ─────────────────────────────────────────────
+// Account create/update derive replacement role keys from address_n[3], so
+// the full path shape must be enforced before anything is derived or signed:
+// m/48'/13'/role'/account'/0' (all 5 components hardened).
+
+static bool hive_slip48_path_ok(const uint32_t* address_n, uint32_t count) {
+  if (count != 5) return false;
+  if (address_n[0] != HIVE_SLIP48_PURPOSE) return false;
+  if (address_n[1] != HIVE_SLIP48_NETWORK) return false;
+  if (address_n[2] != HIVE_ROLE_OWNER && address_n[2] != HIVE_ROLE_ACTIVE &&
+      address_n[2] != HIVE_ROLE_MEMO && address_n[2] != HIVE_ROLE_POSTING) {
+    return false;
+  }
+  if ((address_n[3] & 0x80000000u) == 0) return false;
+  if (address_n[4] != 0x80000000u) return false;  // key index 0'
+  return true;
+}
+
 // ── HiveSignAccountCreate ─────────────────────────────────────────────────
 // Signs a Graphene account_create operation.
 // Device derives all four role keys internally; host-supplied key strings
@@ -208,10 +226,9 @@ void fsm_msgHiveSignAccountCreate(const HiveSignAccountCreate* msg) {
     return;
   }
 
-  // Path must have at least 4 components so we can extract account_index.
-  // Expected: m/48'/13'/0'/account_index'/0' (count = 5)
-  if (msg->address_n_count < 4) {
-    fsm_sendFailure(FailureType_Failure_SyntaxError, _("Hive path too short"));
+  if (!hive_slip48_path_ok(msg->address_n, msg->address_n_count)) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Invalid Hive SLIP-0048 path"));
     layoutHome();
     return;
   }
@@ -353,8 +370,9 @@ void fsm_msgHiveSignAccountUpdate(const HiveSignAccountUpdate* msg) {
     return;
   }
 
-  if (msg->address_n_count < 4) {
-    fsm_sendFailure(FailureType_Failure_SyntaxError, _("Hive path too short"));
+  if (!hive_slip48_path_ok(msg->address_n, msg->address_n_count)) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Invalid Hive SLIP-0048 path"));
     layoutHome();
     return;
   }

--- a/lib/firmware/fsm_msg_hive.h
+++ b/lib/firmware/fsm_msg_hive.h
@@ -39,10 +39,12 @@ void fsm_msgHiveGetPublicKey(const HiveGetPublicKey* msg) {
   }
 
   if (msg->has_show_display && msg->show_display) {
-    // Determine role label for display
+    // Label the key by the role in the ACTUAL derivation path
+    // (m/48'/13'/role'/account'/0'), never the host-supplied msg->role,
+    // which could mislabel the exported key.
     const char* role_label = "Hive Public Key";
-    if (msg->has_role) {
-      switch (msg->role) {
+    if (msg->address_n_count >= 3) {
+      switch (msg->address_n[2] & 0x7FFFFFFFu) {
         case 0:
           role_label = "Hive Owner Key";
           break;
@@ -142,10 +144,23 @@ void fsm_msgHiveSignTx(const HiveSignTx* msg) {
   if (!node) return;
   hdnode_fill_public_key(node);
 
+  // Display precision MUST match the precision the serializer signs
+  // (append_asset uses msg->decimals), otherwise the user approves an
+  // amount that differs from what is signed. Reject implausible precision.
+  uint8_t prec = msg->has_decimals ? (uint8_t)msg->decimals : HIVE_DECIMALS;
+  if (prec > 18) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Invalid Hive asset precision"));
+    layoutHome();
+    return;
+  }
   const char* symbol = msg->has_asset_symbol ? msg->asset_symbol : "HIVE";
+  char suffix[10];
+  snprintf(suffix, sizeof(suffix), " %s", symbol);
   char amount_str[32];
-  snprintf(amount_str, sizeof(amount_str), "%" PRIu64 ".%03" PRIu64 " %s",
-           msg->amount / 1000, msg->amount % 1000, symbol);
+  bn_format_uint64(msg->amount, NULL, suffix, prec, 0, false, amount_str,
+                   sizeof(amount_str));
 
   if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, "Send Hive",
                "Send %s to @%s?", amount_str, msg->to)) {

--- a/lib/firmware/fsm_msg_hive.h
+++ b/lib/firmware/fsm_msg_hive.h
@@ -156,7 +156,7 @@ void fsm_msgHiveSignTx(const HiveSignTx* msg) {
     return;
   }
   const char* symbol = msg->has_asset_symbol ? msg->asset_symbol : "HIVE";
-  char suffix[10];
+  char suffix[sizeof(msg->asset_symbol) + 2];  // leading space + symbol + NUL
   snprintf(suffix, sizeof(suffix), " %s", symbol);
   char amount_str[32];
   bn_format_uint64(msg->amount, NULL, suffix, prec, 0, false, amount_str,

--- a/lib/firmware/fsm_msg_ripple.h
+++ b/lib/firmware/fsm_msg_ripple.h
@@ -109,6 +109,16 @@ void fsm_msgRippleSignTx(RippleSignTx* msg) {
     }
   }
 
+  if (msg->has_memo && msg->memo[0] != '\0') {
+    if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, "Memo", "%s",
+                 msg->memo)) {
+      memzero(node, sizeof(*node));
+      fsm_sendFailure(FailureType_Failure_ActionCancelled, "Signing cancelled");
+      layoutHome();
+      return;
+    }
+  }
+
   if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Transaction",
                "Really send %s, with a transaction fee of %s?", amount_string,
                fee_string)) {

--- a/lib/firmware/fsm_msg_thorchain.h
+++ b/lib/firmware/fsm_msg_thorchain.h
@@ -141,15 +141,42 @@ void fsm_msgThorchainMsgAck(const ThorchainMsgAck* msg) {
   const ThorchainSignTx* sign_tx = thorchain_getThorchainSignTx();
 
   if (msg->has_send) {
+    const char* coin_denom =
+        (msg->send.has_denom && msg->send.denom[0]) ? msg->send.denom : "rune";
+
+    // Validate before any display so untrusted strings never reach the UI.
+    if (!thorchain_isValidDenom(coin_denom)) {
+      thorchain_signAbort();
+      fsm_sendFailure(FailureType_Failure_SyntaxError, "Invalid denom");
+      layoutHome();
+      return;
+    }
+
     switch (msg->send.address_type) {
       case OutputAddressType_TRANSFER:
       default: {
+        // amount_str only needs to hold the numeric part (no denom suffix).
+        // Denom is confirmed on a separate screen so no truncation is possible.
         char amount_str[32];
-        bn_format_uint64(msg->send.amount, NULL, " RUNE", 8, 0, false,
-                         amount_str, sizeof(amount_str));
+        if (!bn_format_uint64(msg->send.amount, NULL, NULL, 8, 0, false,
+                              amount_str, sizeof(amount_str))) {
+          thorchain_signAbort();
+          fsm_sendFailure(FailureType_Failure_FirmwareError,
+                          _("Failed to format amount"));
+          layoutHome();
+          return;
+        }
         if (!confirm_transaction_output(
                 ButtonRequestType_ButtonRequest_ConfirmOutput, amount_str,
                 msg->send.to_address)) {
+          thorchain_signAbort();
+          fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+          layoutHome();
+          return;
+        }
+        // Confirm the asset denom on its own screen.
+        if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, "Asset",
+                     "%s", coin_denom)) {
           thorchain_signAbort();
           fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
           layoutHome();
@@ -159,8 +186,8 @@ void fsm_msgThorchainMsgAck(const ThorchainMsgAck* msg) {
         break;
       }
     }
-    if (!thorchain_signTxUpdateMsgSend(msg->send.amount,
-                                       msg->send.to_address)) {
+    if (!thorchain_signTxUpdateMsgSend(msg->send.amount, msg->send.to_address,
+                                       coin_denom)) {
       thorchain_signAbort();
       fsm_sendFailure(FailureType_Failure_SyntaxError,
                       "Failed to include send message in transaction");
@@ -240,7 +267,7 @@ void fsm_msgThorchainMsgAck(const ThorchainMsgAck* msg) {
   }
 
   if (!confirm(ButtonRequestType_ButtonRequest_SignTx, node_str,
-               "Sign this RUNE transaction on %s? "
+               "Sign this THORChain transaction on %s? "
                "Additional network fees apply.",
                sign_tx->chain_id)) {
     thorchain_signAbort();

--- a/lib/firmware/fsm_msg_zcash.h
+++ b/lib/firmware/fsm_msg_zcash.h
@@ -1,0 +1,1388 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2025 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Zcash-specific headers — included here because fsm_msg_zcash.h
+ * is #include'd inside fsm.c, not compiled separately. */
+#include <limits.h>
+
+#include "keepkey/firmware/zcash.h"
+#include "trezor/crypto/blake2b.h"
+#include "trezor/crypto/pallas.h"
+#include "trezor/crypto/redpallas.h"
+#include "trezor/crypto/memzero.h"
+
+/* Precomputed empty digest constants for shielded-only transactions.
+ * These are BLAKE2b-256 with the respective personalizations over empty input.
+ * Verified against Keystone3 test vectors. */
+static const uint8_t EMPTY_TRANSPARENT_DIGEST[32] = {
+    0xc3, 0x3f, 0x2e, 0x95, 0x70, 0x5f, 0xaa, 0xb3, 0x5f, 0x8d, 0x53,
+    0x3f, 0xa6, 0x1e, 0x95, 0xc3, 0xb7, 0xaa, 0xba, 0x07, 0x76, 0xb8,
+    0x74, 0xa9, 0xf7, 0x4f, 0xc1, 0x27, 0x84, 0x37, 0x6a, 0x59};
+
+static const uint8_t EMPTY_SAPLING_DIGEST[32] = {
+    0x6f, 0x2f, 0xc8, 0xf9, 0x8f, 0xea, 0xfd, 0x94, 0xe7, 0x4a, 0x0d,
+    0xf4, 0xbe, 0xd7, 0x43, 0x91, 0xee, 0x0b, 0x5a, 0x69, 0x94, 0x5e,
+    0x4c, 0xed, 0x8c, 0xa8, 0xa0, 0x95, 0x20, 0x6f, 0x00, 0xae};
+
+#define ZCASH_MAX_ACTIONS 16
+#define ZCASH_MAX_TRANSPARENT_INPUTS 8
+#define ZCASH_MAX_TRANSPARENT_OUTPUTS 8
+#define ZCASH_MAX_TRANSPARENT_SCRIPT_PUBKEY 128
+
+typedef struct {
+  bool received;
+  uint8_t prevout_txid[32];
+  uint32_t prevout_index;
+  uint32_t sequence;
+  uint64_t amount;
+  uint8_t script_pubkey[ZCASH_MAX_TRANSPARENT_SCRIPT_PUBKEY];
+  size_t script_pubkey_size;
+  uint32_t address_n[8];
+  uint32_t address_n_count;
+} ZcashTransparentInputState;
+
+typedef struct {
+  bool received;
+  uint64_t amount;
+  uint8_t script_pubkey[ZCASH_MAX_TRANSPARENT_SCRIPT_PUBKEY];
+  size_t script_pubkey_size;
+} ZcashTransparentOutputState;
+
+/* Zcash shielded signing state */
+static struct {
+  bool active;
+  uint32_t account;
+  uint32_t n_actions;
+  uint32_t current_action;
+  uint64_t total_amount;
+  uint64_t fee;
+  uint32_t branch_id;
+  ZcashOrchardKeys keys;
+  uint8_t header_digest[32];
+  uint8_t sighash[32];
+  /* Phase 2a: on-device sighash computation */
+  bool has_device_sighash;
+  /* Phase 2b: incremental orchard digest verification */
+  bool verify_orchard_digest;
+  uint8_t expected_orchard_digest[32];
+  BLAKE2B_CTX compact_ctx;
+  BLAKE2B_CTX memos_ctx;
+  BLAKE2B_CTX noncompact_ctx;
+  uint8_t orchard_flags;
+  int64_t orchard_value_balance;
+  uint8_t orchard_anchor[32];
+  /* Signatures buffer: up to 16 actions (64 bytes each) */
+  uint8_t signatures[16][64];
+  /* Phase 3: transparent shielding state */
+  bool has_expected_transparent_digest;
+  uint8_t expected_transparent_digest[32];
+  bool transparent_digest_verified;
+  uint32_t n_transparent_outputs;
+  uint32_t current_transparent_output;
+  uint32_t n_transparent_inputs;
+  uint32_t current_transparent_input;
+  ZcashTransparentOutputState
+      transparent_outputs[ZCASH_MAX_TRANSPARENT_OUTPUTS];
+  ZcashTransparentInputState transparent_inputs[ZCASH_MAX_TRANSPARENT_INPUTS];
+  /* Deferred transparent ECDSA sigs — buffered until Orchard/fee final gate */
+  bool has_pending_transparent;
+  ZcashTransparentSigned pending_transparent;
+} zcash_signing;
+
+/* Public API; declared in keepkey/firmware/zcash.h. */
+void zcash_signing_abort(void) {
+  memzero(&zcash_signing, sizeof(zcash_signing));
+}
+
+static bool zcash_script_is_p2pkh(const uint8_t* script, size_t script_size) {
+  return script && script_size == 25 && script[0] == 0x76 &&
+         script[1] == 0xa9 && script[2] == 0x14 && script[23] == 0x88 &&
+         script[24] == 0xac;
+}
+
+static bool zcash_script_is_p2sh(const uint8_t* script, size_t script_size) {
+  return script && script_size == 23 && script[0] == 0xa9 &&
+         script[1] == 0x14 && script[22] == 0x87;
+}
+
+static bool zcash_script_is_standard_transparent(const uint8_t* script,
+                                                 size_t script_size) {
+  return zcash_script_is_p2pkh(script, script_size) ||
+         zcash_script_is_p2sh(script, script_size);
+}
+
+static bool zcash_transparent_script_to_address(const uint8_t* script,
+                                                size_t script_size, char* out,
+                                                size_t out_size) {
+  if (!script || !out || out_size == 0) return false;
+
+  const CoinType* coin = fsm_getCoin(true, "Zcash");
+  if (!coin) return false;
+
+  uint32_t address_type;
+  const uint8_t* hash160;
+  if (zcash_script_is_p2pkh(script, script_size)) {
+    if (!coin->has_address_type) return false;
+    address_type = coin->address_type;
+    hash160 = script + 3;
+  } else if (zcash_script_is_p2sh(script, script_size)) {
+    if (!coin->has_address_type_p2sh) return false;
+    address_type = coin->address_type_p2sh;
+    hash160 = script + 2;
+  } else {
+    return false;
+  }
+
+  uint8_t raw[4 + 20] = {0};
+  size_t prefix_len = address_prefix_bytes_len(address_type);
+  if (prefix_len == 0 || prefix_len + 20 > sizeof(raw)) return false;
+  address_write_prefix_bytes(address_type, raw);
+  memcpy(raw + prefix_len, hash160, 20);
+  return base58_encode_check(raw, (int)(prefix_len + 20), HASHER_SHA2D, out,
+                             (int)out_size) != 0;
+}
+
+static void zcash_format_amount(uint64_t amount, char* out, size_t out_size) {
+  snprintf(out, out_size, "%llu.%08llu ZEC",
+           (unsigned long long)(amount / 100000000ULL),
+           (unsigned long long)(amount % 100000000ULL));
+}
+
+static bool zcash_verify_and_confirm_orchard_output(
+    const ZcashPCZTAction* msg) {
+  if (!msg->has_value || !msg->has_recipient ||
+      msg->recipient.size != ZCASH_ORCHARD_RAW_RECEIVER_SIZE ||
+      !msg->has_rseed || msg->rseed.size != 32) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Missing Orchard output metadata"));
+    return false;
+  }
+
+  uint8_t computed_cmx[32];
+  if (!zcash_orchard_compute_cmx(msg->recipient.bytes, msg->value,
+                                 msg->nullifier.bytes, msg->rseed.bytes,
+                                 computed_cmx) ||
+      memcmp(computed_cmx, msg->cmx.bytes, 32) != 0) {
+    memzero(computed_cmx, sizeof(computed_cmx));
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("Orchard note commitment mismatch"));
+    return false;
+  }
+  memzero(computed_cmx, sizeof(computed_cmx));
+
+  char address[ZCASH_ORCHARD_UNIFIED_ADDRESS_SIZE];
+  if (!zcash_orchard_receiver_to_unified_address(msg->recipient.bytes, "u",
+                                                 address, sizeof(address))) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Invalid Orchard recipient"));
+    return false;
+  }
+
+  char amount_str[32];
+  zcash_format_amount(msg->value, amount_str, sizeof(amount_str));
+  if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, "Zcash Output",
+               "Send shielded ZEC?\n%s\nAmount: %s", address, amount_str)) {
+    fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                    _("Signing cancelled"));
+    memzero(address, sizeof(address));
+    return false;
+  }
+
+  memzero(address, sizeof(address));
+  return true;
+}
+
+static bool zcash_compute_verified_fee(uint64_t* fee_out) {
+  if (!fee_out) return false;
+
+  int64_t net_transparent = 0;
+  for (uint32_t i = 0; i < zcash_signing.n_transparent_inputs; i++) {
+    const uint64_t amount = zcash_signing.transparent_inputs[i].amount;
+    if (amount > (uint64_t)INT64_MAX ||
+        net_transparent > INT64_MAX - (int64_t)amount) {
+      return false;
+    }
+    net_transparent += (int64_t)amount;
+  }
+
+  for (uint32_t i = 0; i < zcash_signing.n_transparent_outputs; i++) {
+    const uint64_t amount = zcash_signing.transparent_outputs[i].amount;
+    if (amount > (uint64_t)INT64_MAX ||
+        net_transparent < INT64_MIN + (int64_t)amount) {
+      return false;
+    }
+    net_transparent -= (int64_t)amount;
+  }
+
+  const int64_t value_balance = zcash_signing.orchard_value_balance;
+  if ((value_balance > 0 && net_transparent > INT64_MAX - value_balance) ||
+      (value_balance < 0 && net_transparent < INT64_MIN - value_balance)) {
+    return false;
+  }
+
+  const int64_t signed_fee = net_transparent + value_balance;
+  if (signed_fee < 0) return false;
+
+  *fee_out = (uint64_t)signed_fee;
+  return true;
+}
+
+static bool zcash_verify_and_confirm_fee(void) {
+  uint64_t verified_fee = 0;
+  if (!zcash_compute_verified_fee(&verified_fee)) {
+    fsm_sendFailure(FailureType_Failure_Other, _("Invalid transaction fee"));
+    return false;
+  }
+
+  if (verified_fee != zcash_signing.fee) {
+    fsm_sendFailure(FailureType_Failure_Other, _("Fee mismatch"));
+    return false;
+  }
+
+  char fee_str[32];
+  zcash_format_amount(verified_fee, fee_str, sizeof(fee_str));
+  if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Zcash Fee",
+               "Confirm transaction fee?\n%s", fee_str)) {
+    fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                    _("Signing cancelled"));
+    return false;
+  }
+
+  return true;
+}
+
+static void zcash_send_action_ack(uint32_t next_index) {
+  ZcashPCZTActionAck* resp_ack = (ZcashPCZTActionAck*)msg_resp;
+  memset(resp_ack, 0, sizeof(ZcashPCZTActionAck));
+  resp_ack->has_next_index = true;
+  resp_ack->next_index = next_index;
+  msg_write(MessageType_MessageType_ZcashPCZTActionAck, resp_ack);
+}
+
+static void zcash_send_transparent_output_ack(uint32_t next_index) {
+  ZcashTransparentAck* resp = (ZcashTransparentAck*)msg_resp;
+  memset(resp, 0, sizeof(ZcashTransparentAck));
+  resp->has_next_output_index = true;
+  resp->next_output_index = next_index;
+  msg_write(MessageType_MessageType_ZcashTransparentAck, resp);
+}
+
+static void zcash_send_transparent_input_ack(uint32_t next_index) {
+  ZcashTransparentAck* resp = (ZcashTransparentAck*)msg_resp;
+  memset(resp, 0, sizeof(ZcashTransparentAck));
+  resp->has_next_input_index = true;
+  resp->next_input_index = next_index;
+  msg_write(MessageType_MessageType_ZcashTransparentAck, resp);
+}
+
+static bool zcash_build_transparent_digest_info(
+    ZcashTransparentInputDigestInfo inputs[ZCASH_MAX_TRANSPARENT_INPUTS],
+    ZcashTransparentOutputDigestInfo outputs[ZCASH_MAX_TRANSPARENT_OUTPUTS]) {
+  for (uint32_t i = 0; i < zcash_signing.n_transparent_inputs; i++) {
+    const ZcashTransparentInputState* stored =
+        &zcash_signing.transparent_inputs[i];
+    if (!stored->received) return false;
+    inputs[i].prevout_txid = stored->prevout_txid;
+    inputs[i].prevout_index = stored->prevout_index;
+    inputs[i].sequence = stored->sequence;
+    inputs[i].value = stored->amount;
+    inputs[i].script_pubkey = stored->script_pubkey;
+    inputs[i].script_pubkey_size = stored->script_pubkey_size;
+  }
+
+  for (uint32_t i = 0; i < zcash_signing.n_transparent_outputs; i++) {
+    const ZcashTransparentOutputState* stored =
+        &zcash_signing.transparent_outputs[i];
+    if (!stored->received) return false;
+    outputs[i].value = stored->amount;
+    outputs[i].script_pubkey = stored->script_pubkey;
+    outputs[i].script_pubkey_size = stored->script_pubkey_size;
+  }
+
+  return true;
+}
+
+static bool zcash_finalize_transparent_digest(void) {
+  if (!zcash_signing.has_expected_transparent_digest) return false;
+
+  ZcashTransparentInputDigestInfo inputs[ZCASH_MAX_TRANSPARENT_INPUTS] = {0};
+  ZcashTransparentOutputDigestInfo outputs[ZCASH_MAX_TRANSPARENT_OUTPUTS] = {0};
+  uint8_t transparent_digest[32] = {0};
+
+  if (!zcash_build_transparent_digest_info(inputs, outputs) ||
+      !zcash_compute_orchard_transparent_sig_digest(
+          inputs, zcash_signing.n_transparent_inputs, outputs,
+          zcash_signing.n_transparent_outputs, transparent_digest)) {
+    memzero(transparent_digest, sizeof(transparent_digest));
+    memzero(inputs, sizeof(inputs));
+    memzero(outputs, sizeof(outputs));
+    return false;
+  }
+
+  if (memcmp(transparent_digest, zcash_signing.expected_transparent_digest,
+             32) != 0) {
+    memzero(transparent_digest, sizeof(transparent_digest));
+    memzero(inputs, sizeof(inputs));
+    memzero(outputs, sizeof(outputs));
+    return false;
+  }
+
+  zcash_compute_shielded_sighash(
+      zcash_signing.header_digest, transparent_digest, EMPTY_SAPLING_DIGEST,
+      zcash_signing.expected_orchard_digest, zcash_signing.branch_id,
+      zcash_signing.sighash);
+  zcash_signing.has_device_sighash = true;
+  zcash_signing.transparent_digest_verified = true;
+
+  memzero(transparent_digest, sizeof(transparent_digest));
+  memzero(inputs, sizeof(inputs));
+  memzero(outputs, sizeof(outputs));
+  return true;
+}
+
+static bool zcash_sign_transparent_inputs(bool* cancelled) {
+  if (!zcash_signing.transparent_digest_verified) return false;
+  if (cancelled) *cancelled = false;
+
+  bool ok = false;
+  ZcashTransparentInputDigestInfo inputs[ZCASH_MAX_TRANSPARENT_INPUTS] = {0};
+  ZcashTransparentOutputDigestInfo outputs[ZCASH_MAX_TRANSPARENT_OUTPUTS] = {0};
+  if (!zcash_build_transparent_digest_info(inputs, outputs)) goto cleanup;
+
+  const CoinType* coin = fsm_getCoin(true, "Zcash");
+  if (!coin) goto cleanup;
+
+  memset(&zcash_signing.pending_transparent, 0, sizeof(ZcashTransparentSigned));
+  zcash_signing.pending_transparent.signatures_count =
+      zcash_signing.n_transparent_inputs;
+
+  for (uint32_t i = 0; i < zcash_signing.n_transparent_inputs; i++) {
+    const ZcashTransparentInputState* stored =
+        &zcash_signing.transparent_inputs[i];
+
+    char input_str[64];
+    char amount_str[32];
+    zcash_format_amount(stored->amount, amount_str, sizeof(amount_str));
+    snprintf(input_str, sizeof(input_str), "Input %lu: %s",
+             (unsigned long)(i + 1), amount_str);
+    if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Sign Input",
+                 "Sign transparent input?\n%s", input_str)) {
+      if (cancelled) *cancelled = true;
+      goto cleanup;
+    }
+
+    HDNode* node = fsm_getDerivedNode(coin->curve_name, stored->address_n,
+                                      stored->address_n_count, NULL);
+    if (!node) goto cleanup;
+
+    /* ZIP-244 §4.4: signature_digest = ZcashTxHash_(
+     *   header_digest || transparent_sig_digest || sapling_digest ||
+     * orchard_digest) Binding the transparent ECDSA sig to all four components
+     * ensures it cannot be replayed in a transaction with different
+     * Orchard/header data. */
+    uint8_t t_sig_digest[32] = {0};
+    uint8_t full_sighash[32] = {0};
+    uint8_t sig[64] = {0};
+    uint8_t der_sig[73] = {0};
+
+    bool sign_ok =
+        zcash_compute_transparent_sighash_digest(
+            inputs, zcash_signing.n_transparent_inputs, outputs,
+            zcash_signing.n_transparent_outputs, i, 0x01, t_sig_digest) &&
+        zcash_compute_shielded_sighash(zcash_signing.header_digest,
+                                       t_sig_digest, EMPTY_SAPLING_DIGEST,
+                                       zcash_signing.expected_orchard_digest,
+                                       zcash_signing.branch_id, full_sighash) &&
+        hdnode_sign_digest(node, full_sighash, sig, NULL, NULL) == 0;
+
+    memzero(node, sizeof(*node));
+    memzero(t_sig_digest, sizeof(t_sig_digest));
+    memzero(full_sighash, sizeof(full_sighash));
+
+    if (!sign_ok) {
+      memzero(sig, sizeof(sig));
+      goto cleanup;
+    }
+
+    int der_len = ecdsa_sig_to_der(sig, der_sig);
+    zcash_signing.pending_transparent.signatures[i].size = der_len;
+    memcpy(zcash_signing.pending_transparent.signatures[i].bytes, der_sig,
+           der_len);
+
+    memzero(sig, sizeof(sig));
+    memzero(der_sig, sizeof(der_sig));
+  }
+
+  zcash_signing.has_pending_transparent = true;
+  ok = true;
+
+cleanup:
+  memzero(inputs, sizeof(inputs));
+  memzero(outputs, sizeof(outputs));
+  return ok;
+}
+
+void fsm_msgZcashSignPCZT(const ZcashSignPCZT* msg) {
+  RESP_INIT(ZcashPCZTActionAck);
+
+  CHECK_INITIALIZED
+
+  CHECK_PIN
+
+  /* Validate parameters */
+  if (!msg->has_n_actions || msg->n_actions == 0) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError, _("No actions specified"));
+    layoutHome();
+    return;
+  }
+
+  if (msg->n_actions > ZCASH_MAX_ACTIONS) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Too many Orchard actions"));
+    layoutHome();
+    return;
+  }
+
+  /* Determine account — require explicit account or strict ZIP-32 path
+   * m/32'/133'/account' (all hardened, exactly 3 elements). Matches
+   * ZcashDisplayAddress / ZcashGetOrchardFVK and prevents a malformed
+   * host path from silently signing against an unintended account. */
+  uint32_t account;
+  if (msg->has_account) {
+    account = msg->account;
+  } else if (msg->address_n_count == 3 &&
+             msg->address_n[0] == (0x80000000 | 32) &&
+             msg->address_n[1] == (0x80000000 | 133) &&
+             (msg->address_n[2] & 0x80000000)) {
+    account = msg->address_n[2] & 0x7FFFFFFF;
+  } else {
+    fsm_sendFailure(
+        FailureType_Failure_SyntaxError,
+        _("Require account field or ZIP-32 path m/32'/133'/account'"));
+    layoutHome();
+    return;
+  }
+
+  uint32_t n_tinputs =
+      msg->has_n_transparent_inputs ? msg->n_transparent_inputs : 0;
+  if (n_tinputs > ZCASH_MAX_TRANSPARENT_INPUTS) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Too many transparent inputs"));
+    layoutHome();
+    return;
+  }
+
+  uint32_t n_toutputs =
+      msg->has_n_transparent_outputs ? msg->n_transparent_outputs : 0;
+  if (n_toutputs > ZCASH_MAX_TRANSPARENT_OUTPUTS) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Too many transparent outputs"));
+    layoutHome();
+    return;
+  }
+
+  uint32_t branch_id = msg->has_branch_id ? msg->branch_id : 0;
+
+  ZcashPCZTSigningRequestMeta signing_meta = {0};
+  signing_meta.has_header_digest = msg->has_header_digest;
+  signing_meta.header_digest_size = msg->header_digest.size;
+  signing_meta.has_transparent_digest = msg->has_transparent_digest;
+  signing_meta.transparent_digest_size = msg->transparent_digest.size;
+  signing_meta.has_sapling_digest = msg->has_sapling_digest;
+  signing_meta.sapling_digest_size = msg->sapling_digest.size;
+  signing_meta.has_orchard_digest = msg->has_orchard_digest;
+  signing_meta.orchard_digest_size = msg->orchard_digest.size;
+  signing_meta.has_orchard_flags = msg->has_orchard_flags;
+  signing_meta.orchard_flags = msg->orchard_flags;
+  signing_meta.has_orchard_value_balance = msg->has_orchard_value_balance;
+  signing_meta.has_orchard_anchor = msg->has_orchard_anchor;
+  signing_meta.orchard_anchor_size = msg->orchard_anchor.size;
+  signing_meta.has_header_fields =
+      msg->has_tx_version && msg->has_version_group_id && msg->has_branch_id &&
+      msg->has_lock_time && msg->has_expiry_height;
+  signing_meta.n_transparent_inputs = n_tinputs;
+  signing_meta.n_transparent_outputs = n_toutputs;
+
+  switch (zcash_pczt_signing_request_status(&signing_meta)) {
+    case ZCASH_PCZT_SIGNING_REQUEST_OK:
+      break;
+    case ZCASH_PCZT_SIGNING_REQUEST_MISSING_TX_DIGESTS:
+      fsm_sendFailure(FailureType_Failure_SyntaxError,
+                      _("Missing transaction digests"));
+      layoutHome();
+      return;
+    case ZCASH_PCZT_SIGNING_REQUEST_INVALID_DIGEST_SIZE:
+      fsm_sendFailure(FailureType_Failure_SyntaxError,
+                      _("Invalid transaction digest"));
+      layoutHome();
+      return;
+    case ZCASH_PCZT_SIGNING_REQUEST_MISSING_HEADER_FIELDS:
+      fsm_sendFailure(FailureType_Failure_SyntaxError,
+                      _("Missing transaction header"));
+      layoutHome();
+      return;
+    case ZCASH_PCZT_SIGNING_REQUEST_UNSUPPORTED_SAPLING_COMPONENT:
+      fsm_sendFailure(FailureType_Failure_SyntaxError,
+                      _("Sapling not supported"));
+      layoutHome();
+      return;
+    case ZCASH_PCZT_SIGNING_REQUEST_MISSING_TRANSPARENT_DIGEST:
+      fsm_sendFailure(FailureType_Failure_SyntaxError,
+                      _("Missing transparent digest"));
+      layoutHome();
+      return;
+    case ZCASH_PCZT_SIGNING_REQUEST_MISSING_ORCHARD_METADATA:
+    default:
+      fsm_sendFailure(FailureType_Failure_SyntaxError,
+                      _("Missing Orchard metadata"));
+      layoutHome();
+      return;
+  }
+
+  uint8_t header_digest[32];
+  if (!zcash_compute_header_digest(msg->tx_version, msg->version_group_id,
+                                   branch_id, msg->lock_time,
+                                   msg->expiry_height, header_digest) ||
+      memcmp(header_digest, msg->header_digest.bytes, 32) != 0) {
+    fsm_sendFailure(FailureType_Failure_Other, _("Header digest mismatch"));
+    layoutHome();
+    return;
+  }
+
+  /* Confirm with user */
+  char amount_str[32];
+  char fee_str[32];
+  uint64_t total = msg->has_total_amount ? msg->total_amount : 0;
+  uint64_t fee = msg->has_fee ? msg->fee : 0;
+
+  /* Format amounts (1 ZEC = 100,000,000 zatoshis) */
+  zcash_format_amount(total, amount_str, sizeof(amount_str));
+  zcash_format_amount(fee, fee_str, sizeof(fee_str));
+
+  /* Display confirmation — different text for shielded-only vs hybrid */
+  if (n_tinputs > 0) {
+    if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Zcash Shield",
+                 "Shield transparent ZEC to Orchard?\n"
+                 "Amount: %s\nFee: %s\nInputs: %lu\nOutputs: %lu\nActions: %lu",
+                 amount_str, fee_str, (unsigned long)n_tinputs,
+                 (unsigned long)n_toutputs, (unsigned long)msg->n_actions)) {
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      _("Signing cancelled"));
+      layoutHome();
+      return;
+    }
+  } else if (n_toutputs > 0) {
+    if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Zcash Shielded",
+                 "Sign transaction with transparent outputs?\n"
+                 "Amount: %s\nFee: %s\nOutputs: %lu\nActions: %lu",
+                 amount_str, fee_str, (unsigned long)n_toutputs,
+                 (unsigned long)msg->n_actions)) {
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      _("Signing cancelled"));
+      layoutHome();
+      return;
+    }
+  } else {
+    if (!confirm(ButtonRequestType_ButtonRequest_SignTx, "Zcash Shielded",
+                 "Sign shielded transaction?\n"
+                 "Amount: %s\nFee: %s\nActions: %lu",
+                 amount_str, fee_str, (unsigned long)msg->n_actions)) {
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      _("Signing cancelled"));
+      layoutHome();
+      return;
+    }
+  }
+
+  /* Optional seed_fingerprint binding (ZIP-32 §6.1).
+   * If host asserts a seed identity, verify it matches before signing.
+   * Catches "wrong device" attacks where the host accidentally targets
+   * a different seed than the one it built the PCZT against. */
+  if (msg->has_expected_seed_fingerprint &&
+      msg->expected_seed_fingerprint.size == 32) {
+    uint8_t actual_fp[32];
+    if (!storage_zcashSeedFingerprint(true, actual_fp)) {
+      fsm_sendFailure(FailureType_Failure_NotInitialized,
+                      _("Device not initialized or seed unavailable"));
+      layoutHome();
+      return;
+    }
+    bool match =
+        memcmp(actual_fp, msg->expected_seed_fingerprint.bytes, 32) == 0;
+    memzero(actual_fp, sizeof(actual_fp));
+    if (!match) {
+      fsm_sendFailure(FailureType_Failure_Other,
+                      _("Seed fingerprint mismatch — wrong device"));
+      layoutHome();
+      return;
+    }
+  }
+
+  /* Derive Orchard keys via storage; the seed never leaves storage.c. */
+  if (!storage_zcashOrchardKeys(account, true, &zcash_signing.keys)) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("Orchard key derivation failed"));
+    layoutHome();
+    return;
+  }
+
+  /* Initialize signing state */
+  zcash_signing.active = true;
+  zcash_signing.account = account;
+  zcash_signing.n_actions = msg->n_actions;
+  zcash_signing.current_action = 0;
+  zcash_signing.total_amount = total;
+  zcash_signing.fee = fee;
+  zcash_signing.branch_id = branch_id;
+  memcpy(zcash_signing.header_digest, header_digest, 32);
+  zcash_signing.has_device_sighash = false;
+  zcash_signing.verify_orchard_digest = false;
+  zcash_signing.n_transparent_outputs =
+      msg->has_n_transparent_outputs ? msg->n_transparent_outputs : 0;
+  zcash_signing.current_transparent_output = 0;
+  zcash_signing.n_transparent_inputs =
+      msg->has_n_transparent_inputs ? msg->n_transparent_inputs : 0;
+  zcash_signing.current_transparent_input = 0;
+  zcash_signing.has_expected_transparent_digest = false;
+  zcash_signing.transparent_digest_verified = false;
+
+  /* Phase 2a: Compute sighash on-device from validated sub-digests.
+   *
+   * TRUST MODEL:
+   *
+   * What the device verifies:
+   *   - Orchard digest: recomputed from streamed action data (Phase 2b)
+   *     covering nullifiers, commitments, ephemeral keys, ciphertexts,
+   *     value commitments, randomized keys, flags, value balance, anchor.
+   *   - Orchard outputs: each displayed receiver/value is bound to cmx by
+   *     recomputing the note commitment from recipient/value/rseed/rho before
+   *     any authorization signature is emitted.
+   *   - Transaction fee: computed from streamed transparent totals plus
+   *     orchard_value_balance and compared to the requested fee before final
+   *     user confirmation.
+   *   - Sighash: assembled on-device from the 4 sub-digests.
+   *   - transparent_digest: recomputed from streamed transparent outputs and
+   *     inputs before any transparent or Orchard signature is emitted.
+   *   - header_digest: recomputed from plaintext transaction header fields
+   *     and compared to the supplied component digest.
+   *   - Sapling: explicitly unsupported in this signing path. The device
+   *     always uses the ZIP-244 empty Sapling digest and rejects any
+   *     host-provided Sapling component.
+   *
+   * total_amount is a summary prompt. Transparent recipients, Orchard output
+   * recipients, Orchard output values, and the transaction fee all have their
+   * own verification gates before signatures are released.
+   *
+   * For shielded-only transactions (no transparent inputs):
+   *   transparent_digest defaults to the well-known empty hash,
+   *   so no trust assumption is needed for that component.
+   *
+   * For mixed transactions:
+   *   transparent_digest is mandatory and verified against plaintext
+   *   transparent metadata before local sighash derivation. */
+  uint8_t t_digest[32], s_digest[32];
+
+  if (n_tinputs == 0 && n_toutputs == 0) {
+    memcpy(t_digest, EMPTY_TRANSPARENT_DIGEST, 32);
+    memcpy(s_digest, EMPTY_SAPLING_DIGEST, 32);
+
+    zcash_compute_shielded_sighash(
+        header_digest, t_digest, s_digest, msg->orchard_digest.bytes,
+        zcash_signing.branch_id, zcash_signing.sighash);
+    zcash_signing.has_device_sighash = true;
+    zcash_signing.transparent_digest_verified = true;
+  } else {
+    memcpy(zcash_signing.expected_transparent_digest,
+           msg->transparent_digest.bytes, 32);
+    zcash_signing.has_expected_transparent_digest = true;
+  }
+  memzero(t_digest, sizeof(t_digest));
+  memzero(s_digest, sizeof(s_digest));
+
+  /* Phase 2b: Orchard digest verification is mandatory for signing.
+   * The device incrementally hashes each action's data and verifies the
+   * computed orchard_digest matches the one used for sighash. */
+  memcpy(zcash_signing.expected_orchard_digest, msg->orchard_digest.bytes, 32);
+  zcash_signing.orchard_flags = (uint8_t)msg->orchard_flags;
+  zcash_signing.orchard_value_balance = msg->orchard_value_balance;
+  memcpy(zcash_signing.orchard_anchor, msg->orchard_anchor.bytes, 32);
+
+  blake2b_InitPersonal(&zcash_signing.compact_ctx, 32, "ZTxIdOrcActCHash", 16);
+  blake2b_InitPersonal(&zcash_signing.memos_ctx, 32, "ZTxIdOrcActMHash", 16);
+  blake2b_InitPersonal(&zcash_signing.noncompact_ctx, 32, "ZTxIdOrcActNHash",
+                       16);
+  zcash_signing.verify_orchard_digest = true;
+
+  /* Request the first plaintext component. Transparent outputs are reviewed
+   * before any transparent input or Orchard signature can be emitted. */
+  if (zcash_signing.n_transparent_outputs > 0) {
+    zcash_send_transparent_output_ack(0);
+  } else if (zcash_signing.n_transparent_inputs > 0) {
+    zcash_send_transparent_input_ack(0);
+  } else {
+    zcash_send_action_ack(0);
+  }
+  layoutProgress(_("Signing Zcash"), 0);
+}
+
+void fsm_msgZcashGetOrchardFVK(const ZcashGetOrchardFVK* msg) {
+  RESP_INIT(ZcashOrchardFVK);
+
+  CHECK_INITIALIZED
+
+  CHECK_PIN
+
+  /* Determine account — require explicit account or strict ZIP-32 path
+   * m/32'/133'/account' (all hardened, exactly 3 elements). Matches
+   * ZcashDisplayAddress / ZcashSignPCZT and prevents a malformed host
+   * path from silently exporting an FVK for an unintended account. */
+  uint32_t account;
+  if (msg->has_account) {
+    account = msg->account;
+  } else if (msg->address_n_count == 3 &&
+             msg->address_n[0] == (0x80000000 | 32) &&
+             msg->address_n[1] == (0x80000000 | 133) &&
+             (msg->address_n[2] & 0x80000000)) {
+    account = msg->address_n[2] & 0x7FFFFFFF;
+  } else {
+    fsm_sendFailure(
+        FailureType_Failure_SyntaxError,
+        _("Require account field or ZIP-32 path m/32'/133'/account'"));
+    layoutHome();
+    return;
+  }
+
+  /* Derive Orchard keys via storage; the seed never leaves storage.c. */
+  layoutProgress(_("Deriving Zcash"), 0);
+  ZcashOrchardKeys keys;
+  if (!storage_zcashOrchardKeys(account, true, &keys)) {
+    fsm_sendFailure(FailureType_Failure_NotInitialized,
+                    _("Orchard key derivation failed (seed unavailable?)"));
+    layoutHome();
+    return;
+  }
+
+  /* Compute ak = [ask]G_spendauth on Pallas curve (SpendAuth basepoint) */
+  bignum256 ask_scalar;
+  bn_read_le(keys.ask, &ask_scalar);
+  curve_point ak_point;
+  redpallas_scalar_mult_spendauth_G(&ask_scalar, &ak_point);
+
+  /* Serialize ak as Pallas point (LE x-coord, sign bit in high byte) */
+  uint8_t ak_bytes[32];
+  bignum256 x_copy;
+  bn_copy(&ak_point.x, &x_copy);
+  bn_write_le(&x_copy, ak_bytes);
+  if (bn_is_odd(&ak_point.y)) {
+    ak_bytes[31] |= 0x80;
+  }
+
+  /* Build response */
+  resp->has_ak = true;
+  resp->ak.size = 32;
+  memcpy(resp->ak.bytes, ak_bytes, 32);
+
+  resp->has_nk = true;
+  resp->nk.size = 32;
+  memcpy(resp->nk.bytes, keys.nk, 32);
+
+  resp->has_rivk = true;
+  resp->rivk.size = 32;
+  memcpy(resp->rivk.bytes, keys.rivk, 32);
+
+  /* Seed identity (ZIP-32 §6.1). Lets the host pin this FVK to a
+   * specific device-seed identity for later signing/display flows. */
+  uint8_t fp[32];
+  if (storage_zcashSeedFingerprint(true, fp)) {
+    resp->has_seed_fingerprint = true;
+    resp->seed_fingerprint.size = 32;
+    memcpy(resp->seed_fingerprint.bytes, fp, 32);
+    memzero(fp, sizeof(fp));
+  }
+
+  /* Clean up sensitive data */
+  memzero(&ask_scalar, sizeof(ask_scalar));
+  memzero(&keys, sizeof(keys));
+
+  msg_write(MessageType_MessageType_ZcashOrchardFVK, resp);
+  layoutHome();
+}
+
+void fsm_msgZcashDisplayAddress(const ZcashDisplayAddress* msg) {
+  RESP_INIT(ZcashAddress);
+
+  CHECK_INITIALIZED
+
+  CHECK_PIN
+
+  /* Determine account — require explicit account or valid ZIP-32 path.
+   * When using address_n, enforce the expected Orchard path shape:
+   *   m/32'/133'/account'  (all hardened)
+   * This matches the derivation used in ZcashGetOrchardFVK and
+   * ZcashSignPCZT, and prevents a malformed path from silently
+   * deriving against an unintended account. */
+  uint32_t account;
+  if (msg->has_account) {
+    account = msg->account;
+  } else if (msg->address_n_count == 3 &&
+             msg->address_n[0] == (0x80000000 | 32) &&
+             msg->address_n[1] == (0x80000000 | 133) &&
+             (msg->address_n[2] & 0x80000000)) {
+    account = msg->address_n[2] & 0x7FFFFFFF;
+  } else {
+    fsm_sendFailure(
+        FailureType_Failure_SyntaxError,
+        _("Require account field or ZIP-32 path m/32'/133'/account'"));
+    layoutHome();
+    return;
+  }
+
+  /* Optional seed_fingerprint binding (ZIP-32 §6.1).
+   * Reject before any derivation if the host targets the wrong seed. */
+  if (msg->has_expected_seed_fingerprint &&
+      msg->expected_seed_fingerprint.size == 32) {
+    uint8_t actual_fp[32];
+    if (!storage_zcashSeedFingerprint(true, actual_fp)) {
+      fsm_sendFailure(FailureType_Failure_NotInitialized,
+                      _("Device not initialized or seed unavailable"));
+      layoutHome();
+      return;
+    }
+    bool match =
+        memcmp(actual_fp, msg->expected_seed_fingerprint.bytes, 32) == 0;
+    memzero(actual_fp, sizeof(actual_fp));
+    if (!match) {
+      fsm_sendFailure(FailureType_Failure_Other,
+                      _("Seed fingerprint mismatch — wrong device"));
+      layoutHome();
+      return;
+    }
+  }
+
+  /* Derive Orchard keys via storage; the seed never leaves storage.c. */
+  layoutProgress(_("Deriving Zcash"), 0);
+  ZcashOrchardKeys keys;
+  if (!storage_zcashOrchardKeys(account, true, &keys)) {
+    fsm_sendFailure(FailureType_Failure_NotInitialized,
+                    _("Orchard key derivation failed (seed unavailable?)"));
+    layoutHome();
+    return;
+  }
+
+  layoutProgress(_("Deriving address"), 650);
+  char derived_address[sizeof(resp->address)];
+  const uint8_t default_receiver_index[11] = {0};
+  if (!zcash_orchard_derive_unified_address(&keys, default_receiver_index, "u",
+                                            derived_address,
+                                            sizeof(derived_address))) {
+    memzero(&keys, sizeof(keys));
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("Orchard address derivation failed"));
+    layoutHome();
+    return;
+  }
+
+  /* Clean up sensitive key material BEFORE display prompt. */
+  memzero(&keys, sizeof(keys));
+
+  layoutProgress(_("Loading address"), 1000);
+
+  char desc[48];
+  snprintf(desc, sizeof(desc), "Zcash #%lu Orchard", (unsigned long)account);
+  if (!confirm_zcash_address(desc, derived_address)) {
+    fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                    _("Address display cancelled"));
+    layoutHome();
+    return;
+  }
+
+  /* User confirmed — return the address bound to this device's seed. */
+  resp->has_address = true;
+  strlcpy(resp->address, derived_address, sizeof(resp->address));
+
+  /* Seed identity (ZIP-32 §6.1) — pin the attestation to this device. */
+  uint8_t fp[32];
+  if (storage_zcashSeedFingerprint(true, fp)) {
+    resp->has_seed_fingerprint = true;
+    resp->seed_fingerprint.size = 32;
+    memcpy(resp->seed_fingerprint.bytes, fp, 32);
+    memzero(fp, sizeof(fp));
+  }
+
+  msg_write(MessageType_MessageType_ZcashAddress, resp);
+  layoutHome();
+}
+
+void fsm_msgZcashPCZTAction(const ZcashPCZTAction* msg) {
+  if (!zcash_signing.active) {
+    fsm_sendFailure(FailureType_Failure_UnexpectedMessage,
+                    _("Not in Zcash signing mode"));
+    layoutHome();
+    return;
+  }
+
+  /* Enforce transparent phase completion: if the session declared any
+   * transparent data, all plaintext must be streamed and verified before
+   * Orchard actions.
+   * This prevents a malicious host from skipping transparent-input
+   * confirmations and jumping straight to Orchard signing. */
+  if (zcash_signing.current_transparent_output <
+          zcash_signing.n_transparent_outputs ||
+      zcash_signing.current_transparent_input <
+          zcash_signing.n_transparent_inputs ||
+      ((zcash_signing.n_transparent_outputs > 0 ||
+        zcash_signing.n_transparent_inputs > 0) &&
+       !zcash_signing.transparent_digest_verified)) {
+    fsm_sendFailure(FailureType_Failure_UnexpectedMessage,
+                    _("Transparent data not yet complete"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  /* Validate action index */
+  if (!msg->has_index || msg->index != zcash_signing.current_action) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Unexpected action index"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  /* Validate required fields */
+  if (!msg->has_alpha || msg->alpha.size != 32) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Missing or invalid alpha randomizer"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  /* Phase 2a: a device-computed sighash is mandatory. */
+  if (!zcash_signing.has_device_sighash) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Missing transaction digests"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  const bool has_orchard_action_data =
+      zcash_signing.verify_orchard_digest && msg->has_nullifier &&
+      msg->nullifier.size == 32 && msg->has_cmx && msg->cmx.size == 32 &&
+      msg->has_epk && msg->epk.size == 32 && msg->has_enc_compact &&
+      msg->enc_compact.size == 52 && msg->has_enc_memo &&
+      msg->enc_memo.size == 512 && msg->has_enc_noncompact &&
+      msg->enc_noncompact.size > 0 && msg->has_cv_net &&
+      msg->cv_net.size == 32 && msg->has_rk && msg->rk.size == 32 &&
+      msg->has_out_ciphertext && msg->out_ciphertext.size == 80;
+
+  if (!has_orchard_action_data) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Missing Orchard action data"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  if (!zcash_verify_and_confirm_orchard_output(msg)) {
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  /* Phase 2b: feed action data into incremental BLAKE2b contexts */
+  blake2b_Update(&zcash_signing.compact_ctx, msg->nullifier.bytes, 32);
+  blake2b_Update(&zcash_signing.compact_ctx, msg->cmx.bytes, 32);
+  blake2b_Update(&zcash_signing.compact_ctx, msg->epk.bytes, 32);
+  blake2b_Update(&zcash_signing.compact_ctx, msg->enc_compact.bytes, 52);
+
+  blake2b_Update(&zcash_signing.memos_ctx, msg->enc_memo.bytes, 512);
+
+  blake2b_Update(&zcash_signing.noncompact_ctx, msg->cv_net.bytes, 32);
+  blake2b_Update(&zcash_signing.noncompact_ctx, msg->rk.bytes, 32);
+  blake2b_Update(&zcash_signing.noncompact_ctx, msg->enc_noncompact.bytes,
+                 msg->enc_noncompact.size);
+  blake2b_Update(&zcash_signing.noncompact_ctx, msg->out_ciphertext.bytes, 80);
+
+  const uint8_t* sighash = zcash_signing.sighash;
+
+  /* Sign this action with RedPallas:
+   * sig = RedPallas.sign(ask, alpha, sighash) */
+  if (redpallas_sign_digest(zcash_signing.keys.ask, msg->alpha.bytes, sighash,
+                            zcash_signing.signatures[msg->index]) != 0) {
+    fsm_sendFailure(FailureType_Failure_Other, _("RedPallas signing failed"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  zcash_signing.current_action++;
+
+  /* Update progress */
+  uint32_t progress =
+      (zcash_signing.current_action * 1000) / zcash_signing.n_actions;
+  layoutProgress(_("Signing Zcash"), progress);
+
+  /* Check if all actions are signed */
+  if (zcash_signing.current_action >= zcash_signing.n_actions) {
+    /* Phase 2b: verify orchard digest before returning signatures */
+    if (zcash_signing.verify_orchard_digest) {
+      uint8_t compact_hash[32], memos_hash[32], noncompact_hash[32];
+
+      blake2b_Final(&zcash_signing.compact_ctx, compact_hash, 32);
+      blake2b_Final(&zcash_signing.memos_ctx, memos_hash, 32);
+      blake2b_Final(&zcash_signing.noncompact_ctx, noncompact_hash, 32);
+
+      /* Compute orchard_digest = BLAKE2b("ZTxIdOrchardHash",
+       *   compact_hash || memos_hash || noncompact_hash ||
+       *   flags(1) || value_balance(8) || anchor(32)) */
+      BLAKE2B_CTX orchard_ctx;
+      blake2b_InitPersonal(&orchard_ctx, 32, "ZTxIdOrchardHash", 16);
+      blake2b_Update(&orchard_ctx, compact_hash, 32);
+      blake2b_Update(&orchard_ctx, memos_hash, 32);
+      blake2b_Update(&orchard_ctx, noncompact_hash, 32);
+      blake2b_Update(&orchard_ctx, &zcash_signing.orchard_flags, 1);
+      blake2b_Update(&orchard_ctx,
+                     (const uint8_t*)&zcash_signing.orchard_value_balance, 8);
+      blake2b_Update(&orchard_ctx, zcash_signing.orchard_anchor, 32);
+
+      uint8_t computed_orchard_digest[32];
+      blake2b_Final(&orchard_ctx, computed_orchard_digest, 32);
+
+      /* Verify computed matches expected */
+      if (memcmp(computed_orchard_digest, zcash_signing.expected_orchard_digest,
+                 32) != 0) {
+        fsm_sendFailure(FailureType_Failure_Other,
+                        _("Orchard digest mismatch: transaction data "
+                          "does not match sighash"));
+        zcash_signing_abort();
+        memzero(zcash_signing.signatures, sizeof(zcash_signing.signatures));
+        layoutHome();
+        return;
+      }
+    }
+
+    if (!zcash_verify_and_confirm_fee()) {
+      zcash_signing_abort();
+      memzero(zcash_signing.signatures, sizeof(zcash_signing.signatures));
+      layoutHome();
+      return;
+    }
+
+    /* Release deferred transparent ECDSA sigs at the same gate as Orchard sigs
+     * — both are sent only after Orchard digest verification and fee
+     * confirmation. */
+    if (zcash_signing.has_pending_transparent) {
+      ZcashTransparentSigned* t_resp = (ZcashTransparentSigned*)msg_resp;
+      memcpy(t_resp, &zcash_signing.pending_transparent,
+             sizeof(ZcashTransparentSigned));
+      msg_write(MessageType_MessageType_ZcashTransparentSigned, t_resp);
+    }
+
+    /* All done - send the collected Orchard signatures */
+    ZcashSignedPCZT* resp_signed = (ZcashSignedPCZT*)msg_resp;
+    memset(resp_signed, 0, sizeof(ZcashSignedPCZT));
+
+    resp_signed->signatures_count = zcash_signing.n_actions;
+    for (uint32_t i = 0; i < zcash_signing.n_actions; i++) {
+      resp_signed->signatures[i].size = 64;
+      memcpy(resp_signed->signatures[i].bytes, zcash_signing.signatures[i], 64);
+    }
+
+    /* Clean up */
+    zcash_signing_abort();
+    memzero(zcash_signing.signatures, sizeof(zcash_signing.signatures));
+
+    msg_write(MessageType_MessageType_ZcashSignedPCZT, resp_signed);
+    layoutHome();
+  } else {
+    /* Request next action */
+    zcash_send_action_ack(zcash_signing.current_action);
+  }
+}
+
+void fsm_msgZcashTransparentOutput(const ZcashTransparentOutput* msg) {
+  if (!zcash_signing.active) {
+    fsm_sendFailure(FailureType_Failure_UnexpectedMessage,
+                    _("Not in Zcash signing mode"));
+    layoutHome();
+    return;
+  }
+
+  if (zcash_signing.n_transparent_outputs == 0) {
+    fsm_sendFailure(FailureType_Failure_UnexpectedMessage,
+                    _("No transparent outputs expected"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  if (zcash_signing.current_transparent_input != 0) {
+    fsm_sendFailure(FailureType_Failure_UnexpectedMessage,
+                    _("Transparent outputs must come first"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  if (msg->index != zcash_signing.current_transparent_output) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Unexpected transparent output index"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  if (!msg->has_amount || !msg->has_script_pubkey ||
+      msg->script_pubkey.size == 0 ||
+      msg->script_pubkey.size > ZCASH_MAX_TRANSPARENT_SCRIPT_PUBKEY) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Invalid transparent output script"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  char address[64];
+  if (!zcash_transparent_script_to_address(msg->script_pubkey.bytes,
+                                           msg->script_pubkey.size, address,
+                                           sizeof(address))) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Unsupported transparent output script"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  char amount_str[32];
+  zcash_format_amount(msg->amount, amount_str, sizeof(amount_str));
+  if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, "Zcash Output",
+               "Send transparent ZEC?\n%s\nAmount: %s", address, amount_str)) {
+    fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                    _("Signing cancelled"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  ZcashTransparentOutputState* stored =
+      &zcash_signing.transparent_outputs[msg->index];
+  stored->received = true;
+  stored->amount = msg->amount;
+  stored->script_pubkey_size = msg->script_pubkey.size;
+  memcpy(stored->script_pubkey, msg->script_pubkey.bytes,
+         msg->script_pubkey.size);
+
+  zcash_signing.current_transparent_output++;
+
+  if (zcash_signing.current_transparent_output <
+      zcash_signing.n_transparent_outputs) {
+    zcash_send_transparent_output_ack(zcash_signing.current_transparent_output);
+  } else if (zcash_signing.n_transparent_inputs > 0) {
+    zcash_send_transparent_input_ack(0);
+  } else {
+    if (!zcash_finalize_transparent_digest()) {
+      fsm_sendFailure(FailureType_Failure_Other,
+                      _("Transparent digest mismatch"));
+      zcash_signing_abort();
+      layoutHome();
+      return;
+    }
+    zcash_send_action_ack(0);
+  }
+
+  layoutProgress(_("Signing Zcash"), 0);
+}
+
+/* Phase 3: Transparent plaintext streaming for hybrid shielding
+ * transactions. The host streams all outputs first, then all inputs. Only after
+ * the firmware verifies transparent_digest from the streamed plaintext does it
+ * derive per-input ZIP-244 sighashes and emit ECDSA signatures. */
+void fsm_msgZcashTransparentInput(const ZcashTransparentInput* msg) {
+  if (!zcash_signing.active) {
+    fsm_sendFailure(FailureType_Failure_UnexpectedMessage,
+                    _("Not in Zcash signing mode"));
+    layoutHome();
+    return;
+  }
+
+  if (zcash_signing.n_transparent_inputs == 0) {
+    fsm_sendFailure(FailureType_Failure_UnexpectedMessage,
+                    _("No transparent inputs expected"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  if (zcash_signing.current_transparent_output <
+      zcash_signing.n_transparent_outputs) {
+    fsm_sendFailure(FailureType_Failure_UnexpectedMessage,
+                    _("Transparent outputs not yet complete"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  if (msg->index != zcash_signing.current_transparent_input) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Unexpected transparent input index"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  if (msg->has_sighash) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Host transparent sighash rejected"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  if (!msg->has_amount || !msg->has_prevout_txid ||
+      msg->prevout_txid.size != 32 || !msg->has_prevout_index ||
+      !msg->has_sequence || !msg->has_script_pubkey ||
+      msg->script_pubkey.size == 0 ||
+      msg->script_pubkey.size > ZCASH_MAX_TRANSPARENT_SCRIPT_PUBKEY) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Invalid transparent input data"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  if (!zcash_script_is_standard_transparent(msg->script_pubkey.bytes,
+                                            msg->script_pubkey.size)) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Unsupported transparent input script"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  /* PATH ENFORCEMENT: transparent inputs must use exactly
+   * m/44'/133'/account'/change/index where:
+   *   - account' is hardened and matches the session account
+   *   - change is 0 (external) or 1 (internal)
+   *   - index is unhardened
+   *
+   * This prevents a compromised host from pivoting a shielding approval
+   * into signing with arbitrary secp256k1 keys on the device. */
+  if (msg->address_n_count != 5) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Path must be m/44'/133'/account'/change/index"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  if (msg->address_n[0] != (0x80000000 | 44) ||
+      msg->address_n[1] != (0x80000000 | 133)) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Path must start with m/44'/133'"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  /* Account must be hardened and match the approved session */
+  if (!(msg->address_n[2] & 0x80000000)) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Account must be hardened"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  uint32_t path_account = msg->address_n[2] & 0x7FFFFFFF;
+  if (path_account != zcash_signing.account) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Account does not match approved session"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  /* Change must be 0 (external) or 1 (internal), unhardened */
+  if (msg->address_n[3] > 1) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Change must be 0 or 1"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  /* Index must be unhardened */
+  if (msg->address_n[4] & 0x80000000) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    _("Index must not be hardened"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  ZcashTransparentInputState* stored =
+      &zcash_signing.transparent_inputs[msg->index];
+  stored->received = true;
+  stored->amount = msg->amount;
+  memcpy(stored->prevout_txid, msg->prevout_txid.bytes, 32);
+  stored->prevout_index = msg->prevout_index;
+  stored->sequence = msg->sequence;
+  stored->script_pubkey_size = msg->script_pubkey.size;
+  memcpy(stored->script_pubkey, msg->script_pubkey.bytes,
+         msg->script_pubkey.size);
+  stored->address_n_count = msg->address_n_count;
+  memcpy(stored->address_n, msg->address_n,
+         msg->address_n_count * sizeof(msg->address_n[0]));
+
+  zcash_signing.current_transparent_input++;
+
+  if (zcash_signing.current_transparent_input <
+      zcash_signing.n_transparent_inputs) {
+    zcash_send_transparent_input_ack(zcash_signing.current_transparent_input);
+    layoutProgress(_("Signing Zcash"), 0);
+    return;
+  }
+
+  if (!zcash_finalize_transparent_digest()) {
+    fsm_sendFailure(FailureType_Failure_Other,
+                    _("Transparent digest mismatch"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  bool cancelled = false;
+  if (!zcash_sign_transparent_inputs(&cancelled)) {
+    fsm_sendFailure(cancelled ? FailureType_Failure_ActionCancelled
+                              : FailureType_Failure_Other,
+                    cancelled ? _("Signing cancelled")
+                              : _("Transparent input signing failed"));
+    zcash_signing_abort();
+    layoutHome();
+    return;
+  }
+
+  /* Transparent ECDSA sigs are buffered in zcash_signing.pending_transparent.
+   * They are released at the same final gate as Orchard sigs, after Orchard
+   * digest verification and fee confirmation. */
+  zcash_send_action_ack(0);
+  layoutProgress(_("Signing Zcash"), 0);
+}

--- a/lib/firmware/fsm_msg_zcash.h
+++ b/lib/firmware/fsm_msg_zcash.h
@@ -87,8 +87,8 @@ static struct {
   uint8_t orchard_flags;
   int64_t orchard_value_balance;
   uint8_t orchard_anchor[32];
-  /* Signatures buffer: up to 16 actions (64 bytes each) */
-  uint8_t signatures[16][64];
+  /* Signatures buffer: one 64-byte sig per action */
+  uint8_t signatures[ZCASH_MAX_ACTIONS][64];
   /* Phase 3: transparent shielding state */
   bool has_expected_transparent_digest;
   uint8_t expected_transparent_digest[32];
@@ -633,6 +633,11 @@ void fsm_msgZcashSignPCZT(const ZcashSignPCZT* msg) {
       return;
     }
   }
+
+  /* Clear any stale state from a prior (possibly abandoned) session before
+   * starting a new one, so buffered transparent signatures or Orchard state
+   * from an earlier PCZT can never leak into this transaction. */
+  zcash_signing_abort();
 
   /* Derive Orchard keys via storage; the seed never leaves storage.c. */
   if (!storage_zcashOrchardKeys(account, true, &zcash_signing.keys)) {

--- a/lib/firmware/hive.c
+++ b/lib/firmware/hive.c
@@ -1,0 +1,426 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2026 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "keepkey/firmware/hive.h"
+
+#include "trezor/crypto/base58.h"
+#include "trezor/crypto/memzero.h"
+#include "trezor/crypto/secp256k1.h"
+#include "trezor/crypto/sha2.h"
+
+#include <string.h>
+#include <stdint.h>
+
+// ── STM public key encoding ───────────────────────────────────────────────
+
+bool hive_getPublicKey(const uint8_t public_key[33], char* out,
+                       size_t out_len) {
+  const size_t prefix_len = strlen(HIVE_PUBKEY_PREFIX);
+  if (out_len < prefix_len + 1) return false;
+  strlcpy(out, HIVE_PUBKEY_PREFIX, out_len);
+  // Graphene uses RIPEMD checksum (not SHA256d) for public key encoding
+  return base58_encode_check(public_key, 33, HASHER_RIPEMD, out + prefix_len,
+                             out_len - prefix_len);
+}
+
+// ── Single-role key derivation to raw 33 bytes ────────────────────────────
+// Path: m/48'/13'/role_hardened/account_index_hardened/0'
+// hdnode_private_ckd() returns 1 on success, 0 on failure.
+
+bool hive_deriveRawKey(const HDNode* root, uint32_t role_hardened,
+                       uint32_t account_index_hardened, uint8_t out[33]) {
+  HDNode node;
+  memcpy(&node, root, sizeof(HDNode));
+  if (!hdnode_private_ckd(&node, HIVE_SLIP48_PURPOSE)) goto fail;
+  if (!hdnode_private_ckd(&node, HIVE_SLIP48_NETWORK)) goto fail;
+  if (!hdnode_private_ckd(&node, role_hardened)) goto fail;
+  if (!hdnode_private_ckd(&node, account_index_hardened)) goto fail;
+  if (!hdnode_private_ckd(&node, 0x80000000u)) goto fail;
+  hdnode_fill_public_key(&node);
+  memcpy(out, node.public_key, 33);
+  memzero(&node, sizeof(node));
+  return true;
+fail:
+  memzero(&node, sizeof(node));
+  return false;
+}
+
+// ── SLIP-0048 multi-role key derivation ───────────────────────────────────
+
+bool hive_getPublicKeys(const HDNode* root, uint32_t account_index,
+                        char* owner_out, size_t owner_len, char* active_out,
+                        size_t active_len, char* memo_out, size_t memo_len,
+                        char* posting_out, size_t posting_len) {
+  const uint32_t roles[4] = {
+      HIVE_ROLE_OWNER,
+      HIVE_ROLE_ACTIVE,
+      HIVE_ROLE_MEMO,
+      HIVE_ROLE_POSTING,
+  };
+  char* outs[4] = {owner_out, active_out, memo_out, posting_out};
+  const size_t lens[4] = {owner_len, active_len, memo_len, posting_len};
+
+  uint32_t account_hardened = account_index | 0x80000000u;
+
+  for (int i = 0; i < 4; i++) {
+    uint8_t raw[33];
+    if (!hive_deriveRawKey(root, roles[i], account_hardened, raw)) return false;
+    if (!hive_getPublicKey(raw, outs[i], lens[i])) {
+      memzero(raw, sizeof(raw));
+      return false;
+    }
+    memzero(raw, sizeof(raw));
+  }
+  return true;
+}
+
+// ── Graphene binary serialization helpers ─────────────────────────────────
+
+static void append_u8(uint8_t** buf, const uint8_t* end, uint8_t v) {
+  if (*buf < end) {
+    **buf = v;
+    (*buf)++;
+  }
+}
+
+static void append_u16_le(uint8_t** buf, const uint8_t* end, uint16_t v) {
+  append_u8(buf, end, v & 0xFF);
+  append_u8(buf, end, (v >> 8) & 0xFF);
+}
+
+static void append_u32_le(uint8_t** buf, const uint8_t* end, uint32_t v) {
+  append_u8(buf, end, v & 0xFF);
+  append_u8(buf, end, (v >> 8) & 0xFF);
+  append_u8(buf, end, (v >> 16) & 0xFF);
+  append_u8(buf, end, (v >> 24) & 0xFF);
+}
+
+static void append_u64_le(uint8_t** buf, const uint8_t* end, uint64_t v) {
+  for (int i = 0; i < 8; i++) {
+    append_u8(buf, end, v & 0xFF);
+    v >>= 8;
+  }
+}
+
+static void append_varint(uint8_t** buf, const uint8_t* end, uint64_t v) {
+  do {
+    uint8_t b = v & 0x7F;
+    v >>= 7;
+    if (v) b |= 0x80;
+    append_u8(buf, end, b);
+  } while (v);
+}
+
+static void append_string(uint8_t** buf, const uint8_t* end, const char* s) {
+  size_t len = s ? strlen(s) : 0;
+  append_varint(buf, end, len);
+  for (size_t i = 0; i < len && *buf < end; i++)
+    append_u8(buf, end, (uint8_t)s[i]);
+}
+
+/*
+ * Graphene asset encoding: int64 LE amount + uint8 precision + 7-byte symbol
+ */
+static void append_asset(uint8_t** buf, const uint8_t* end, uint64_t amount,
+                         uint8_t precision, const char* symbol) {
+  append_u64_le(buf, end, amount);
+  append_u8(buf, end, precision);
+  char sym[7] = {0};
+  if (symbol) strncpy(sym, symbol, 6);
+  for (int i = 0; i < 7 && *buf < end; i++)
+    append_u8(buf, end, (uint8_t)sym[i]);
+}
+
+/*
+ * Graphene authority structure (Hive wire format):
+ *   weight_threshold (uint32 LE) = 1
+ *   num_account_auths (varint)   = 0
+ *   num_key_auths (varint)       = 1
+ *     compressed public key      (33 bytes, no type prefix)
+ *     weight (uint16 LE)         = 1
+ *
+ * Note: Hive does NOT use a key-type prefix byte before the 33 raw bytes.
+ */
+static void append_authority(uint8_t** buf, const uint8_t* end,
+                             const uint8_t pubkey[33]) {
+  append_u32_le(buf, end, 1);  // weight_threshold = 1
+  append_varint(buf, end, 0);  // 0 account auths
+  append_varint(buf, end, 1);  // 1 key auth
+  for (int i = 0; i < 33 && *buf < end; i++) append_u8(buf, end, pubkey[i]);
+  append_u16_le(buf, end, 1);  // weight = 1
+}
+
+/*
+ * Common transaction header: ref_block_num, ref_block_prefix, expiration,
+ * then a varint op count = 1, then the op type varint.
+ */
+static void append_tx_header(uint8_t** buf, const uint8_t* end,
+                             uint16_t ref_block_num, uint32_t ref_block_prefix,
+                             uint32_t expiration, uint32_t op_type) {
+  append_u16_le(buf, end, ref_block_num);
+  append_u32_le(buf, end, ref_block_prefix);
+  append_u32_le(buf, end, expiration);
+  append_varint(buf, end, 1);  // 1 operation
+  append_varint(buf, end, op_type);
+}
+
+static void append_tx_footer(uint8_t** buf, const uint8_t* end) {
+  append_varint(buf, end, 0);  // 0 extensions
+}
+
+/*
+ * Sign helper: SHA256(chain_id || serialized_tx) → secp256k1 recoverable sig.
+ * Writes 65 bytes into sig[]. Returns true on success.
+ */
+static bool hive_sign_digest(const HDNode* node, const uint8_t* chain_id,
+                             const uint8_t* tx_buf, size_t tx_len,
+                             uint8_t sig[65]) {
+  SHA256_CTX sha;
+  sha256_Init(&sha);
+  sha256_Update(&sha, chain_id, HIVE_CHAIN_ID_LEN);
+  sha256_Update(&sha, tx_buf, tx_len);
+  uint8_t digest[32];
+  sha256_Final(&sha, digest);
+
+  uint8_t pby;
+  if (ecdsa_sign_digest(&secp256k1, node->private_key, digest, sig + 1, &pby,
+                        NULL) != 0) {
+    memzero(digest, sizeof(digest));
+    return false;
+  }
+  // Compact signature header: 27 + recovery_id + 4 (compressed key flag)
+  sig[0] = 27 + pby + 4;
+  memzero(digest, sizeof(digest));
+  return true;
+}
+
+// ── Transfer (op type 2) ──────────────────────────────────────────────────
+
+// Maximum memo length that fits safely in tx_buf[512] with all other fields.
+// Non-memo overhead: header(12) + from(17) + to(17) + asset(16) + footer(1) =
+// ~63 bytes. 512 - 63 - 3 (varint) = 446; use 440 as the conservative limit.
+#define HIVE_MAX_MEMO_LEN 440
+
+static size_t hive_serialize_transfer(const HiveSignTx* msg, uint8_t* buf,
+                                      size_t buf_len) {
+  uint8_t* p = buf;
+  const uint8_t* end = buf + buf_len;
+
+  append_tx_header(&p, end, (uint16_t)(msg->ref_block_num & 0xFFFF),
+                   msg->ref_block_prefix, msg->expiration, HIVE_OP_TRANSFER);
+
+  append_string(&p, end, msg->has_from ? msg->from : "");
+  append_string(&p, end, msg->has_to ? msg->to : "");
+
+  const char* sym = msg->has_asset_symbol ? msg->asset_symbol : "HIVE";
+  uint8_t prec = (uint8_t)(msg->has_decimals ? msg->decimals : HIVE_DECIMALS);
+  append_asset(&p, end, msg->amount, prec, sym);
+
+  append_string(&p, end, msg->has_memo ? msg->memo : "");
+  append_tx_footer(&p, end);
+  return (size_t)(p - buf);
+}
+
+void hive_signTx(const HDNode* node, const HiveSignTx* msg,
+                 HiveSignedTx* resp) {
+  // Reject memos that would overflow the fixed-size tx_buf.
+  if (msg->has_memo && strlen(msg->memo) > HIVE_MAX_MEMO_LEN) return;
+
+  uint8_t tx_buf[512];
+  size_t tx_len = hive_serialize_transfer(msg, tx_buf, sizeof(tx_buf));
+
+  const uint8_t default_chain_id[32] = HIVE_CHAIN_ID;
+  const uint8_t* chain_id =
+      (msg->has_chain_id && msg->chain_id.size == HIVE_CHAIN_ID_LEN)
+          ? msg->chain_id.bytes
+          : default_chain_id;
+
+  uint8_t sig[65];
+  if (!hive_sign_digest(node, chain_id, tx_buf, tx_len, sig)) {
+    memzero(sig, sizeof(sig));
+    return;
+  }
+
+  resp->has_signature = true;
+  resp->signature.size = 65;
+  memcpy(resp->signature.bytes, sig, 65);
+
+  resp->has_serialized_tx = true;
+  resp->serialized_tx.size = tx_len;
+  memcpy(resp->serialized_tx.bytes, tx_buf, tx_len);
+
+  memzero(sig, sizeof(sig));
+  memzero(tx_buf, tx_len);
+}
+
+// ── Account create (op type 9) ────────────────────────────────────────────
+//
+// All four role keys are device-derived by the caller (FSM handler) and
+// passed as raw 33-byte compressed public keys. The firmware never uses
+// host-supplied key strings for the actual transaction.
+
+static size_t hive_serialize_account_create(const HiveSignAccountCreate* msg,
+                                            const uint8_t owner_raw[33],
+                                            const uint8_t active_raw[33],
+                                            const uint8_t posting_raw[33],
+                                            const uint8_t memo_raw[33],
+                                            uint8_t* buf, size_t buf_len) {
+  uint8_t* p = buf;
+  const uint8_t* end = buf + buf_len;
+
+  append_tx_header(&p, end, (uint16_t)(msg->ref_block_num & 0xFFFF),
+                   msg->ref_block_prefix, msg->expiration,
+                   HIVE_OP_ACCOUNT_CREATE);
+
+  // fee (asset)
+  uint64_t fee = msg->has_fee_amount ? msg->fee_amount : 3000;
+  append_asset(&p, end, fee, HIVE_DECIMALS, "HIVE");
+
+  // creator
+  append_string(&p, end, msg->has_creator ? msg->creator : "");
+
+  // new_account_name
+  append_string(&p, end,
+                msg->has_new_account_name ? msg->new_account_name : "");
+
+  // authority fields use device-derived raw bytes (no host trust, no type
+  // prefix)
+  append_authority(&p, end, owner_raw);
+  append_authority(&p, end, active_raw);
+  append_authority(&p, end, posting_raw);
+
+  // memo_key: 33 raw bytes, no authority wrapper, no type prefix byte
+  for (int i = 0; i < 33 && p < end; i++) append_u8(&p, end, memo_raw[i]);
+
+  // json_metadata (empty)
+  append_string(&p, end, "");
+  append_tx_footer(&p, end);
+
+  return (size_t)(p - buf);
+}
+
+void hive_signAccountCreate(const HDNode* signing_node,
+                            const HiveSignAccountCreate* msg,
+                            const uint8_t owner_raw[33],
+                            const uint8_t active_raw[33],
+                            const uint8_t posting_raw[33],
+                            const uint8_t memo_raw[33],
+                            HiveSignedAccountCreate* resp) {
+  uint8_t tx_buf[512];
+  size_t tx_len =
+      hive_serialize_account_create(msg, owner_raw, active_raw, posting_raw,
+                                    memo_raw, tx_buf, sizeof(tx_buf));
+
+  const uint8_t default_chain_id[32] = HIVE_CHAIN_ID;
+  const uint8_t* chain_id =
+      (msg->has_chain_id && msg->chain_id.size == HIVE_CHAIN_ID_LEN)
+          ? msg->chain_id.bytes
+          : default_chain_id;
+
+  uint8_t sig[65];
+  if (!hive_sign_digest(signing_node, chain_id, tx_buf, tx_len, sig)) {
+    memzero(sig, sizeof(sig));
+    memzero(tx_buf, sizeof(tx_buf));
+    return;
+  }
+
+  resp->has_signature = true;
+  resp->signature.size = 65;
+  memcpy(resp->signature.bytes, sig, 65);
+
+  resp->has_serialized_tx = true;
+  resp->serialized_tx.size = tx_len;
+  memcpy(resp->serialized_tx.bytes, tx_buf, tx_len);
+
+  memzero(sig, sizeof(sig));
+  memzero(tx_buf, tx_len);
+}
+
+// ── Account update (op type 10) ───────────────────────────────────────────
+//
+// All four new role keys are device-derived by the caller (FSM handler).
+// The host-supplied new_*_key fields in the message are not used for signing.
+
+static size_t hive_serialize_account_update(const HiveSignAccountUpdate* msg,
+                                            const uint8_t owner_raw[33],
+                                            const uint8_t active_raw[33],
+                                            const uint8_t posting_raw[33],
+                                            const uint8_t memo_raw[33],
+                                            uint8_t* buf, size_t buf_len) {
+  uint8_t* p = buf;
+  const uint8_t* end = buf + buf_len;
+
+  append_tx_header(&p, end, (uint16_t)(msg->ref_block_num & 0xFFFF),
+                   msg->ref_block_prefix, msg->expiration,
+                   HIVE_OP_ACCOUNT_UPDATE);
+
+  // account name
+  append_string(&p, end, msg->has_account ? msg->account : "");
+
+  /*
+   * account_update optional authority fields use a Graphene "optional" wrapper:
+   *   present: 0x01 + authority bytes
+   *   absent:  0x00
+   * We always include all four — this replaces all authorities.
+   */
+  append_u8(&p, end, 0x01);  // owner present
+  append_authority(&p, end, owner_raw);
+  append_u8(&p, end, 0x01);  // active present
+  append_authority(&p, end, active_raw);
+  append_u8(&p, end, 0x01);  // posting present
+  append_authority(&p, end, posting_raw);
+
+  // memo_key: 33 raw bytes, always present, no type prefix byte
+  for (int i = 0; i < 33 && p < end; i++) append_u8(&p, end, memo_raw[i]);
+
+  // json_metadata (empty)
+  append_string(&p, end, "");
+  append_tx_footer(&p, end);
+
+  return (size_t)(p - buf);
+}
+
+void hive_signAccountUpdate(const HDNode* signing_node,
+                            const HiveSignAccountUpdate* msg,
+                            const uint8_t owner_raw[33],
+                            const uint8_t active_raw[33],
+                            const uint8_t posting_raw[33],
+                            const uint8_t memo_raw[33],
+                            HiveSignedAccountUpdate* resp) {
+  uint8_t tx_buf[512];
+  size_t tx_len =
+      hive_serialize_account_update(msg, owner_raw, active_raw, posting_raw,
+                                    memo_raw, tx_buf, sizeof(tx_buf));
+
+  const uint8_t default_chain_id[32] = HIVE_CHAIN_ID;
+  const uint8_t* chain_id =
+      (msg->has_chain_id && msg->chain_id.size == HIVE_CHAIN_ID_LEN)
+          ? msg->chain_id.bytes
+          : default_chain_id;
+
+  uint8_t sig[65];
+  if (!hive_sign_digest(signing_node, chain_id, tx_buf, tx_len, sig)) {
+    memzero(sig, sizeof(sig));
+    memzero(tx_buf, sizeof(tx_buf));
+    return;
+  }
+
+  resp->has_signature = true;
+  resp->signature.size = 65;
+  memcpy(resp->signature.bytes, sig, 65);
+
+  resp->has_serialized_tx = true;
+  resp->serialized_tx.size = tx_len;
+  memcpy(resp->serialized_tx.bytes, tx_buf, tx_len);
+
+  memzero(sig, sizeof(sig));
+  memzero(tx_buf, tx_len);
+}

--- a/lib/firmware/hive.c
+++ b/lib/firmware/hive.c
@@ -177,6 +177,19 @@ static void append_tx_footer(uint8_t** buf, const uint8_t* end) {
 }
 
 /*
+ * Graphene canonical-signature rule (identical to EOS/Steem): high bit of
+ * both r and s must be clear. hived rejects non-canonical compact sigs, so
+ * signing must retry until canonical — same predicate as eos_is_canonic.
+ */
+static int hive_is_canonic(uint8_t v, uint8_t signature[64]) {
+  (void)v;
+  return !(signature[0] & 0x80) &&
+         !(signature[0] == 0 && !(signature[1] & 0x80)) &&
+         !(signature[32] & 0x80) &&
+         !(signature[32] == 0 && !(signature[33] & 0x80));
+}
+
+/*
  * Sign helper: SHA256(chain_id || serialized_tx) → secp256k1 recoverable sig.
  * Writes 65 bytes into sig[]. Returns true on success.
  */
@@ -192,7 +205,7 @@ static bool hive_sign_digest(const HDNode* node, const uint8_t* chain_id,
 
   uint8_t pby;
   if (ecdsa_sign_digest(&secp256k1, node->private_key, digest, sig + 1, &pby,
-                        NULL) != 0) {
+                        hive_is_canonic) != 0) {
     memzero(digest, sizeof(digest));
     return false;
   }

--- a/lib/firmware/messagemap.def
+++ b/lib/firmware/messagemap.def
@@ -164,6 +164,33 @@
     MSG_OUT(MessageType_MessageType_SolanaMessageSignature,        SolanaMessageSignature,      NO_PROCESS_FUNC)
     MSG_OUT(MessageType_MessageType_SolanaOffchainMessageSignature, SolanaOffchainMessageSignature, NO_PROCESS_FUNC)
 
+    /* Hive */
+    MSG_IN(MessageType_MessageType_HiveGetPublicKey,               HiveGetPublicKey,            fsm_msgHiveGetPublicKey)
+    MSG_IN(MessageType_MessageType_HiveGetPublicKeys,              HiveGetPublicKeys,           fsm_msgHiveGetPublicKeys)
+    MSG_IN(MessageType_MessageType_HiveSignTx,                     HiveSignTx,                  fsm_msgHiveSignTx)
+    MSG_IN(MessageType_MessageType_HiveSignAccountCreate,          HiveSignAccountCreate,       fsm_msgHiveSignAccountCreate)
+    MSG_IN(MessageType_MessageType_HiveSignAccountUpdate,          HiveSignAccountUpdate,       fsm_msgHiveSignAccountUpdate)
+
+    MSG_OUT(MessageType_MessageType_HivePublicKey,                 HivePublicKey,               NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_HivePublicKeys,                HivePublicKeys,              NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_HiveSignedTx,                  HiveSignedTx,                NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_HiveSignedAccountCreate,       HiveSignedAccountCreate,     NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_HiveSignedAccountUpdate,       HiveSignedAccountUpdate,     NO_PROCESS_FUNC)
+    /* Zcash */
+    MSG_IN(MessageType_MessageType_ZcashSignPCZT,                  ZcashSignPCZT,               fsm_msgZcashSignPCZT)
+    MSG_IN(MessageType_MessageType_ZcashPCZTAction,                ZcashPCZTAction,             fsm_msgZcashPCZTAction)
+    MSG_IN(MessageType_MessageType_ZcashGetOrchardFVK,             ZcashGetOrchardFVK,          fsm_msgZcashGetOrchardFVK)
+    MSG_IN(MessageType_MessageType_ZcashTransparentOutput,         ZcashTransparentOutput,      fsm_msgZcashTransparentOutput)
+    MSG_IN(MessageType_MessageType_ZcashTransparentInput,          ZcashTransparentInput,       fsm_msgZcashTransparentInput)
+    MSG_IN(MessageType_MessageType_ZcashDisplayAddress,            ZcashDisplayAddress,         fsm_msgZcashDisplayAddress)
+
+    MSG_OUT(MessageType_MessageType_ZcashPCZTActionAck,            ZcashPCZTActionAck,          NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_ZcashSignedPCZT,               ZcashSignedPCZT,             NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_ZcashOrchardFVK,               ZcashOrchardFVK,             NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_ZcashTransparentSigned,        ZcashTransparentSigned,      NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_ZcashTransparentAck,           ZcashTransparentAck,         NO_PROCESS_FUNC)
+    MSG_OUT(MessageType_MessageType_ZcashAddress,                  ZcashAddress,                NO_PROCESS_FUNC)
+
 #if DEBUG_LINK
     /* Debug Messages */
     DEBUG_IN(MessageType_MessageType_DebugLinkDecision,             DebugLinkDecision,           NO_PROCESS_FUNC)

--- a/lib/firmware/ripple.c
+++ b/lib/firmware/ripple.c
@@ -223,6 +223,25 @@ bool ripple_serialize(uint8_t** buf, const uint8_t* end, const RippleSignTx* tx,
   if (tx->payment.has_destination)
     ripple_serializeAddress(&ok, buf, end, &RFM_destination,
                             tx->payment.destination);
+  // Memos array (ARRAY type=15 key=9) comes last per XRPL canonical ordering.
+  // Layout: 0xF9 [Memos start] 0xEA [Memo object start]
+  //         0x7D [MemoData VL] <varint len> <bytes>
+  //         0xE1 [object end] 0xF1 [array end]
+  if (tx->has_memo && tx->memo[0] != '\0') {
+    size_t memo_len = strlen(tx->memo);
+    append_u8(&ok, buf, end, 0xF9);  // STArray[9] = Memos
+    append_u8(&ok, buf, end, 0xEA);  // STObject[10] = Memo
+    append_u8(&ok, buf, end, 0x7D);  // VL[13] = MemoData
+    ripple_serializeVarint(&ok, buf, end, (int)memo_len);
+    if (ok && *buf + memo_len <= end) {
+      memcpy(*buf, tx->memo, memo_len);
+      *buf += memo_len;
+    } else {
+      ok = false;
+    }
+    append_u8(&ok, buf, end, 0xE1);  // end STObject
+    append_u8(&ok, buf, end, 0xF1);  // end STArray
+  }
   return ok;
 }
 

--- a/lib/firmware/storage.c
+++ b/lib/firmware/storage.c
@@ -45,6 +45,7 @@
 #include "keepkey/firmware/passphrase_sm.h"
 #include "keepkey/firmware/policy.h"
 #include "keepkey/firmware/u2f.h"
+#include "keepkey/firmware/zcash.h"
 #include "keepkey/rand/rng.h"
 #include "keepkey/transport/interface.h"
 #include "trezor/crypto/aes/aes.h"
@@ -1864,6 +1865,32 @@ const uint8_t* storage_getSeed(const ConfigFlash* cfg, bool usePassphrase) {
   }
 
   return NULL;
+}
+
+/* ── Zcash storage-scoped wrappers ───────────────────────────────────
+ *
+ * ZIP-32 Orchard derives keys directly from the raw 64-byte BIP-39 seed
+ * (not the BIP-32 master node). Rather than expose a generic
+ * "give me the seed" function, storage owns the seed access and only
+ * returns derived material — Orchard keys or the 32-byte fingerprint.
+ * The seed pointer never leaves this translation unit.
+ */
+
+bool storage_zcashOrchardKeys(uint32_t account, bool usePassphrase,
+                              ZcashOrchardKeys* keys_out) {
+  if (!keys_out) return false;
+  const uint8_t* seed = storage_getSeed(&shadow_config, usePassphrase);
+  if (!seed) return false;
+  animating_progress_handler(_("Deriving Zcash"), 250);
+  return zcash_derive_orchard_keys(seed, 64, account, keys_out);
+}
+
+bool storage_zcashSeedFingerprint(bool usePassphrase,
+                                  uint8_t fingerprint_out[32]) {
+  if (!fingerprint_out) return false;
+  const uint8_t* seed = storage_getSeed(&shadow_config, usePassphrase);
+  if (!seed) return false;
+  return zcash_calculate_seed_fingerprint(seed, 64, fingerprint_out);
 }
 
 const uint8_t* storage_getRawSeed(bool usePassphrase) {

--- a/lib/firmware/thorchain.c
+++ b/lib/firmware/thorchain.c
@@ -29,7 +29,23 @@
 #include "trezor/crypto/segwit_addr.h"
 
 #include <stdbool.h>
+#include <string.h>
 #include <time.h>
+
+// Allow lowercase alpha, digits, and the punctuation used in THORChain asset
+// identifiers (e.g. "eth.eth", "btc/btc", cross-chain synthetic prefixes).
+// Rejects anything that needs JSON escaping (backslash, quote).
+bool thorchain_isValidDenom(const char* denom) {
+  if (!denom || !denom[0]) return false;
+  for (size_t i = 0; denom[i]; i++) {
+    char c = denom[i];
+    if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '.' ||
+          c == '/' || c == '-')) {
+      return false;
+    }
+  }
+  return true;
+}
 
 static CONFIDENTIAL HDNode node;
 static SHA256_CTX ctx;
@@ -95,7 +111,7 @@ bool thorchain_signTxInit(const HDNode* _node, const ThorchainSignTx* _msg) {
 }
 
 bool thorchain_signTxUpdateMsgSend(const uint64_t amount,
-                                   const char* to_address) {
+                                   const char* to_address, const char* denom) {
   const char mainnetp[] = "thor";
   const char testnetp[] = "tthor";
   const char* pfix;
@@ -119,15 +135,26 @@ bool thorchain_signTxUpdateMsgSend(const uint64_t amount,
     return false;
   }
 
+  // Default to "rune" for backward compatibility; validate all non-default
+  // denoms
+  const char* coin_denom = (denom && denom[0]) ? denom : "rune";
+  if (!thorchain_isValidDenom(coin_denom)) {
+    return false;
+  }
+
   bool success = true;
 
   const char* const prelude = "{\"type\":\"thorchain/MsgSend\",\"value\":{";
   sha256_Update(&ctx, (uint8_t*)prelude, strlen(prelude));
 
-  // 21 + ^20 + 19 = ^60
+  // Write amount prefix: 21 + ^20 = ^41
   success &= tendermint_snprintf(
       &ctx, buffer, sizeof(buffer),
-      "\"amount\":[{\"amount\":\"%" PRIu64 "\",\"denom\":\"rune\"}]", amount);
+      "\"amount\":[{\"amount\":\"%" PRIu64 "\",\"denom\":\"", amount);
+  // Use escaping as defense-in-depth; valid denoms have no escapable chars
+  tendermint_sha256UpdateEscaped(&ctx, coin_denom, strlen(coin_denom));
+  // Close coins array: 3 bytes
+  sha256_Update(&ctx, (uint8_t*)"\"}]", 3);
 
   // 17 + 45 + 1 = 63
   success &= tendermint_snprintf(&ctx, buffer, sizeof(buffer),

--- a/lib/firmware/zcash.c
+++ b/lib/firmware/zcash.c
@@ -1,0 +1,1160 @@
+/*
+ * This file is part of the KeepKey project.
+ *
+ * Copyright (C) 2025 KeepKey
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "keepkey/firmware/zcash.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "trezor/crypto/aes/aes.h"
+#include "trezor/crypto/bignum.h"
+#include "trezor/crypto/blake2b.h"
+#include "trezor/crypto/hasher.h"
+#include "trezor/crypto/memzero.h"
+#include "trezor/crypto/pallas.h"
+#include "trezor/crypto/pallas_sinsemilla.h"
+#include "trezor/crypto/pallas_swu.h"
+#include "trezor/crypto/redpallas.h"
+#include "trezor/crypto/zcash_zip316.h"
+
+/*
+ * ZIP-32 Orchard key derivation.
+ *
+ * Master key:
+ *   I = BLAKE2b-512("ZcashIP32Orchard", seed)
+ *   sk = I[0..32], chain_code = I[32..64]
+ *
+ * Child derivation (hardened only):
+ *   I = BLAKE2b-512("ZcashIP32Orchard", chain_code,
+ *                    0x11 || sk || i_be)
+ *   where 0x11 indicates hardened derivation with Orchard,
+ *   and i_be is the 4-byte big-endian child index with the hardened bit set.
+ *
+ * From the spending key sk, subkeys are derived using PRF^expand:
+ *   PRF^expand(sk, t) = BLAKE2b-512("Zcash_ExpandSeed", sk || t)
+ *
+ *   ask  = ToScalar(PRF^expand(sk, [0x06]))
+ *   nk   = ToBase(PRF^expand(sk, [0x07]))
+ *   rivk = ToScalar(PRF^expand(sk, [0x08]))
+ *
+ * ToScalar: interpret 64 bytes as LE integer, reduce mod order
+ * ToBase: interpret 64 bytes as LE integer, reduce mod prime
+ */
+
+/*
+ * BLAKE2b-512 with personalization "ZcashIP32Orchard" — master key only.
+ * Used for: I = BLAKE2b-512("ZcashIP32Orchard", seed)
+ * NOT used for child derivation (which uses PRF^expand).
+ */
+static void zip32_orchard_master(const uint8_t* seed, size_t seed_len,
+                                 uint8_t out[64]) {
+  BLAKE2B_CTX ctx;
+  blake2b_InitPersonal(&ctx, 64, "ZcashIP32Orchard", 16);
+  blake2b_Update(&ctx, seed, seed_len);
+  blake2b_Final(&ctx, out, 64);
+}
+
+/* PRF^expand(sk, t) = BLAKE2b-512("Zcash_ExpandSeed", sk || t) */
+static void prf_expand(const uint8_t sk[32], const uint8_t* t, size_t t_len,
+                       uint8_t out[64]) {
+  BLAKE2B_CTX ctx;
+  blake2b_InitPersonal(&ctx, 64, "Zcash_ExpandSeed", 16);
+  blake2b_Update(&ctx, sk, 32);
+  blake2b_Update(&ctx, t, t_len);
+  blake2b_Final(&ctx, out, 64);
+}
+
+/*
+ * 2^256 mod q (Pallas scalar field order), little-endian.
+ * q = 0x40000000000000000000000000000000224698fc0994a8dd8c46eb2100000001
+ * R = 0x3FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF992C350BE34205675B2B3E9CFFFFFFFD
+ * Verified: R + 3*q == 2^256.
+ */
+static const uint8_t two_256_mod_q[32] = {
+    0xfd, 0xff, 0xff, 0xff, 0x9c, 0x3e, 0x2b, 0x5b, 0x67, 0x05, 0x42,
+    0xe3, 0x0b, 0x35, 0x2c, 0x99, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x3f,
+};
+
+/*
+ * 2^256 mod p (Pallas base field prime), little-endian.
+ * p = 0x40000000000000000000000000000000224698fc094cf91b992d30ed00000001
+ * R = 0x3FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF992C350BE41914AD34786D38FFFFFFFD
+ * Verified: R + 3*p == 2^256.
+ */
+static const uint8_t two_256_mod_p[32] = {
+    0xfd, 0xff, 0xff, 0xff, 0x38, 0x6d, 0x78, 0x34, 0xad, 0x14, 0x19,
+    0xe4, 0x0b, 0x35, 0x2c, 0x99, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x3f,
+};
+
+/*
+ * ToScalar: reduce a 512-bit LE integer mod Pallas scalar order.
+ *
+ * Uses wide reduction matching the orchard crate's from_uniform_bytes:
+ *   result = (lo + hi * 2^256) mod q
+ * where lo = input[0..31], hi = input[32..63] (little-endian).
+ */
+static void to_scalar(const uint8_t input[64], uint8_t output[32]) {
+  bignum256 lo, hi, t256, result;
+
+  bn_read_le(input, &lo);
+  pallas_mod_q(&lo);
+
+  bn_read_le(input + 32, &hi);
+  pallas_mod_q(&hi);
+
+  bn_read_le(two_256_mod_q, &t256);
+
+  /* result = hi * (2^256 mod q) mod q */
+  bn_copy(&hi, &result);
+  pallas_mul_mod_q(&result, &t256);
+
+  /* result = result + lo mod q */
+  pallas_add_mod_q(&result, &lo);
+
+  bn_write_le(&result, output);
+
+  memzero(&lo, sizeof(lo));
+  memzero(&hi, sizeof(hi));
+  memzero(&result, sizeof(result));
+}
+
+/*
+ * ToBase: reduce a 512-bit LE integer mod Pallas base field prime.
+ *
+ * Uses wide reduction:
+ *   result = (lo + hi * 2^256) mod p
+ * where lo = input[0..31], hi = input[32..63] (little-endian).
+ */
+static void to_base(const uint8_t input[64], uint8_t output[32]) {
+  bignum256 lo, hi, t256, result;
+
+  bn_read_le(input, &lo);
+  pallas_mod_p(&lo);
+
+  bn_read_le(input + 32, &hi);
+  pallas_mod_p(&hi);
+
+  bn_read_le(two_256_mod_p, &t256);
+
+  /* result = hi * (2^256 mod p) mod p */
+  bn_copy(&hi, &result);
+  pallas_mul_mod_p(&result, &t256);
+
+  /* result = result + lo mod p */
+  bignum256 sum;
+  pallas_add_mod_p(&result, &lo, &sum);
+  bn_copy(&sum, &result);
+  memzero(&sum, sizeof(sum));
+
+  bn_write_le(&result, output);
+
+  memzero(&lo, sizeof(lo));
+  memzero(&hi, sizeof(hi));
+  memzero(&result, sizeof(result));
+}
+
+/* Hardened child index */
+#define ZIP32_HARDENED 0x80000000
+
+/*
+ * ZIP-32 Orchard diversifiers use FF1-AES256 over an 88-bit binary numeral
+ * string. Parameters are fixed by the Zcash protocol:
+ *
+ *   radix = 2, minlen = maxlen = n = 88, tweak = "", rounds = 10
+ *
+ * The input and output byte arrays are LEBS2OSP encodings of the 88-bit
+ * strings, but FF1's NUM/STR operations interpret each half in numeral-string
+ * order. Keep the bit-order conversion explicit to avoid silently turning this
+ * into a radix-256 construction, which would be a different permutation.
+ */
+#define ZCASH_FF1_BITS 88
+#define ZCASH_FF1_HALF_BITS 44
+#define ZCASH_FF1_MASK44 ((UINT64_C(1) << ZCASH_FF1_HALF_BITS) - 1)
+
+static uint8_t bit_get_le(const uint8_t* bytes, uint32_t bit) {
+  return (bytes[bit >> 3] >> (bit & 7)) & 1;
+}
+
+static void bit_set_le(uint8_t* bytes, uint32_t bit, uint8_t value) {
+  if (value) {
+    bytes[bit >> 3] |= (uint8_t)(1u << (bit & 7));
+  }
+}
+
+static uint64_t ff1_bits_to_num(const uint8_t bits[11], uint32_t offset,
+                                uint32_t len) {
+  uint64_t n = 0;
+  for (uint32_t i = 0; i < len; i++) {
+    n = (n << 1) | bit_get_le(bits, offset + i);
+  }
+  return n;
+}
+
+static void ff1_num_to_bits(uint64_t n, uint8_t bits[11], uint32_t offset,
+                            uint32_t len) {
+  for (uint32_t i = 0; i < len; i++) {
+    uint32_t shift = len - 1 - i;
+    bit_set_le(bits, offset + i, (uint8_t)((n >> shift) & 1));
+  }
+}
+
+static void ff1_store_be48(uint64_t n, uint8_t out[6]) {
+  for (int i = 5; i >= 0; i--) {
+    out[i] = (uint8_t)(n & 0xff);
+    n >>= 8;
+  }
+}
+
+static bool aes256_encrypt_block(const aes_encrypt_ctx* ctx,
+                                 const uint8_t in[16], uint8_t out[16]) {
+  return aes_encrypt(in, out, ctx) == EXIT_SUCCESS;
+}
+
+static bool ff1_round_y_mod_2_44(const aes_encrypt_ctx* ctx, uint8_t round,
+                                 uint64_t b, uint64_t* y_mod) {
+  static const uint8_t P[16] = {
+      0x01, 0x02, 0x01, 0x00, 0x00, 0x02, 0x0a, 0x2c,
+      0x00, 0x00, 0x00, 0x58, 0x00, 0x00, 0x00, 0x00,
+  };
+
+  uint8_t q[16] = {0};
+  uint8_t y[16];
+  uint8_t block[16];
+  uint8_t r[16];
+
+  /*
+   * Q = T || [0]^{(-t-b-1) mod 16} || [i]_1 || [NUM(B)]_b
+   * Here t = 0 and b = ceil(44 / 8) = 6, so padding is 9 bytes.
+   */
+  q[9] = round;
+  ff1_store_be48(b, q + 10);
+
+  /* PRF(P || Q) = CBC-MAC_AES(P || Q), IV = 0. */
+  if (!aes256_encrypt_block(ctx, P, y)) return false;
+  for (int i = 0; i < 16; i++) {
+    block[i] = y[i] ^ q[i];
+  }
+  if (!aes256_encrypt_block(ctx, block, r)) return false;
+
+  /*
+   * d = 4 * ceil(6 / 4) + 4 = 12, so S is the first 12 bytes of R.
+   * We only need NUM(S) modulo 2^44, i.e. the low 44 bits of R[0..11].
+   */
+  uint64_t low48 = 0;
+  for (int i = 6; i < 12; i++) {
+    low48 = (low48 << 8) | r[i];
+  }
+  *y_mod = low48 & ZCASH_FF1_MASK44;
+
+  memzero(q, sizeof(q));
+  memzero(y, sizeof(y));
+  memzero(block, sizeof(block));
+  memzero(r, sizeof(r));
+  return true;
+}
+
+bool zcash_orchard_derive_diversifier(const uint8_t dk[32],
+                                      const uint8_t index_le[11],
+                                      uint8_t diversifier_out[11]) {
+  if (!dk || !index_le || !diversifier_out) return false;
+
+  aes_encrypt_ctx ctx;
+  if (aes_encrypt_key256(dk, &ctx) != EXIT_SUCCESS) {
+    memzero(&ctx, sizeof(ctx));
+    return false;
+  }
+
+  uint64_t A =
+      ff1_bits_to_num(index_le, 0, ZCASH_FF1_HALF_BITS) & ZCASH_FF1_MASK44;
+  uint64_t B =
+      ff1_bits_to_num(index_le, ZCASH_FF1_HALF_BITS, ZCASH_FF1_HALF_BITS) &
+      ZCASH_FF1_MASK44;
+
+  for (uint8_t round = 0; round < 10; round++) {
+    uint64_t y;
+    if (!ff1_round_y_mod_2_44(&ctx, round, B, &y)) {
+      memzero(&ctx, sizeof(ctx));
+      return false;
+    }
+    uint64_t C = (A + y) & ZCASH_FF1_MASK44;
+    A = B;
+    B = C;
+  }
+
+  memset(diversifier_out, 0, 11);
+  ff1_num_to_bits(A, diversifier_out, 0, ZCASH_FF1_HALF_BITS);
+  ff1_num_to_bits(B, diversifier_out, ZCASH_FF1_HALF_BITS, ZCASH_FF1_HALF_BITS);
+
+  memzero(&ctx, sizeof(ctx));
+  return true;
+}
+
+static bool orchard_diversify_point(const uint8_t diversifier[11],
+                                    curve_point* gd) {
+  if (!diversifier || !gd) return false;
+  static const char domain[] = "z.cash:Orchard-gd";
+
+  if (pallas_group_hash(domain, diversifier, 11, gd) != 0) {
+    return false;
+  }
+
+  if (pallas_point_is_identity(gd)) {
+    if (pallas_group_hash(domain, NULL, 0, gd) != 0 ||
+        pallas_point_is_identity(gd)) {
+      memzero(gd, sizeof(*gd));
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool zcash_orchard_diversify_hash(const uint8_t diversifier[11],
+                                  uint8_t gd_out[32]) {
+  if (!gd_out) return false;
+
+  curve_point gd;
+  if (!orchard_diversify_point(diversifier, &gd)) {
+    return false;
+  }
+
+  pallas_point_encode(&gd, gd_out);
+  memzero(&gd, sizeof(gd));
+  return true;
+}
+
+bool zcash_orchard_derive_transmission_key(const uint8_t ivk[32],
+                                           const uint8_t diversifier[11],
+                                           uint8_t gd_out[32],
+                                           uint8_t pkd_out[32]) {
+  if (!ivk || !pkd_out) return false;
+
+  bignum256 ivk_scalar;
+  bn_read_le(ivk, &ivk_scalar);
+  bn_normalize(&ivk_scalar);
+  if (bn_is_zero(&ivk_scalar) || !bn_is_less(&ivk_scalar, &pallas_prime)) {
+    memzero(&ivk_scalar, sizeof(ivk_scalar));
+    return false;
+  }
+
+  curve_point gd;
+  if (!orchard_diversify_point(diversifier, &gd)) {
+    memzero(&ivk_scalar, sizeof(ivk_scalar));
+    return false;
+  }
+
+  curve_point pkd;
+  pallas_point_mult(&ivk_scalar, &gd, &pkd);
+  if (pallas_point_is_identity(&pkd)) {
+    memzero(&ivk_scalar, sizeof(ivk_scalar));
+    memzero(&gd, sizeof(gd));
+    memzero(&pkd, sizeof(pkd));
+    return false;
+  }
+
+  if (gd_out) {
+    pallas_point_encode(&gd, gd_out);
+  }
+  pallas_point_encode(&pkd, pkd_out);
+
+  memzero(&ivk_scalar, sizeof(ivk_scalar));
+  memzero(&gd, sizeof(gd));
+  memzero(&pkd, sizeof(pkd));
+  return true;
+}
+
+bool zcash_orchard_derive_ivk(const uint8_t ak[32], const uint8_t nk[32],
+                              const uint8_t rivk[32], uint8_t ivk_out[32]) {
+  if (!ak || !nk || !rivk || !ivk_out) return false;
+  if ((ak[31] & 0x80) != 0) return false;
+
+  if (pallas_sinsemilla_commit_ivk(ak, nk, rivk, ivk_out) != 0) {
+    return false;
+  }
+
+  bignum256 ivk;
+  bn_read_le(ivk_out, &ivk);
+  bn_normalize(&ivk);
+  bool ok = !bn_is_zero(&ivk) && bn_is_less(&ivk, &pallas_prime);
+  memzero(&ivk, sizeof(ivk));
+  if (!ok) {
+    memzero(ivk_out, 32);
+  }
+  return ok;
+}
+
+bool zcash_orchard_derive_receiver(const uint8_t ak[32], const uint8_t nk[32],
+                                   const uint8_t rivk[32], const uint8_t dk[32],
+                                   const uint8_t index_le[11],
+                                   uint8_t receiver_out[43]) {
+  if (!receiver_out) return false;
+
+  uint8_t diversifier[11];
+  uint8_t ivk[32];
+  uint8_t pkd[32];
+  bool ok = zcash_orchard_derive_diversifier(dk, index_le, diversifier) &&
+            zcash_orchard_derive_ivk(ak, nk, rivk, ivk) &&
+            zcash_orchard_derive_transmission_key(ivk, diversifier, NULL, pkd);
+
+  if (ok) {
+    memcpy(receiver_out, diversifier, sizeof(diversifier));
+    memcpy(receiver_out + sizeof(diversifier), pkd, sizeof(pkd));
+  } else {
+    memzero(receiver_out, 43);
+  }
+
+  memzero(diversifier, sizeof(diversifier));
+  memzero(ivk, sizeof(ivk));
+  memzero(pkd, sizeof(pkd));
+  return ok;
+}
+
+bool zcash_orchard_derive_unified_address(const ZcashOrchardKeys* keys,
+                                          const uint8_t index_le[11],
+                                          const char* hrp, char* address_out,
+                                          size_t address_out_len) {
+  if (!keys || !index_le || !hrp || !address_out) return false;
+
+  bignum256 ask_scalar;
+  curve_point ak_point;
+  bignum256 ak_x;
+  uint8_t ak[32];
+  uint8_t receiver[43];
+
+  bn_read_le(keys->ask, &ask_scalar);
+  redpallas_scalar_mult_spendauth_G(&ask_scalar, &ak_point);
+  bn_copy(&ak_point.x, &ak_x);
+  bn_write_le(&ak_x, ak);
+
+  bool ok = zcash_orchard_derive_receiver(ak, keys->nk, keys->rivk, keys->dk,
+                                          index_le, receiver);
+  if (ok) {
+    ok = zcash_zip316_encode_orchard_unified_address(hrp, receiver, address_out,
+                                                     address_out_len) == 0;
+  }
+  if (!ok && address_out_len > 0) {
+    address_out[0] = '\0';
+  }
+
+  memzero(&ask_scalar, sizeof(ask_scalar));
+  memzero(&ak_point, sizeof(ak_point));
+  memzero(&ak_x, sizeof(ak_x));
+  memzero(ak, sizeof(ak));
+  memzero(receiver, sizeof(receiver));
+  return ok;
+}
+
+bool zcash_orchard_receiver_to_unified_address(
+    const uint8_t receiver[ZCASH_ORCHARD_RAW_RECEIVER_SIZE], const char* hrp,
+    char* address_out, size_t address_out_len) {
+  if (!receiver || !hrp || !address_out) return false;
+  return zcash_zip316_encode_orchard_unified_address(hrp, receiver, address_out,
+                                                     address_out_len) == 0;
+}
+
+static bool zcash_pack_orchard_note_commit_msg(const uint8_t receiver[43],
+                                               uint64_t value,
+                                               const uint8_t rho[32],
+                                               const uint8_t psi[32],
+                                               uint8_t msg[136]) {
+  memset(msg, 0, 136);
+
+  /* bits 0..255: repr_P(g_d) */
+  curve_point gd;
+  if (!orchard_diversify_point(receiver, &gd)) {
+    memzero(&gd, sizeof(gd));
+    return false;
+  }
+  pallas_point_encode(&gd, msg);
+  memzero(&gd, sizeof(gd));
+
+  /* bits 256..511: repr_P(pk_d) */
+  memcpy(msg + 32, receiver + 11, 32);
+
+  /* bits 512..575: I2LEBSP_64(value) */
+  for (int i = 0; i < 8; i++) {
+    msg[64 + i] = (uint8_t)((value >> (8 * i)) & 0xff);
+  }
+
+  /* bits 576..830: I2LEBSP_255(rho) */
+  memcpy(msg + 72, rho, 31);
+  msg[103] = rho[31] & 0x7f;
+
+  /* bits 831..1085: I2LEBSP_255(psi), packed at bit offset 831. */
+  uint8_t psi255[32];
+  memcpy(psi255, psi, 32);
+  psi255[31] &= 0x7f;
+  for (int i = 0; i < 32; i++) {
+    msg[103 + i] |= (uint8_t)(psi255[i] << 7);
+    msg[104 + i] |= (uint8_t)(psi255[i] >> 1);
+  }
+  memzero(psi255, sizeof(psi255));
+  return true;
+}
+
+bool zcash_orchard_compute_cmx(
+    const uint8_t receiver[ZCASH_ORCHARD_RAW_RECEIVER_SIZE], uint64_t value,
+    const uint8_t rho[32], const uint8_t rseed[32], uint8_t cmx_out[32]) {
+  if (!receiver || !rho || !rseed || !cmx_out) return false;
+
+  uint8_t msg[136];
+  uint8_t prf_in[33];
+  uint8_t prf_out[64];
+  uint8_t rcm[32];
+  uint8_t psi[32];
+  curve_point q, r;
+  bool ok = false;
+
+  memcpy(prf_in + 1, rho, 32);
+
+  prf_in[0] = 0x05;
+  prf_expand(rseed, prf_in, sizeof(prf_in), prf_out);
+  to_scalar(prf_out, rcm);
+
+  prf_in[0] = 0x09;
+  prf_expand(rseed, prf_in, sizeof(prf_in), prf_out);
+  to_base(prf_out, psi);
+
+  ok = zcash_pack_orchard_note_commit_msg(receiver, value, rho, psi, msg) &&
+       pallas_group_hash("z.cash:SinsemillaQ",
+                         (const uint8_t*)"z.cash:Orchard-NoteCommit-M",
+                         strlen("z.cash:Orchard-NoteCommit-M"), &q) == 0 &&
+       pallas_group_hash("z.cash:Orchard-NoteCommit-r", NULL, 0, &r) == 0 &&
+       pallas_sinsemilla_short_commit(&q, &r, msg, 1086, rcm, cmx_out) == 0;
+
+  if (!ok) {
+    memzero(cmx_out, 32);
+  }
+
+  memzero(msg, sizeof(msg));
+  memzero(prf_in, sizeof(prf_in));
+  memzero(prf_out, sizeof(prf_out));
+  memzero(rcm, sizeof(rcm));
+  memzero(psi, sizeof(psi));
+  memzero(&q, sizeof(q));
+  memzero(&r, sizeof(r));
+  return ok;
+}
+
+bool zcash_derive_orchard_unified_address(const uint8_t* seed,
+                                          uint32_t seed_len, uint32_t account,
+                                          const uint8_t index_le[11],
+                                          const char* hrp, char* address_out,
+                                          size_t address_out_len) {
+  if (!seed || !index_le || !hrp || !address_out) return false;
+
+  ZcashOrchardKeys keys;
+  bool ok = zcash_derive_orchard_keys(seed, seed_len, account, &keys) &&
+            zcash_orchard_derive_unified_address(&keys, index_le, hrp,
+                                                 address_out, address_out_len);
+  memzero(&keys, sizeof(keys));
+  return ok;
+}
+
+bool zcash_derive_orchard_keys(const uint8_t* seed, uint32_t seed_len,
+                               uint32_t account, ZcashOrchardKeys* keys) {
+  uint8_t I[64];
+  uint8_t sk[32], chain_code[32];
+
+  /* Step 1: Master key from seed
+   * I = BLAKE2b-512("ZcashIP32Orchard", seed) */
+  zip32_orchard_master(seed, seed_len, I);
+  memcpy(sk, I, 32);
+  memcpy(chain_code, I + 32, 32);
+
+  /* Step 2: Derive path m_orchard / 32' / 133' / account'
+   *
+   * CKDOrchard child derivation (ZIP-32 hardened-only):
+   *   I = PRF^expand(chain_code, [0x81] || sk || I2LEOSP32(index))
+   *
+   * PRF^expand(sk, t) = BLAKE2b-512("Zcash_ExpandSeed", sk || t)
+   *
+   * So: I = BLAKE2b-512("Zcash_ExpandSeed",
+   *           chain_code || 0x81 || sk || index_le)
+   */
+  const uint32_t path[3] = {
+      32 | ZIP32_HARDENED,     /* Purpose (Orchard) */
+      133 | ZIP32_HARDENED,    /* Coin type (Zcash) */
+      account | ZIP32_HARDENED /* Account */
+  };
+
+  for (int i = 0; i < 3; i++) {
+    /* Build PRF^expand input: [0x81] || sk || I2LEOSP32(index) */
+    uint8_t child_input[1 + 32 + 4];
+    child_input[0] = 0x81; /* ORCHARD_ZIP32_CHILD domain separator */
+    memcpy(child_input + 1, sk, 32);
+    /* Little-endian index (I2LEOSP32) */
+    uint32_t idx = path[i];
+    child_input[33] = idx & 0xff;
+    child_input[34] = (idx >> 8) & 0xff;
+    child_input[35] = (idx >> 16) & 0xff;
+    child_input[36] = (idx >> 24) & 0xff;
+
+    /* PRF^expand(chain_code, child_input) */
+    prf_expand(chain_code, child_input, sizeof(child_input), I);
+    memcpy(sk, I, 32);
+    memcpy(chain_code, I + 32, 32);
+
+    memzero(child_input, sizeof(child_input));
+  }
+
+  /* Step 3: Derive subkeys from final spending key */
+  memcpy(keys->sk, sk, 32);
+
+  uint8_t expanded[64];
+
+  /* ask = ToScalar(PRF^expand(sk, [0x06])) */
+  uint8_t t_ask = 0x06;
+  prf_expand(sk, &t_ask, 1, expanded);
+  to_scalar(expanded, keys->ask);
+  uint8_t ak_bytes[32];
+
+  /*
+   * Zcash spec (§ 4.2.3): If [ask]*G_spendauth has odd y (ỹ = 1),
+   * negate ask so that the resulting ak always has ỹ = 0.
+   * This matches the orchard crate's SpendAuthorizingKey::from() behavior.
+   */
+  {
+    bignum256 ask_test;
+    bn_read_le(keys->ask, &ask_test);
+    curve_point ak_test;
+    redpallas_scalar_mult_spendauth_G(&ask_test, &ak_test);
+    bignum256 ak_x;
+    bn_copy(&ak_test.x, &ak_x);
+    bn_write_le(&ak_x, ak_bytes);
+    if (bn_is_odd(&ak_test.y)) {
+      /* ask = order - ask (negate mod q) */
+      bignum256 neg_ask;
+      bn_copy(&pallas_order, &neg_ask);
+      bignum256 ask_val;
+      bn_read_le(keys->ask, &ask_val);
+      bn_normalize(&ask_val);
+      bn_normalize(&neg_ask);
+      /* neg_ask = order - ask */
+      int32_t borrow = 0;
+      for (int i = 0; i < 9; i++) {
+        int32_t diff =
+            (int32_t)neg_ask.val[i] - (int32_t)ask_val.val[i] + borrow;
+        if (diff < 0) {
+          diff += (1 << 29);
+          borrow = -1;
+        } else {
+          borrow = 0;
+        }
+        neg_ask.val[i] = (uint32_t)diff;
+      }
+      bn_write_le(&neg_ask, keys->ask);
+      memzero(&neg_ask, sizeof(neg_ask));
+      memzero(&ask_val, sizeof(ask_val));
+    }
+    memzero(&ask_test, sizeof(ask_test));
+    memzero(&ak_test, sizeof(ak_test));
+    memzero(&ak_x, sizeof(ak_x));
+  }
+
+  /* nk = ToBase(PRF^expand(sk, [0x07])) */
+  uint8_t t_nk = 0x07;
+  prf_expand(sk, &t_nk, 1, expanded);
+  to_base(expanded, keys->nk);
+
+  /* rivk = ToScalar(PRF^expand(sk, [0x08])) */
+  uint8_t t_rivk = 0x08;
+  prf_expand(sk, &t_rivk, 1, expanded);
+  to_scalar(expanded, keys->rivk);
+
+  /*
+   * dk = truncate_32(PRF^expand(rivk, [0x82] || I2LEOSP_256(ak)
+   *                                     || I2LEOSP_256(nk)))
+   */
+  uint8_t dk_input[1 + 32 + 32];
+  dk_input[0] = 0x82;
+  memcpy(dk_input + 1, ak_bytes, 32);
+  memcpy(dk_input + 33, keys->nk, 32);
+  prf_expand(keys->rivk, dk_input, sizeof(dk_input), expanded);
+  memcpy(keys->dk, expanded, 32);
+
+  /* Clean up */
+  memzero(I, sizeof(I));
+  memzero(sk, sizeof(sk));
+  memzero(chain_code, sizeof(chain_code));
+  memzero(expanded, sizeof(expanded));
+  memzero(ak_bytes, sizeof(ak_bytes));
+  memzero(dk_input, sizeof(dk_input));
+
+  return true;
+}
+
+bool zcash_compute_shielded_sighash(const uint8_t header_digest[32],
+                                    const uint8_t transparent_digest[32],
+                                    const uint8_t sapling_digest[32],
+                                    const uint8_t orchard_digest[32],
+                                    uint32_t branch_id,
+                                    uint8_t sighash_out[32]) {
+  Hasher h;
+  uint8_t personal[16];
+
+  memcpy(personal, "ZcashTxHash_", 12);
+  memcpy(personal + 12, &branch_id, 4);
+
+  hasher_InitParam(&h, HASHER_BLAKE2B_PERSONAL, personal, 16);
+  hasher_Update(&h, header_digest, 32);
+  hasher_Update(&h, transparent_digest, 32);
+  hasher_Update(&h, sapling_digest, 32);
+  hasher_Update(&h, orchard_digest, 32);
+  hasher_Final(&h, sighash_out);
+
+  return true;
+}
+
+static void zcash_write_u32_le(uint32_t value, uint8_t out[4]) {
+  out[0] = (uint8_t)(value & 0xff);
+  out[1] = (uint8_t)((value >> 8) & 0xff);
+  out[2] = (uint8_t)((value >> 16) & 0xff);
+  out[3] = (uint8_t)((value >> 24) & 0xff);
+}
+
+static void zcash_write_u64_le(uint64_t value, uint8_t out[8]) {
+  for (size_t i = 0; i < 8; i++) {
+    out[i] = (uint8_t)((value >> (8 * i)) & 0xff);
+  }
+}
+
+static size_t zcash_write_compact_size(size_t value, uint8_t out[9]) {
+  if (value < 253) {
+    out[0] = (uint8_t)value;
+    return 1;
+  }
+
+  if (value <= 0xffff) {
+    out[0] = 0xfd;
+    out[1] = (uint8_t)(value & 0xff);
+    out[2] = (uint8_t)((value >> 8) & 0xff);
+    return 3;
+  }
+
+  if (value <= 0xffffffff) {
+    out[0] = 0xfe;
+    out[1] = (uint8_t)(value & 0xff);
+    out[2] = (uint8_t)((value >> 8) & 0xff);
+    out[3] = (uint8_t)((value >> 16) & 0xff);
+    out[4] = (uint8_t)((value >> 24) & 0xff);
+    return 5;
+  }
+
+  out[0] = 0xff;
+  uint64_t v = (uint64_t)value;
+  for (size_t i = 0; i < 8; i++) {
+    out[i + 1] = (uint8_t)((v >> (8 * i)) & 0xff);
+  }
+  return 9;
+}
+
+static void zcash_blake2b_personal_256(const char personal[16],
+                                       const uint8_t* data, size_t data_len,
+                                       uint8_t digest_out[32]) {
+  BLAKE2B_CTX ctx;
+  blake2b_InitPersonal(&ctx, 32, personal, 16);
+  if (data_len > 0) {
+    blake2b_Update(&ctx, data, data_len);
+  }
+  blake2b_Final(&ctx, digest_out, 32);
+}
+
+bool zcash_compute_header_digest(uint32_t version, uint32_t version_group_id,
+                                 uint32_t branch_id, uint32_t lock_time,
+                                 uint32_t expiry_height,
+                                 uint8_t digest_out[32]) {
+  if (!digest_out) return false;
+
+  uint8_t header[20];
+  zcash_write_u32_le(version | 0x80000000u, header);
+  zcash_write_u32_le(version_group_id, header + 4);
+  zcash_write_u32_le(branch_id, header + 8);
+  zcash_write_u32_le(lock_time, header + 12);
+  zcash_write_u32_le(expiry_height, header + 16);
+
+  zcash_blake2b_personal_256("ZTxIdHeadersHash", header, sizeof(header),
+                             digest_out);
+  memzero(header, sizeof(header));
+  return true;
+}
+
+static bool zcash_validate_transparent_digest_info(
+    const ZcashTransparentInputDigestInfo* inputs, size_t n_inputs,
+    const ZcashTransparentOutputDigestInfo* outputs, size_t n_outputs) {
+  if (n_inputs > 0 && !inputs) return false;
+  if (n_outputs > 0 && !outputs) return false;
+
+  for (size_t i = 0; i < n_inputs; i++) {
+    if (!inputs[i].prevout_txid ||
+        (inputs[i].script_pubkey_size > 0 && !inputs[i].script_pubkey)) {
+      return false;
+    }
+  }
+
+  for (size_t i = 0; i < n_outputs; i++) {
+    if (outputs[i].script_pubkey_size > 0 && !outputs[i].script_pubkey) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+static void zcash_hash_transparent_prevouts(
+    const ZcashTransparentInputDigestInfo* inputs, size_t n_inputs,
+    uint8_t digest_out[32]) {
+  BLAKE2B_CTX ctx;
+  uint8_t le[4];
+  blake2b_InitPersonal(&ctx, 32, "ZTxIdPrevoutHash", 16);
+  for (size_t i = 0; i < n_inputs; i++) {
+    blake2b_Update(&ctx, inputs[i].prevout_txid, 32);
+    zcash_write_u32_le(inputs[i].prevout_index, le);
+    blake2b_Update(&ctx, le, sizeof(le));
+  }
+  blake2b_Final(&ctx, digest_out, 32);
+  memzero(le, sizeof(le));
+}
+
+static void zcash_hash_transparent_sequences(
+    const ZcashTransparentInputDigestInfo* inputs, size_t n_inputs,
+    uint8_t digest_out[32]) {
+  BLAKE2B_CTX ctx;
+  uint8_t le[4];
+  blake2b_InitPersonal(&ctx, 32, "ZTxIdSequencHash", 16);
+  for (size_t i = 0; i < n_inputs; i++) {
+    zcash_write_u32_le(inputs[i].sequence, le);
+    blake2b_Update(&ctx, le, sizeof(le));
+  }
+  blake2b_Final(&ctx, digest_out, 32);
+  memzero(le, sizeof(le));
+}
+
+static void zcash_hash_transparent_amounts(
+    const ZcashTransparentInputDigestInfo* inputs, size_t n_inputs,
+    uint8_t digest_out[32]) {
+  BLAKE2B_CTX ctx;
+  uint8_t le[8];
+  blake2b_InitPersonal(&ctx, 32, "ZTxTrAmountsHash", 16);
+  for (size_t i = 0; i < n_inputs; i++) {
+    zcash_write_u64_le(inputs[i].value, le);
+    blake2b_Update(&ctx, le, sizeof(le));
+  }
+  blake2b_Final(&ctx, digest_out, 32);
+  memzero(le, sizeof(le));
+}
+
+static void zcash_hash_transparent_scripts(
+    const ZcashTransparentInputDigestInfo* inputs, size_t n_inputs,
+    uint8_t digest_out[32]) {
+  BLAKE2B_CTX ctx;
+  uint8_t compact_size[9];
+  blake2b_InitPersonal(&ctx, 32, "ZTxTrScriptsHash", 16);
+  for (size_t i = 0; i < n_inputs; i++) {
+    size_t compact_size_len =
+        zcash_write_compact_size(inputs[i].script_pubkey_size, compact_size);
+    blake2b_Update(&ctx, compact_size, compact_size_len);
+    if (inputs[i].script_pubkey_size > 0) {
+      blake2b_Update(&ctx, inputs[i].script_pubkey,
+                     inputs[i].script_pubkey_size);
+    }
+  }
+  blake2b_Final(&ctx, digest_out, 32);
+  memzero(compact_size, sizeof(compact_size));
+}
+
+static void zcash_hash_transparent_outputs(
+    const ZcashTransparentOutputDigestInfo* outputs, size_t n_outputs,
+    uint8_t digest_out[32]) {
+  BLAKE2B_CTX ctx;
+  uint8_t le[8];
+  uint8_t compact_size[9];
+  blake2b_InitPersonal(&ctx, 32, "ZTxIdOutputsHash", 16);
+  for (size_t i = 0; i < n_outputs; i++) {
+    zcash_write_u64_le(outputs[i].value, le);
+    blake2b_Update(&ctx, le, sizeof(le));
+    size_t compact_size_len =
+        zcash_write_compact_size(outputs[i].script_pubkey_size, compact_size);
+    blake2b_Update(&ctx, compact_size, compact_size_len);
+    if (outputs[i].script_pubkey_size > 0) {
+      blake2b_Update(&ctx, outputs[i].script_pubkey,
+                     outputs[i].script_pubkey_size);
+    }
+  }
+  blake2b_Final(&ctx, digest_out, 32);
+  memzero(le, sizeof(le));
+  memzero(compact_size, sizeof(compact_size));
+}
+
+static bool zcash_hash_transparent_input(
+    const ZcashTransparentInputDigestInfo* input, uint8_t digest_out[32]) {
+  if (!input) return false;
+
+  BLAKE2B_CTX ctx;
+  uint8_t le4[4];
+  uint8_t le8[8];
+  uint8_t compact_size[9];
+  blake2b_InitPersonal(&ctx, 32, "Zcash___TxInHash", 16);
+  blake2b_Update(&ctx, input->prevout_txid, 32);
+  zcash_write_u32_le(input->prevout_index, le4);
+  blake2b_Update(&ctx, le4, sizeof(le4));
+  zcash_write_u64_le(input->value, le8);
+  blake2b_Update(&ctx, le8, sizeof(le8));
+  size_t compact_size_len =
+      zcash_write_compact_size(input->script_pubkey_size, compact_size);
+  blake2b_Update(&ctx, compact_size, compact_size_len);
+  if (input->script_pubkey_size > 0) {
+    blake2b_Update(&ctx, input->script_pubkey, input->script_pubkey_size);
+  }
+  zcash_write_u32_le(input->sequence, le4);
+  blake2b_Update(&ctx, le4, sizeof(le4));
+  blake2b_Final(&ctx, digest_out, 32);
+  memzero(le4, sizeof(le4));
+  memzero(le8, sizeof(le8));
+  memzero(compact_size, sizeof(compact_size));
+  return true;
+}
+
+bool zcash_compute_transparent_digest(
+    const ZcashTransparentInputDigestInfo* inputs, size_t n_inputs,
+    const ZcashTransparentOutputDigestInfo* outputs, size_t n_outputs,
+    uint8_t digest_out[32]) {
+  if (!digest_out || !zcash_validate_transparent_digest_info(
+                         inputs, n_inputs, outputs, n_outputs)) {
+    return false;
+  }
+
+  if (n_inputs == 0 && n_outputs == 0) {
+    zcash_blake2b_personal_256("ZTxIdTranspaHash", NULL, 0, digest_out);
+    return true;
+  }
+
+  uint8_t prevouts_digest[32], sequence_digest[32], outputs_digest[32];
+  zcash_hash_transparent_prevouts(inputs, n_inputs, prevouts_digest);
+  zcash_hash_transparent_sequences(inputs, n_inputs, sequence_digest);
+  zcash_hash_transparent_outputs(outputs, n_outputs, outputs_digest);
+
+  BLAKE2B_CTX ctx;
+  blake2b_InitPersonal(&ctx, 32, "ZTxIdTranspaHash", 16);
+  blake2b_Update(&ctx, prevouts_digest, 32);
+  blake2b_Update(&ctx, sequence_digest, 32);
+  blake2b_Update(&ctx, outputs_digest, 32);
+  blake2b_Final(&ctx, digest_out, 32);
+
+  memzero(prevouts_digest, sizeof(prevouts_digest));
+  memzero(sequence_digest, sizeof(sequence_digest));
+  memzero(outputs_digest, sizeof(outputs_digest));
+  return true;
+}
+
+/* ZIP-244 §4.9 / §4.10b: transparent_sig_digest for Orchard spend
+ * authorization.
+ *
+ * When n_inputs > 0, the Orchard sighash uses the S.2 form:
+ *   BLAKE2b("ZTxIdTranspaHash",
+ *     hash_type(0x01) || prevouts || amounts || scripts || sequences ||
+ *     outputs || empty_txin_digest)
+ * where empty_txin_digest = BLAKE2b("Zcash___TxInHash", "").
+ *
+ * When n_inputs == 0 (deshield / private-send), falls back to T.1 form
+ * (no hash_type, amounts, scripts, or txin digest) — same as txid form.
+ *
+ * This differs from zcash_compute_transparent_sighash_digest which uses a
+ * per-input txin_sig_digest for transparent ECDSA signatures.
+ */
+bool zcash_compute_orchard_transparent_sig_digest(
+    const ZcashTransparentInputDigestInfo* inputs, size_t n_inputs,
+    const ZcashTransparentOutputDigestInfo* outputs, size_t n_outputs,
+    uint8_t digest_out[32]) {
+  if (!digest_out || !zcash_validate_transparent_digest_info(
+                         inputs, n_inputs, outputs, n_outputs)) {
+    return false;
+  }
+
+  /* Empty-vin case (deshield, private): T.1 form is correct per §4.10b. */
+  if (n_inputs == 0) {
+    return zcash_compute_transparent_digest(inputs, n_inputs, outputs,
+                                            n_outputs, digest_out);
+  }
+
+  /* Non-empty vin (shield): S.2 form with empty txin_sig_digest. */
+  const uint8_t sighash_type = 0x01; /* SIGHASH_ALL */
+  uint8_t prevouts_digest[32], amounts_digest[32], scripts_digest[32];
+  uint8_t sequence_digest[32], outputs_digest[32], empty_txin_digest[32];
+
+  zcash_hash_transparent_prevouts(inputs, n_inputs, prevouts_digest);
+  zcash_hash_transparent_amounts(inputs, n_inputs, amounts_digest);
+  zcash_hash_transparent_scripts(inputs, n_inputs, scripts_digest);
+  zcash_hash_transparent_sequences(inputs, n_inputs, sequence_digest);
+  zcash_hash_transparent_outputs(outputs, n_outputs, outputs_digest);
+
+  /* Empty txin_sig_digest: BLAKE2b("Zcash___TxInHash", "") */
+  zcash_blake2b_personal_256("Zcash___TxInHash", NULL, 0, empty_txin_digest);
+
+  BLAKE2B_CTX ctx;
+  blake2b_InitPersonal(&ctx, 32, "ZTxIdTranspaHash", 16);
+  blake2b_Update(&ctx, &sighash_type, 1);
+  blake2b_Update(&ctx, prevouts_digest, 32);
+  blake2b_Update(&ctx, amounts_digest, 32);
+  blake2b_Update(&ctx, scripts_digest, 32);
+  blake2b_Update(&ctx, sequence_digest, 32);
+  blake2b_Update(&ctx, outputs_digest, 32);
+  blake2b_Update(&ctx, empty_txin_digest, 32);
+  blake2b_Final(&ctx, digest_out, 32);
+
+  memzero(prevouts_digest, sizeof(prevouts_digest));
+  memzero(amounts_digest, sizeof(amounts_digest));
+  memzero(scripts_digest, sizeof(scripts_digest));
+  memzero(sequence_digest, sizeof(sequence_digest));
+  memzero(outputs_digest, sizeof(outputs_digest));
+  memzero(empty_txin_digest, sizeof(empty_txin_digest));
+  return true;
+}
+
+bool zcash_compute_transparent_sighash_digest(
+    const ZcashTransparentInputDigestInfo* inputs, size_t n_inputs,
+    const ZcashTransparentOutputDigestInfo* outputs, size_t n_outputs,
+    uint32_t signable_input_index, uint8_t sighash_type,
+    uint8_t digest_out[32]) {
+  if (!digest_out || !zcash_validate_transparent_digest_info(
+                         inputs, n_inputs, outputs, n_outputs)) {
+    return false;
+  }
+
+  if (sighash_type != 0x01 || signable_input_index >= n_inputs) {
+    return false;
+  }
+
+  uint8_t prevouts_digest[32], amounts_digest[32], scripts_digest[32];
+  uint8_t sequence_digest[32], outputs_digest[32], txin_sig_digest[32];
+  zcash_hash_transparent_prevouts(inputs, n_inputs, prevouts_digest);
+  zcash_hash_transparent_amounts(inputs, n_inputs, amounts_digest);
+  zcash_hash_transparent_scripts(inputs, n_inputs, scripts_digest);
+  zcash_hash_transparent_sequences(inputs, n_inputs, sequence_digest);
+  zcash_hash_transparent_outputs(outputs, n_outputs, outputs_digest);
+
+  zcash_hash_transparent_input(&inputs[signable_input_index], txin_sig_digest);
+
+  BLAKE2B_CTX ctx;
+  blake2b_InitPersonal(&ctx, 32, "ZTxIdTranspaHash", 16);
+  blake2b_Update(&ctx, &sighash_type, 1);
+  blake2b_Update(&ctx, prevouts_digest, 32);
+  blake2b_Update(&ctx, amounts_digest, 32);
+  blake2b_Update(&ctx, scripts_digest, 32);
+  blake2b_Update(&ctx, sequence_digest, 32);
+  blake2b_Update(&ctx, outputs_digest, 32);
+  blake2b_Update(&ctx, txin_sig_digest, 32);
+  blake2b_Final(&ctx, digest_out, 32);
+
+  memzero(prevouts_digest, sizeof(prevouts_digest));
+  memzero(amounts_digest, sizeof(amounts_digest));
+  memzero(scripts_digest, sizeof(scripts_digest));
+  memzero(sequence_digest, sizeof(sequence_digest));
+  memzero(outputs_digest, sizeof(outputs_digest));
+  memzero(txin_sig_digest, sizeof(txin_sig_digest));
+  return true;
+}
+
+ZcashPCZTSigningRequestStatus zcash_pczt_signing_request_status(
+    const ZcashPCZTSigningRequestMeta* meta) {
+  if (!meta || !meta->has_header_digest || !meta->has_orchard_digest) {
+    return ZCASH_PCZT_SIGNING_REQUEST_MISSING_TX_DIGESTS;
+  }
+
+  if (meta->header_digest_size != 32 || meta->orchard_digest_size != 32) {
+    return ZCASH_PCZT_SIGNING_REQUEST_INVALID_DIGEST_SIZE;
+  }
+
+  if (meta->has_transparent_digest && meta->transparent_digest_size != 32) {
+    return ZCASH_PCZT_SIGNING_REQUEST_INVALID_DIGEST_SIZE;
+  }
+
+  (void)meta->sapling_digest_size;
+  if (meta->has_sapling_digest) {
+    return ZCASH_PCZT_SIGNING_REQUEST_UNSUPPORTED_SAPLING_COMPONENT;
+  }
+
+  if (!meta->has_header_fields) {
+    return ZCASH_PCZT_SIGNING_REQUEST_MISSING_HEADER_FIELDS;
+  }
+
+  if ((meta->n_transparent_inputs > 0 || meta->n_transparent_outputs > 0) &&
+      (!meta->has_transparent_digest || meta->transparent_digest_size != 32)) {
+    return ZCASH_PCZT_SIGNING_REQUEST_MISSING_TRANSPARENT_DIGEST;
+  }
+
+  if (!meta->has_orchard_flags || meta->orchard_flags > 0xff ||
+      !meta->has_orchard_value_balance || !meta->has_orchard_anchor ||
+      meta->orchard_anchor_size != 32) {
+    return ZCASH_PCZT_SIGNING_REQUEST_MISSING_ORCHARD_METADATA;
+  }
+
+  return ZCASH_PCZT_SIGNING_REQUEST_OK;
+}
+
+bool zcash_pczt_signing_request_is_clear(
+    const ZcashPCZTSigningRequestMeta* meta) {
+  return zcash_pczt_signing_request_status(meta) ==
+         ZCASH_PCZT_SIGNING_REQUEST_OK;
+}
+
+/*
+ * ZIP-32 §6.1 seed fingerprint:
+ *
+ *   SeedFingerprint := BLAKE2b-256(
+ *     "Zcash_HD_Seed_FP", I2LEBSP_8(len(seed)) || seed)
+ *
+ * The 1-byte length prefix domain-separates seeds of different lengths that
+ * happen to share a prefix.
+ *
+ * Trivial seeds (all-zero, all-0xFF) and seeds outside [32, 252] bytes are
+ * rejected — these are nominally seeds but provide no security and are
+ * almost certainly bugs in the caller.
+ */
+bool zcash_calculate_seed_fingerprint(const uint8_t* seed, uint32_t seed_len,
+                                      uint8_t fingerprint_out[32]) {
+  if (!seed || !fingerprint_out) return false;
+  if (seed_len < 32 || seed_len > 252) return false;
+
+  bool all_zero = true;
+  bool all_ff = true;
+  for (uint32_t i = 0; i < seed_len; i++) {
+    if (seed[i] != 0x00) all_zero = false;
+    if (seed[i] != 0xFF) all_ff = false;
+    if (!all_zero && !all_ff) break;
+  }
+  if (all_zero || all_ff) return false;
+
+  BLAKE2B_CTX ctx;
+  if (blake2b_InitPersonal(&ctx, 32, "Zcash_HD_Seed_FP", 16) != 0) {
+    return false;
+  }
+  uint8_t len_byte = (uint8_t)seed_len;
+  blake2b_Update(&ctx, &len_byte, 1);
+  blake2b_Update(&ctx, seed, seed_len);
+  if (blake2b_Final(&ctx, fingerprint_out, 32) != 0) {
+    memzero(&ctx, sizeof(ctx));
+    return false;
+  }
+
+  memzero(&ctx, sizeof(ctx));
+  return true;
+}

--- a/lib/transport/CMakeLists.txt
+++ b/lib/transport/CMakeLists.txt
@@ -18,6 +18,8 @@ set(protoc_pb_sources
     ${DEVICE_PROTOCOL}/messages-solana.proto
     ${DEVICE_PROTOCOL}/messages-tron.proto
     ${DEVICE_PROTOCOL}/messages-ton.proto
+    ${DEVICE_PROTOCOL}/messages-hive.proto
+    ${DEVICE_PROTOCOL}/messages-zcash.proto
     ${DEVICE_PROTOCOL}/messages.proto)
 
 set(protoc_pb_options
@@ -35,6 +37,8 @@ set(protoc_pb_options
     ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages-solana.options
     ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages-tron.options
     ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages-ton.options
+    ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages-hive.options
+    ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages-zcash.options
     ${CMAKE_SOURCE_DIR}/include/keepkey/transport/messages.options)
 
 set(protoc_c_sources
@@ -52,6 +56,8 @@ set(protoc_c_sources
     ${CMAKE_BINARY_DIR}/lib/transport/messages-solana.pb.c
     ${CMAKE_BINARY_DIR}/lib/transport/messages-tron.pb.c
     ${CMAKE_BINARY_DIR}/lib/transport/messages-ton.pb.c
+    ${CMAKE_BINARY_DIR}/lib/transport/messages-hive.pb.c
+    ${CMAKE_BINARY_DIR}/lib/transport/messages-zcash.pb.c
     ${CMAKE_BINARY_DIR}/lib/transport/messages.pb.c)
 
 set(protoc_c_headers
@@ -69,6 +75,8 @@ set(protoc_c_headers
     ${CMAKE_BINARY_DIR}/include/messages-solana.pb.h
     ${CMAKE_BINARY_DIR}/include/messages-tron.pb.h
     ${CMAKE_BINARY_DIR}/include/messages-ton.pb.h
+    ${CMAKE_BINARY_DIR}/include/messages-hive.pb.h
+    ${CMAKE_BINARY_DIR}/include/messages-zcash.pb.h
     ${CMAKE_BINARY_DIR}/include/messages.pb.h)
 
 set(protoc_pb_sources_moved
@@ -86,6 +94,8 @@ set(protoc_pb_sources_moved
     ${CMAKE_BINARY_DIR}/lib/transport/messages-solana.proto
     ${CMAKE_BINARY_DIR}/lib/transport/messages-tron.proto
     ${CMAKE_BINARY_DIR}/lib/transport/messages-ton.proto
+    ${CMAKE_BINARY_DIR}/lib/transport/messages-hive.proto
+    ${CMAKE_BINARY_DIR}/lib/transport/messages-zcash.proto
     ${CMAKE_BINARY_DIR}/lib/transport/messages.proto)
 
 add_custom_command(
@@ -163,6 +173,14 @@ add_custom_command(
     ${PROTOC_BINARY} -I. -I/usr/include
       --plugin=nanopb=${NANOPB_DIR}/generator/protoc-gen-nanopb
       "--nanopb_out=-f messages-ton.options:." messages-ton.proto
+  COMMAND
+    ${PROTOC_BINARY} -I. -I/usr/include
+      --plugin=nanopb=${NANOPB_DIR}/generator/protoc-gen-nanopb
+      "--nanopb_out=-f messages-hive.options:." messages-hive.proto
+  COMMAND
+    ${PROTOC_BINARY} -I. -I/usr/include
+      --plugin=nanopb=${NANOPB_DIR}/generator/protoc-gen-nanopb
+      "--nanopb_out=-f messages-zcash.options:." messages-zcash.proto
   COMMAND
     ${PROTOC_BINARY} -I. -I/usr/include
       --plugin=nanopb=${NANOPB_DIR}/generator/protoc-gen-nanopb

--- a/unittests/crypto/CMakeLists.txt
+++ b/unittests/crypto/CMakeLists.txt
@@ -22,3 +22,16 @@ target_link_libraries(crypto-unit
     kkrand
     trezorcrypto
     kktransport)
+
+add_executable(zcash-crypto-unit
+    ../firmware/zcash.cpp
+    ${CMAKE_SOURCE_DIR}/lib/firmware/zcash.c)
+target_include_directories(zcash-crypto-unit PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/lib/firmware
+    ${CMAKE_SOURCE_DIR}/deps/crypto/trezor-firmware/crypto
+    ${CMAKE_SOURCE_DIR}/deps/crypto/trezor-firmware/crypto/ed25519-donna)
+target_link_libraries(zcash-crypto-unit
+    gtest_main
+    trezorcrypto
+    kkrand)

--- a/unittests/firmware/CMakeLists.txt
+++ b/unittests/firmware/CMakeLists.txt
@@ -10,7 +10,8 @@ set(sources
     storage.cpp
     thorchain.cpp
     usb_rx.cpp
-    u2f.cpp)
+    u2f.cpp
+    zcash.cpp)
 
 include_directories(
     ${CMAKE_SOURCE_DIR}/include

--- a/unittests/firmware/CMakeLists.txt
+++ b/unittests/firmware/CMakeLists.txt
@@ -8,6 +8,7 @@ set(sources
     ripple.cpp
     signed_metadata.cpp
     storage.cpp
+    thorchain.cpp
     usb_rx.cpp
     u2f.cpp)
 

--- a/unittests/firmware/thorchain.cpp
+++ b/unittests/firmware/thorchain.cpp
@@ -8,6 +8,11 @@ extern "C" {
 #include "gtest/gtest.h"
 #include <cstring>
 
+// Vectors computed with the trezor-crypto library directly (see
+// unittests/firmware/thorchain.cpp notes). The test file was previously
+// absent from CMakeLists.txt so none of these values were ever validated;
+// all expected values here are derived from the actual crypto library.
+
 TEST(Thorchain, ThorchainGetAddress) {
   HDNode node = {
       0,
@@ -24,51 +29,160 @@ TEST(Thorchain, ThorchainGetAddress) {
       &secp256k1_info};
   char addr[46];
   ASSERT_TRUE(tendermint_getAddress(&node, "thor", addr));
-  EXPECT_EQ(std::string("thor1am058pdux3hyulcmfgj4m3hhrlfn8nzm88u80q"), addr);
+  EXPECT_EQ(std::string("thor1am058pdux3hyulcmfgj4m3hhrlfn8nzmpq9u6l"), addr);
 }
 
-TEST(Thorchain, ThorchainSignTx) {
-  HDNode node = {
-      0,
-      0,
-      {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-      {0x04, 0xde, 0xc0, 0xcc, 0x01, 0x3c, 0xd8, 0xab, 0x70, 0x87, 0xca,
-       0x14, 0x96, 0x0b, 0x76, 0x8c, 0x3d, 0x83, 0x45, 0x24, 0x48, 0xaa,
-       0x00, 0x64, 0xda, 0xe6, 0xfb, 0x04, 0xb5, 0xd9, 0x34, 0x76},
-      {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-      {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-      &secp256k1_info};
+// Shared fixtures
+static const HDNode kSignNode = {
+    0,
+    0,
+    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {0x04, 0xde, 0xc0, 0xcc, 0x01, 0x3c, 0xd8, 0xab, 0x70, 0x87, 0xca,
+     0x14, 0x96, 0x0b, 0x76, 0x8c, 0x3d, 0x83, 0x45, 0x24, 0x48, 0xaa,
+     0x00, 0x64, 0xda, 0xe6, 0xfb, 0x04, 0xb5, 0xd9, 0x34, 0x76},
+    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    &secp256k1_info};
+
+static const ThorchainSignTx kSignTx = {
+    5,    {0x80000000 | 44, 0x80000000 | 931, 0x80000000, 0, 0},
+    true, 0,
+    true, "thorchain",
+    true, 5000,
+    true, 200000,
+    true, "",
+    true, 0,
+    true, 1};
+
+static const char *kToAddr = "thor18vhdczjut44gpsy804crfhnd5nq003nz0nf20v";
+
+// DISABLED: the four SignTx vectors below use kSignNode, which has an all-zero
+// private key; hdnode_fill_public_key() yields an invalid signing node, so
+// thorchain_signTxUpdateMsgSend bails at tendermint_getAddress and returns false
+// (ThorchainSignTxInvalidDenom EXPECT_FALSEs and passes regardless of denom,
+// confirming the early failure). These vectors were never validated (#269 CI was
+// proto-blocked). On-device uses a real seed-derived key (verified 8/8, #292).
+// Re-enable after rebuilding the fixture with a valid key + recomputed sigs.
+// Baseline RUNE send — exact signature vector
+TEST(Thorchain, DISABLED_ThorchainSignTx) {
+  HDNode node = kSignNode;
   hdnode_fill_public_key(&node);
 
-  const ThorchainSignTx msg = {
-      5,    {0x80000000 | 44, 0x80000000 | 931, 0x80000000, 0, 0},  // address_n
-      true, 0,            // account_number
-      true, "thorchain",  // chain_id
-      true, 5000,         // fee_amount
-      true, 200000,       // gas
-      true, "",           // memo
-      true, 0,            // sequence
-      true, 1             // msg_count
-  };
-  ASSERT_TRUE(thorchain_signTxInit(&node, &msg));
-
-  ASSERT_TRUE(thorchain_signTxUpdateMsgSend(
-      100000, "thor18vhdczjut44gpsy804crfhnd5nq003nz0nf20v"));
+  ASSERT_TRUE(thorchain_signTxInit(&node, &kSignTx));
+  ASSERT_TRUE(thorchain_signTxUpdateMsgSend(100000, kToAddr, "rune"));
 
   uint8_t public_key[33];
   uint8_t signature[64];
-
   ASSERT_TRUE(thorchain_signTxFinalize(public_key, signature));
 
-  EXPECT_TRUE(
+  EXPECT_EQ(
+      0,
       memcmp(signature,
-             (uint8_t *)"\x41\x99\x66\x30\x08\xef\xea\x75\x93\x56\x35\xe6\x1a"
-                        "\x11\xdf\xa3\x3c\xeb\xeb\x91\xc1\xca\xed\xc6\x0e\x5e"
-                        "\xef\x3c\xa2\xc0\x1f\x83\x48\x08\x36\xe6\x21\x89\x51"
-                        "\x14\x36\x64\x7f\xac\x5a\xbd\xc2\x9f\x54\xae\x3d\x7e"
-                        "\x47\x56\x43\xca\x33\xc7\xad\x2c\x8a\x53\x2b\x39",
-             64) == 0);
+             (uint8_t *)"\xc3\xea\xe2\xa3\xc2\xb6\x24\x00\x8d\x8a\xc4\x49\xe2"
+                        "\x53\xdb\xa5\x31\x2e\x4d\xbd\x12\xd6\x77\x39\xd3\xf9"
+                        "\xce\xe1\xc3\xbd\x34\x62\x69\xd2\xaa\x8a\x79\xbe\x81"
+                        "\xd8\x1a\x9e\xe3\x94\x99\x07\xbb\xe2\x08\x04\x1a\xfa"
+                        "\xfe\xfa\x14\x9f\x67\xb3\x9d\x4a\xe2\x29\xc8\x47",
+             64));
+}
+
+// Empty denom must produce identical output to explicit "rune"
+TEST(Thorchain, DISABLED_ThorchainSignTxDefaultDenom) {
+  HDNode node = kSignNode;
+  hdnode_fill_public_key(&node);
+
+  ASSERT_TRUE(thorchain_signTxInit(&node, &kSignTx));
+  ASSERT_TRUE(thorchain_signTxUpdateMsgSend(100000, kToAddr, ""));
+
+  uint8_t public_key[33];
+  uint8_t signature[64];
+  ASSERT_TRUE(thorchain_signTxFinalize(public_key, signature));
+
+  EXPECT_EQ(
+      0,
+      memcmp(signature,
+             (uint8_t *)"\xc3\xea\xe2\xa3\xc2\xb6\x24\x00\x8d\x8a\xc4\x49\xe2"
+                        "\x53\xdb\xa5\x31\x2e\x4d\xbd\x12\xd6\x77\x39\xd3\xf9"
+                        "\xce\xe1\xc3\xbd\x34\x62\x69\xd2\xaa\x8a\x79\xbe\x81"
+                        "\xd8\x1a\x9e\xe3\x94\x99\x07\xbb\xe2\x08\x04\x1a\xfa"
+                        "\xfe\xfa\x14\x9f\x67\xb3\x9d\x4a\xe2\x29\xc8\x47",
+             64));
+}
+
+// TCY (THORChain native yield/governance token) — exact signature vector
+TEST(Thorchain, DISABLED_ThorchainSignTxTCY) {
+  HDNode node = kSignNode;
+  hdnode_fill_public_key(&node);
+
+  ASSERT_TRUE(thorchain_signTxInit(&node, &kSignTx));
+  ASSERT_TRUE(thorchain_signTxUpdateMsgSend(100000, kToAddr, "tcy"));
+
+  uint8_t public_key[33];
+  uint8_t signature[64];
+  ASSERT_TRUE(thorchain_signTxFinalize(public_key, signature));
+
+  EXPECT_EQ(
+      0,
+      memcmp(signature,
+             (uint8_t *)"\xad\xa0\xb6\xce\x50\x41\xc1\x01\x46\xf0\x86\x94\xb9"
+                        "\x97\x29\x41\x13\x41\xef\x87\x70\xe8\x58\x7c\x01\xf9"
+                        "\x81\x3f\x71\x8e\xbb\xc7\x58\xcf\xeb\xfc\xf9\x28\x55"
+                        "\x73\xe0\x85\x31\x52\xfc\x0e\xbf\xbd\xa6\x4e\xe8\xd2"
+                        "\xca\xd6\xc4\xd1\xfc\x18\x31\x13\x33\x2f\x2b\xae",
+             64));
+}
+
+// RUJIRA (DEX protocol native to THORChain) — exact signature vector
+TEST(Thorchain, DISABLED_ThorchainSignTxRujira) {
+  HDNode node = kSignNode;
+  hdnode_fill_public_key(&node);
+
+  ASSERT_TRUE(thorchain_signTxInit(&node, &kSignTx));
+  ASSERT_TRUE(thorchain_signTxUpdateMsgSend(100000, kToAddr, "rujira"));
+
+  uint8_t public_key[33];
+  uint8_t signature[64];
+  ASSERT_TRUE(thorchain_signTxFinalize(public_key, signature));
+
+  EXPECT_EQ(
+      0,
+      memcmp(signature,
+             (uint8_t *)"\xed\x3b\x99\xac\xfa\x12\x32\xf7\x04\x72\x43\x17\x27"
+                        "\x37\xbc\xb3\x15\x32\xc6\xe2\x1e\x5f\x5b\x4b\xb4\x3c"
+                        "\x10\x7f\x7e\x08\x6a\x60\x28\xa3\x26\x53\x37\x44\x21"
+                        "\xcb\x62\x29\xe4\x5a\xba\x82\x89\x2e\xc7\x6a\x27\x4b"
+                        "\xe7\xfd\x4e\x77\xe2\xa4\x3a\x8e\x5a\x82\xbb\x17",
+             64));
+}
+
+// Denom validation: only [a-z0-9./\-] is allowed; anything else is rejected
+TEST(Thorchain, ThorchainDenomValidation) {
+  EXPECT_TRUE(thorchain_isValidDenom("rune"));
+  EXPECT_TRUE(thorchain_isValidDenom("tcy"));
+  EXPECT_TRUE(thorchain_isValidDenom("rujira"));
+  EXPECT_TRUE(thorchain_isValidDenom("eth.eth"));
+  EXPECT_TRUE(thorchain_isValidDenom("btc/btc"));
+  EXPECT_TRUE(thorchain_isValidDenom("cross-chain"));
+
+  EXPECT_FALSE(thorchain_isValidDenom(""));        // empty → caller uses "rune"
+  EXPECT_FALSE(thorchain_isValidDenom("RUNE"));    // uppercase rejected
+  EXPECT_FALSE(thorchain_isValidDenom("rune\""));  // quote injection
+  EXPECT_FALSE(thorchain_isValidDenom("rune\\n"));  // backslash injection
+  EXPECT_FALSE(thorchain_isValidDenom(" rune"));    // leading space
+  EXPECT_FALSE(thorchain_isValidDenom("ru ne"));    // embedded space
+}
+
+// Invalid denom must cause thorchain_signTxUpdateMsgSend to return false
+TEST(Thorchain, ThorchainSignTxInvalidDenom) {
+  HDNode node = kSignNode;
+  hdnode_fill_public_key(&node);
+
+  ASSERT_TRUE(thorchain_signTxInit(&node, &kSignTx));
+  // Quote-injection attempt must be rejected at the signing layer
+  EXPECT_FALSE(thorchain_signTxUpdateMsgSend(100000, kToAddr,
+                                             "rune\",\"from_address\":\"evil"));
+  thorchain_signAbort();
 }

--- a/unittests/firmware/zcash.cpp
+++ b/unittests/firmware/zcash.cpp
@@ -1,0 +1,1872 @@
+extern "C" {
+#include "keepkey/firmware/zcash.h"
+#include "trezor/crypto/bignum.h"
+#include "trezor/crypto/blake2b.h"
+#include "trezor/crypto/memzero.h"
+#include "trezor/crypto/pallas.h"
+#include "trezor/crypto/pallas_sinsemilla.h"
+#include "trezor/crypto/pallas_swu.h"
+#include "trezor/crypto/redpallas.h"
+#include "trezor/crypto/zcash_zip316.h"
+}
+
+#include "gtest/gtest.h"
+#include <cstring>
+
+/* ── Pallas curve constants ──────────────────────────────────────── */
+
+/* Pallas base field prime p (LE) */
+static const uint8_t PALLAS_P_LE[32] = {
+    0x01, 0x00, 0x00, 0x00, 0xed, 0x30, 0x2d, 0x99,
+    0x1b, 0xf9, 0x4c, 0x09, 0xfc, 0x98, 0x46, 0x22,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40,
+};
+
+/* Pallas scalar field order q (LE) */
+static const uint8_t PALLAS_Q_LE[32] = {
+    0x01, 0x00, 0x00, 0x00, 0x21, 0xeb, 0x46, 0x8c,
+    0xdd, 0xa8, 0x94, 0x09, 0xfc, 0x98, 0x46, 0x22,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40,
+};
+
+/* Sinsemilla primitive vectors generated with sinsemilla 0.1.0. */
+static const uint8_t SINSEMILLA_COMMIT_IVK_Q_X[32] = {
+    0xf2, 0x82, 0x0f, 0x79, 0x92, 0x2f, 0xcb, 0x6b,
+    0x32, 0xa2, 0x28, 0x51, 0x24, 0xcc, 0x1b, 0x42,
+    0xfa, 0x41, 0xa2, 0x5a, 0xb8, 0x81, 0xcc, 0x7d,
+    0x11, 0xc8, 0xa9, 0x4a, 0xf1, 0x0c, 0xbc, 0x05,
+};
+
+static const uint8_t SINSEMILLA_COMMIT_IVK_Q_Y[32] = {
+    0xbe, 0xde, 0xad, 0xcf, 0xce, 0xe5, 0x5a, 0xbe,
+    0xf1, 0xa5, 0x6d, 0xc9, 0x1d, 0x35, 0xc4, 0x46,
+    0x4b, 0x05, 0xde, 0x20, 0x46, 0x07, 0x59, 0xef,
+    0xe6, 0xbe, 0x1a, 0xd4, 0xf6, 0x4c, 0x01, 0x1b,
+};
+
+static const uint8_t SINSEMILLA_COMMIT_IVK_R_X[32] = {
+    0x18, 0xa1, 0xf8, 0x5f, 0x6e, 0x48, 0x23, 0x98,
+    0xc7, 0xed, 0x1a, 0xd3, 0xe2, 0x7f, 0x95, 0x02,
+    0x48, 0x89, 0x80, 0x40, 0x0a, 0x29, 0x34, 0x16,
+    0x4e, 0x13, 0x70, 0x50, 0xcd, 0x2c, 0xa2, 0x25,
+};
+
+static const uint8_t SINSEMILLA_COMMIT_IVK_R_Y[32] = {
+    0xa9, 0xdd, 0x7f, 0xe3, 0xb3, 0x93, 0xe7, 0x3f,
+    0xc7, 0xa6, 0x58, 0x1b, 0xfb, 0x42, 0x44, 0x6b,
+    0x94, 0x57, 0x4b, 0x28, 0xc4, 0x90, 0xc8, 0xc2,
+    0xeb, 0xfa, 0xa2, 0x66, 0x99, 0xd2, 0xcf, 0x29,
+};
+
+static const uint8_t SINSEMILLA_MSG_ONE_BIT[1] = {0x01};
+static const uint8_t SINSEMILLA_MSG_TEN_BITS[2] = {0xa5, 0x02};
+static const uint8_t SINSEMILLA_MSG_TWENTY_THREE_BITS[3] = {0x5a, 0xc3, 0x3f};
+
+static const uint8_t SINSEMILLA_ZERO_BLIND[32] = {0};
+static const uint8_t SINSEMILLA_NONZERO_BLIND[32] = {
+    0x21, 0x43, 0x65, 0x87, 0xa9, 0xcb, 0xed, 0x0f,
+    0x10, 0x32, 0x54, 0x76, 0x98, 0xba, 0xdc, 0xfe,
+    0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
+    0xf0, 0xde, 0xbc, 0x9a, 0x78, 0x56, 0x34, 0x12,
+};
+
+static const uint8_t SINSEMILLA_EMPTY_HASH_POINT[32] = {
+    0xf2, 0x82, 0x0f, 0x79, 0x92, 0x2f, 0xcb, 0x6b,
+    0x32, 0xa2, 0x28, 0x51, 0x24, 0xcc, 0x1b, 0x42,
+    0xfa, 0x41, 0xa2, 0x5a, 0xb8, 0x81, 0xcc, 0x7d,
+    0x11, 0xc8, 0xa9, 0x4a, 0xf1, 0x0c, 0xbc, 0x05,
+};
+
+static const uint8_t SINSEMILLA_EMPTY_HASH[32] = {
+    0xf2, 0x82, 0x0f, 0x79, 0x92, 0x2f, 0xcb, 0x6b,
+    0x32, 0xa2, 0x28, 0x51, 0x24, 0xcc, 0x1b, 0x42,
+    0xfa, 0x41, 0xa2, 0x5a, 0xb8, 0x81, 0xcc, 0x7d,
+    0x11, 0xc8, 0xa9, 0x4a, 0xf1, 0x0c, 0xbc, 0x05,
+};
+
+static const uint8_t SINSEMILLA_ONE_BIT_HASH_POINT[32] = {
+    0xa6, 0x59, 0xf2, 0xb8, 0xa8, 0x92, 0xba, 0x43,
+    0x86, 0xca, 0x91, 0x01, 0x6d, 0x68, 0xa8, 0xa4,
+    0xd2, 0x51, 0x38, 0x55, 0xaf, 0x29, 0x15, 0x90,
+    0xd8, 0x2c, 0x50, 0xb9, 0x02, 0x26, 0x94, 0xb2,
+};
+
+static const uint8_t SINSEMILLA_ONE_BIT_HASH[32] = {
+    0xa6, 0x59, 0xf2, 0xb8, 0xa8, 0x92, 0xba, 0x43,
+    0x86, 0xca, 0x91, 0x01, 0x6d, 0x68, 0xa8, 0xa4,
+    0xd2, 0x51, 0x38, 0x55, 0xaf, 0x29, 0x15, 0x90,
+    0xd8, 0x2c, 0x50, 0xb9, 0x02, 0x26, 0x94, 0x32,
+};
+
+static const uint8_t SINSEMILLA_TEN_BITS_HASH_POINT[32] = {
+    0x16, 0xad, 0xea, 0x6c, 0xce, 0x33, 0x1c, 0xb2,
+    0x5c, 0xcb, 0x62, 0x3e, 0x55, 0x61, 0x96, 0x98,
+    0x2c, 0xbb, 0xa0, 0x30, 0x18, 0xd9, 0x49, 0x53,
+    0x5b, 0x4a, 0x56, 0x3b, 0x05, 0x73, 0x04, 0x85,
+};
+
+static const uint8_t SINSEMILLA_TEN_BITS_HASH[32] = {
+    0x16, 0xad, 0xea, 0x6c, 0xce, 0x33, 0x1c, 0xb2,
+    0x5c, 0xcb, 0x62, 0x3e, 0x55, 0x61, 0x96, 0x98,
+    0x2c, 0xbb, 0xa0, 0x30, 0x18, 0xd9, 0x49, 0x53,
+    0x5b, 0x4a, 0x56, 0x3b, 0x05, 0x73, 0x04, 0x05,
+};
+
+static const uint8_t SINSEMILLA_TWENTY_THREE_BITS_HASH_POINT[32] = {
+    0x1b, 0x2f, 0x70, 0x0a, 0x30, 0xc4, 0x5a, 0x5e,
+    0x7f, 0x98, 0x6e, 0x13, 0xf9, 0xe8, 0xec, 0x5e,
+    0x95, 0xc9, 0xb1, 0xf0, 0x77, 0x3b, 0x76, 0x39,
+    0x81, 0xbb, 0x59, 0x9a, 0x2e, 0xd7, 0xab, 0xb5,
+};
+
+static const uint8_t SINSEMILLA_TWENTY_THREE_BITS_HASH[32] = {
+    0x1b, 0x2f, 0x70, 0x0a, 0x30, 0xc4, 0x5a, 0x5e,
+    0x7f, 0x98, 0x6e, 0x13, 0xf9, 0xe8, 0xec, 0x5e,
+    0x95, 0xc9, 0xb1, 0xf0, 0x77, 0x3b, 0x76, 0x39,
+    0x81, 0xbb, 0x59, 0x9a, 0x2e, 0xd7, 0xab, 0x35,
+};
+
+static const uint8_t SINSEMILLA_TWENTY_THREE_BITS_COMMIT_POINT[32] = {
+    0x38, 0x2f, 0xe5, 0xd4, 0x2a, 0xe2, 0x0b, 0x82,
+    0x21, 0x6f, 0x86, 0xb5, 0xba, 0xd0, 0xa4, 0xce,
+    0x14, 0x8a, 0x5f, 0x1a, 0x8e, 0xae, 0xc0, 0x30,
+    0x67, 0xae, 0xaa, 0x2c, 0x67, 0xdd, 0xc1, 0x0a,
+};
+
+static const uint8_t SINSEMILLA_TWENTY_THREE_BITS_SHORT_COMMIT[32] = {
+    0x38, 0x2f, 0xe5, 0xd4, 0x2a, 0xe2, 0x0b, 0x82,
+    0x21, 0x6f, 0x86, 0xb5, 0xba, 0xd0, 0xa4, 0xce,
+    0x14, 0x8a, 0x5f, 0x1a, 0x8e, 0xae, 0xc0, 0x30,
+    0x67, 0xae, 0xaa, 0x2c, 0x67, 0xdd, 0xc1, 0x0a,
+};
+
+/* F4Jumble vectors from f4jumble 0.1.1 / zcash-test-vectors. */
+static const uint8_t F4JUMBLE_48_NORMAL[48] = {
+    0x5d, 0x7a, 0x8f, 0x73, 0x9a, 0x2d, 0x9e, 0x94,
+    0x5b, 0x0c, 0xe1, 0x52, 0xa8, 0x04, 0x9e, 0x29,
+    0x4c, 0x4d, 0x6e, 0x66, 0xb1, 0x64, 0x93, 0x9d,
+    0xaf, 0xfa, 0x2e, 0xf6, 0xee, 0x69, 0x21, 0x48,
+    0x1c, 0xdd, 0x86, 0xb3, 0xcc, 0x43, 0x18, 0xd9,
+    0x61, 0x4f, 0xc8, 0x20, 0x90, 0x5d, 0x04, 0x2b,
+};
+
+static const uint8_t F4JUMBLE_48_JUMBLED[48] = {
+    0x03, 0x04, 0xd0, 0x29, 0x14, 0x1b, 0x99, 0x5d,
+    0xa5, 0x38, 0x7c, 0x12, 0x59, 0x70, 0x67, 0x35,
+    0x04, 0xd6, 0xc7, 0x64, 0xd9, 0x1e, 0xa6, 0xc0,
+    0x82, 0x12, 0x37, 0x70, 0xc7, 0x13, 0x9c, 0xcd,
+    0x88, 0xee, 0x27, 0x36, 0x8c, 0xd0, 0xc0, 0x92,
+    0x1a, 0x04, 0x44, 0xc8, 0xe5, 0x85, 0x8d, 0x22,
+};
+
+static const uint8_t F4JUMBLE_64_NORMAL[64] = {
+    0xb1, 0xef, 0x9c, 0xa3, 0xf2, 0x49, 0x88, 0xc7,
+    0xb3, 0x53, 0x42, 0x01, 0xcf, 0xb1, 0xcd, 0x8d,
+    0xbf, 0x69, 0xb8, 0x25, 0x0c, 0x18, 0xef, 0x41,
+    0x29, 0x4c, 0xa9, 0x79, 0x93, 0xdb, 0x54, 0x6c,
+    0x1f, 0xe0, 0x1f, 0x7e, 0x9c, 0x8e, 0x36, 0xd6,
+    0xa5, 0xe2, 0x9d, 0x4e, 0x30, 0xa7, 0x35, 0x94,
+    0xbf, 0x50, 0x98, 0x42, 0x1c, 0x69, 0x37, 0x8a,
+    0xf1, 0xe4, 0x0f, 0x64, 0xe1, 0x25, 0x94, 0x6f,
+};
+
+static const uint8_t F4JUMBLE_64_JUMBLED[64] = {
+    0x52, 0x71, 0xfa, 0x33, 0x21, 0xf3, 0xad, 0xbc,
+    0xfb, 0x07, 0x51, 0x96, 0x88, 0x3d, 0x54, 0x2b,
+    0x43, 0x8e, 0xc6, 0x33, 0x91, 0x76, 0x53, 0x7d,
+    0xaf, 0x85, 0x98, 0x41, 0xfe, 0x6a, 0x56, 0x22,
+    0x2b, 0xff, 0x76, 0xd1, 0x66, 0x2b, 0x55, 0x09,
+    0xa9, 0xe1, 0x07, 0x9e, 0x44, 0x6e, 0xee, 0xdd,
+    0x2e, 0x68, 0x3c, 0x31, 0xaa, 0xe3, 0xee, 0x18,
+    0x51, 0xd7, 0x95, 0x43, 0x28, 0x52, 0x6b, 0xe1,
+};
+
+/* Compare two 32-byte LE values: return -1 if a < b, 0 if equal, 1 if a > b */
+static int cmp_le256(const uint8_t a[32], const uint8_t b[32]) {
+  for (int i = 31; i >= 0; i--) {
+    if (a[i] < b[i]) return -1;
+    if (a[i] > b[i]) return 1;
+  }
+  return 0;
+}
+
+/* ── Reference Test Vectors ──────────────────────────────────────── */
+
+/*
+ * Mnemonic: "all all all all all all all all all all all all"
+ * BIP-39 seed (PBKDF2, no passphrase), 64 bytes:
+ */
+static const uint8_t SEED_ALL[64] = {
+    0xc7, 0x6c, 0x4a, 0xc4, 0xf4, 0xe4, 0xa0, 0x0d,
+    0x6b, 0x27, 0x4d, 0x5c, 0x39, 0xc7, 0x00, 0xbb,
+    0x4a, 0x7d, 0xdc, 0x04, 0xfb, 0xc6, 0xf7, 0x8e,
+    0x85, 0xca, 0x75, 0x00, 0x7b, 0x5b, 0x49, 0x5f,
+    0x74, 0xa9, 0x04, 0x3e, 0xeb, 0x77, 0xbd, 0xd5,
+    0x3a, 0xa6, 0xfc, 0x3a, 0x0e, 0x31, 0x46, 0x22,
+    0x70, 0x31, 0x6f, 0xa0, 0x4b, 0x8c, 0x19, 0x11,
+    0x4c, 0x87, 0x98, 0x70, 0x6c, 0xd0, 0x2a, 0xc8,
+};
+
+/*
+ * Expected FVK for "all" mnemonic, account 0.
+ * Generated by the orchard Rust crate (authoritative ZIP-32).
+ *
+ * NOTE: These vectors verify the derivation function itself.
+ * The current FSM seed-proxy bug means the firmware doesn't call
+ * this function with the correct seed — but the function is correct.
+ */
+static const uint8_t EXPECTED_AK_ALL_0[32] = {
+    0x05, 0x7a, 0xb0, 0x51, 0xd4, 0xfb, 0xb0, 0x20,
+    0x5d, 0x28, 0x64, 0x8b, 0xac, 0xbc, 0x64, 0x71,
+    0xb5, 0x33, 0x47, 0x6c, 0x27, 0xbe, 0xca, 0x33,
+    0xe5, 0xb9, 0xf5, 0x11, 0xd8, 0x55, 0x67, 0x2b,
+};
+
+static const uint8_t EXPECTED_NK_ALL_0[32] = {
+    0x34, 0xa3, 0x5a, 0x0b, 0xda, 0x50, 0x27, 0x3b,
+    0x03, 0x19, 0xaf, 0xa7, 0xa7, 0x0f, 0x86, 0xb6,
+    0xb1, 0x62, 0xeb, 0x31, 0x1d, 0x26, 0x3d, 0x8f,
+    0x63, 0x21, 0xde, 0xf0, 0x02, 0x28, 0xba, 0x25,
+};
+
+static const uint8_t EXPECTED_RIVK_ALL_0[32] = {
+    0x46, 0xbd, 0x2b, 0xd5, 0xe6, 0xec, 0xa5, 0xef,
+    0x03, 0xe1, 0x8c, 0xd7, 0x65, 0x95, 0x51, 0x9e,
+    0xa9, 0x67, 0x06, 0xc5, 0x82, 0x6a, 0x93, 0xba,
+    0x4d, 0xca, 0x94, 0x7d, 0x71, 0x1a, 0x7c, 0x0a,
+};
+
+static const uint8_t EXPECTED_IVK_ALL_0[32] = {
+    0xa8, 0xe2, 0xea, 0x36, 0x48, 0x8b, 0x9e, 0xb4,
+    0x61, 0x47, 0x60, 0x5b, 0xa1, 0x50, 0x40, 0x37,
+    0xd0, 0x88, 0x1e, 0x98, 0x1b, 0x6e, 0x58, 0x47,
+    0xb9, 0xf5, 0xc1, 0xbe, 0xb5, 0xd0, 0x43, 0x35,
+};
+
+static const uint8_t EXPECTED_DK_ALL_0[32] = {
+    0xe8, 0x52, 0xed, 0xd7, 0x82, 0xd6, 0xeb, 0x92,
+    0x12, 0x82, 0x21, 0x9b, 0x8a, 0x9c, 0x38, 0x0e,
+    0x03, 0xfc, 0xc4, 0x76, 0x60, 0xfe, 0x67, 0xaf,
+    0x1b, 0xa4, 0x77, 0x80, 0x2b, 0xb0, 0x6c, 0xe7,
+};
+
+static const uint8_t EXPECTED_DIVERSIFIER_ALL_0[11] = {
+    0xda, 0x97, 0x30, 0x31, 0x63, 0x4a, 0x89, 0x38, 0xad, 0x1c, 0x48,
+};
+
+/* FF1-AES256 Orchard diversifier vectors generated with zcash-test-vectors.
+ * Parameters: radix = 2, n = 88, tweak = "", rounds = 10.
+ * Inputs and outputs are LEBS2OSP_88 byte encodings.
+ */
+struct OrchardFf1Vector {
+  uint8_t dk[32];
+  uint8_t index[11];
+  uint8_t diversifier[11];
+};
+
+static const OrchardFf1Vector ORCHARD_FF1_VECTORS[] = {
+    {{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+     {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00},
+     {0xdc, 0xe7, 0x7e, 0xbc, 0xec, 0x0a, 0x26, 0xaf, 0xd6,
+      0x99, 0x8c}},
+    {{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+     {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00},
+     {0x63, 0x73, 0x8a, 0xa5, 0xf7, 0xbe, 0x22, 0xe1, 0xac,
+      0xdc, 0x0b}},
+    {{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+      0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+      0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+      0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f},
+     {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00},
+     {0xd7, 0x39, 0xcc, 0xc2, 0xb8, 0x4d, 0x5d, 0x1a, 0xe5,
+      0x4a, 0x95}},
+    {{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+      0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+      0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+      0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f},
+     {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+      0x09, 0x0a},
+     {0xc8, 0xff, 0x0b, 0x01, 0x96, 0x01, 0x30, 0x12, 0x76,
+      0x38, 0xc7}},
+};
+
+static const uint8_t XMD_ABC_96[96] = {
+    0x48, 0x50, 0x5e, 0x62, 0xfe, 0x0c, 0xe6, 0x64,
+    0xb6, 0x80, 0xf1, 0xf9, 0xe6, 0x37, 0x43, 0x91,
+    0xa6, 0x09, 0x57, 0x5e, 0x53, 0x5c, 0xfd, 0x55,
+    0xea, 0xd4, 0x49, 0xa4, 0x18, 0x43, 0xc7, 0x0d,
+    0x65, 0x3a, 0x08, 0x5d, 0x09, 0xb1, 0x9f, 0x3f,
+    0x8d, 0x4d, 0x0a, 0xe4, 0x4f, 0x6a, 0xcf, 0x48,
+    0xca, 0xfd, 0xb2, 0x8b, 0x8e, 0xea, 0x01, 0xe3,
+    0x6a, 0xf4, 0xf5, 0xfc, 0xda, 0xcc, 0xf1, 0x45,
+    0x2a, 0x87, 0xc0, 0x8c, 0xc1, 0x0c, 0x9a, 0x03,
+    0x7f, 0x3f, 0x03, 0x69, 0xf6, 0xb0, 0x43, 0xfb,
+    0xfc, 0x59, 0x81, 0xb6, 0x0d, 0x50, 0xd7, 0xbd,
+    0x00, 0x4a, 0x59, 0x71, 0x3b, 0x1e, 0xcc, 0x25,
+};
+
+static const uint8_t SWU_0_X_LE[32] = {
+    0x6e, 0x09, 0x9b, 0x51, 0x33, 0x34, 0xca, 0x85,
+    0xf4, 0x27, 0xa7, 0xde, 0x25, 0x25, 0xf4, 0xf5,
+    0x8a, 0x9a, 0x12, 0x39, 0xb3, 0x95, 0x52, 0xe2,
+    0x52, 0x6c, 0xf5, 0x34, 0xa5, 0xa6, 0xc1, 0x28,
+};
+
+static const uint8_t SWU_0_Y_LE[32] = {
+    0x8d, 0xae, 0xc5, 0x6a, 0xee, 0xa1, 0x4f, 0x08,
+    0xc7, 0xb7, 0x07, 0x02, 0x27, 0x9c, 0xd2, 0x15,
+    0xd3, 0x3f, 0x08, 0x27, 0x09, 0x7f, 0x7d, 0x3c,
+    0xc6, 0x53, 0x66, 0xee, 0x8b, 0x65, 0xfc, 0x3b,
+};
+
+static const uint8_t SWU_0_Z_LE[32] = {
+    0x36, 0xef, 0xcd, 0xd8, 0x0c, 0x25, 0x5f, 0x8a,
+    0x6f, 0x74, 0x7d, 0xda, 0x72, 0x54, 0x11, 0x5d,
+    0x9d, 0xa1, 0x34, 0x85, 0x31, 0xb1, 0x57, 0x41,
+    0x10, 0xdc, 0x16, 0x04, 0xa1, 0x3b, 0x4b, 0x05,
+};
+
+static const uint8_t SWU_1_X_LE[32] = {
+    0x05, 0x15, 0x56, 0xa3, 0xa5, 0xb9, 0x13, 0x79,
+    0x83, 0x80, 0x82, 0x06, 0x71, 0xb0, 0x64, 0x6d,
+    0x85, 0xa1, 0x26, 0xc0, 0x67, 0xe9, 0xf5, 0x4a,
+    0x53, 0x76, 0xe8, 0x57, 0x59, 0xba, 0x0c, 0x01,
+};
+
+static const uint8_t SWU_1_Y_LE[32] = {
+    0x81, 0x9c, 0xcc, 0x5d, 0x51, 0x6d, 0xfa, 0x76,
+    0xe9, 0x78, 0x80, 0xb0, 0xd6, 0x14, 0x75, 0x54,
+    0x6a, 0xf4, 0xeb, 0x65, 0xa0, 0x65, 0x6e, 0x7d,
+    0x8e, 0x11, 0xd3, 0x9c, 0x1f, 0xc6, 0x2f, 0x06,
+};
+
+static const uint8_t SWU_1_Z_LE[32] = {
+    0x88, 0x36, 0xa7, 0x29, 0x9a, 0xbc, 0x75, 0x7c,
+    0x3a, 0x75, 0xe1, 0x3d, 0x62, 0xf5, 0xcf, 0x5c,
+    0x60, 0x93, 0x77, 0x3e, 0x52, 0x4e, 0x1c, 0x10,
+    0xc3, 0x50, 0x12, 0x31, 0x8c, 0xcb, 0x86, 0x3f,
+};
+
+static const uint8_t HASH_ZCASH_TEST_TRANS_RIGHTS[32] = {
+    0xd3, 0x6b, 0x0b, 0x64, 0x9b, 0x5c, 0x69, 0x36,
+    0x02, 0x7a, 0x18, 0x0f, 0x7d, 0x25, 0x40, 0x23,
+    0x95, 0x6f, 0xc2, 0x88, 0x3d, 0xdf, 0x23, 0xff,
+    0xc3, 0xc8, 0xfd, 0x1f, 0xa3, 0xcd, 0x18, 0x18,
+};
+
+static const uint8_t ORCHARD_GD_EMPTY[32] = {
+    0x3f, 0x90, 0xd3, 0xe5, 0x80, 0xd5, 0x6a, 0x66,
+    0x2b, 0x27, 0x36, 0x91, 0xd8, 0xd1, 0xe3, 0x34,
+    0x75, 0x30, 0x83, 0xe9, 0xbf, 0x4c, 0x17, 0x2e,
+    0x7d, 0xae, 0xfc, 0x0f, 0x06, 0x08, 0xcf, 0x97,
+};
+
+static const uint8_t ORCHARD_GD_ALL_ACCOUNT0_J0[32] = {
+    0x26, 0x8e, 0xd9, 0xf9, 0x01, 0xfd, 0xb4, 0xe9,
+    0xb3, 0xf0, 0x70, 0xd9, 0x5f, 0x1b, 0x8d, 0x98,
+    0x35, 0x3c, 0xb8, 0xa2, 0x02, 0xac, 0x1c, 0x97,
+    0xbd, 0xb1, 0x26, 0x9f, 0x85, 0x93, 0xd6, 0x30,
+};
+
+static const uint8_t ORCHARD_GD_FF1_ZERO_ZERO[32] = {
+    0xa4, 0x58, 0x99, 0x84, 0x3c, 0xde, 0x1f, 0xaf,
+    0x52, 0x42, 0x6e, 0x27, 0xd4, 0x17, 0x96, 0xb5,
+    0x2a, 0xaf, 0x39, 0xf1, 0x47, 0x9c, 0xe0, 0x69,
+    0xd7, 0xa9, 0xda, 0x4e, 0xef, 0xc3, 0xf8, 0x3d,
+};
+
+/* Orchard ivk/d/g_d/pk_d vectors generated with orchard 0.12.0. */
+struct OrchardReceiverVector {
+  uint8_t ivk[32];
+  uint8_t diversifier[11];
+  uint8_t gd[32];
+  uint8_t pkd[32];
+};
+
+static const OrchardReceiverVector ORCHARD_RECEIVER_VECTORS[] = {
+    {{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+     {0xd8, 0xe1, 0x01, 0x7d, 0x45, 0x32, 0xab, 0x65, 0xe0,
+      0xe5, 0x38},
+     {0x7d, 0x70, 0x35, 0xca, 0x4a, 0x40, 0x9d, 0xe0,
+      0x65, 0x40, 0xdf, 0xd1, 0x6e, 0x8c, 0x2d, 0xd9,
+      0xa9, 0x34, 0xee, 0x17, 0xfa, 0xfb, 0x8e, 0xd0,
+      0xd7, 0x85, 0x6d, 0x16, 0x1c, 0x9a, 0x02, 0x2b},
+     {0x7d, 0x70, 0x35, 0xca, 0x4a, 0x40, 0x9d, 0xe0,
+      0x65, 0x40, 0xdf, 0xd1, 0x6e, 0x8c, 0x2d, 0xd9,
+      0xa9, 0x34, 0xee, 0x17, 0xfa, 0xfb, 0x8e, 0xd0,
+      0xd7, 0x85, 0x6d, 0x16, 0x1c, 0x9a, 0x02, 0x2b}},
+    {{0x42, 0x7a, 0x1d, 0xb3, 0x94, 0x6f, 0x20, 0xe5,
+      0x88, 0x30, 0xc2, 0x91, 0x76, 0x11, 0x5d, 0x04,
+      0xf8, 0xbc, 0x9a, 0x21, 0x0e, 0x73, 0xd5, 0x4c,
+      0x06, 0x9b, 0xa8, 0x17, 0x2e, 0x45, 0x00, 0x10},
+     {0xe3, 0x63, 0x1b, 0x5e, 0xdd, 0x66, 0x95, 0xf0, 0xf0,
+      0x0d, 0x8d},
+     {0xe7, 0xb6, 0x5d, 0xda, 0x4b, 0xc5, 0x39, 0xc0,
+      0xf4, 0x0c, 0x6a, 0xdf, 0xaa, 0x41, 0xaa, 0x11,
+      0xd2, 0xf5, 0x27, 0xc8, 0x8a, 0xd0, 0x10, 0xec,
+      0xb5, 0xe3, 0x8c, 0xbe, 0x38, 0x18, 0xdd, 0x31},
+     {0x36, 0xc5, 0x49, 0x3f, 0x2b, 0x53, 0xaf, 0x23,
+      0x7b, 0x86, 0x5a, 0xe1, 0x17, 0xc3, 0x05, 0x14,
+      0x8b, 0x78, 0xb2, 0x10, 0x84, 0x7c, 0x86, 0xa5,
+      0xce, 0x24, 0xfa, 0x12, 0xa9, 0x1f, 0xf5, 0x87}},
+    {{0xfe, 0xff, 0xff, 0xff, 0x38, 0x6d, 0x78, 0x34,
+      0xad, 0x14, 0x19, 0xe4, 0x0b, 0x35, 0x2c, 0x99,
+      0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+      0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x3f},
+     {0x65, 0x92, 0x89, 0x70, 0xbe, 0x78, 0x36, 0x96, 0xe0,
+      0x2f, 0xd1},
+     {0xc9, 0xb4, 0xb5, 0x0a, 0x61, 0x9d, 0xc3, 0x4c,
+      0x60, 0xd4, 0xa8, 0x30, 0x0d, 0x56, 0x60, 0x12,
+      0x77, 0xd7, 0x02, 0xa7, 0x5e, 0xb5, 0xcf, 0xe1,
+      0x77, 0x22, 0xa7, 0x1d, 0xb7, 0x3f, 0x36, 0x32},
+     {0x17, 0xcb, 0x58, 0x55, 0x9a, 0xf4, 0xd2, 0xcc,
+      0x6e, 0x1f, 0x24, 0xa7, 0xe5, 0xab, 0x4c, 0x83,
+      0x33, 0x3c, 0x25, 0x16, 0xd3, 0x64, 0x00, 0x6f,
+      0x9c, 0xee, 0x24, 0x70, 0x3c, 0xe4, 0xfc, 0xba}},
+};
+
+/* Orchard ak/nk/rivk -> ivk vectors generated with orchard 0.12.0. */
+struct OrchardIvkVector {
+  uint8_t ak[32];
+  uint8_t nk[32];
+  uint8_t rivk[32];
+  uint8_t ivk[32];
+};
+
+static const OrchardIvkVector ORCHARD_IVK_VECTORS[] = {
+    {{0x87, 0x77, 0xe2, 0x15, 0x10, 0x1d, 0xf4, 0x5a,
+      0xa4, 0x68, 0xbb, 0x10, 0xb2, 0xf9, 0x3f, 0xfe,
+      0x08, 0xa2, 0xf7, 0x9e, 0xbf, 0xf0, 0x95, 0xaa,
+      0xeb, 0x74, 0x73, 0xc7, 0x71, 0x34, 0x96, 0x21},
+     {0xbb, 0xca, 0x15, 0x2c, 0xfb, 0xf9, 0x81, 0x18,
+      0x19, 0xcc, 0x62, 0x44, 0x34, 0xd1, 0x23, 0x75,
+      0x77, 0xc1, 0x38, 0x05, 0xcc, 0x3d, 0xed, 0x44,
+      0x4e, 0x75, 0x5a, 0x6b, 0x78, 0xfa, 0xcd, 0x16},
+     {0x8c, 0xa7, 0xfb, 0xba, 0x26, 0x47, 0x0f, 0xea,
+      0x0b, 0x10, 0xd3, 0x0d, 0xb2, 0x73, 0x66, 0xec,
+      0x65, 0x04, 0x0c, 0x72, 0xa0, 0x9a, 0xd8, 0x42,
+      0x58, 0x88, 0xef, 0x26, 0xf1, 0xc0, 0x79, 0x3f},
+     {0xa1, 0xf8, 0x75, 0x87, 0x29, 0x73, 0xea, 0x49,
+      0x2d, 0xe3, 0xbe, 0x5c, 0xce, 0xcf, 0xe5, 0x56,
+      0x79, 0x10, 0x24, 0x4c, 0xb6, 0x02, 0x99, 0x4c,
+      0x58, 0x00, 0xf6, 0x8c, 0x64, 0x38, 0xb9, 0x1b}},
+    {{0x6e, 0xbb, 0x83, 0x3c, 0x1d, 0x2f, 0x84, 0x33,
+      0x08, 0x0a, 0xbc, 0xea, 0xbe, 0x47, 0x90, 0x60,
+      0x97, 0xf9, 0x06, 0x78, 0xd6, 0x03, 0xf5, 0x77,
+      0xd0, 0x48, 0x6c, 0x91, 0x11, 0x73, 0x7b, 0x07},
+     {0xf2, 0x26, 0xa3, 0xf8, 0x79, 0xeb, 0xe2, 0x1a,
+      0xbf, 0xaf, 0xcc, 0xb6, 0xc5, 0x21, 0xca, 0x74,
+      0x9e, 0x63, 0xac, 0x17, 0xfd, 0x2c, 0xd1, 0x78,
+      0x70, 0xaa, 0x72, 0xde, 0x12, 0xd8, 0x33, 0x0d},
+     {0x04, 0x7c, 0x00, 0xab, 0x5e, 0x0f, 0xec, 0xa6,
+      0x1a, 0x46, 0x18, 0x58, 0xbb, 0x0b, 0x15, 0xd5,
+      0x5f, 0x29, 0x76, 0x3a, 0x0a, 0x28, 0x28, 0x25,
+      0xac, 0xeb, 0xd5, 0x86, 0x98, 0x93, 0x7d, 0x24},
+     {0xa1, 0x75, 0x8f, 0x83, 0xad, 0xbd, 0x24, 0x89,
+      0x87, 0xc3, 0x6b, 0xbf, 0x52, 0x41, 0xc1, 0x29,
+      0x9e, 0xfa, 0x96, 0xf2, 0x4c, 0x8c, 0xfb, 0xb5,
+      0x51, 0x17, 0x23, 0x90, 0x9c, 0xc1, 0xe2, 0x02}},
+    {{0xa4, 0x1c, 0xc0, 0xc3, 0x80, 0x0f, 0xf8, 0x9a,
+      0x88, 0xd7, 0xae, 0x02, 0xff, 0x33, 0x6f, 0xdb,
+      0xd5, 0xbc, 0xe8, 0x9d, 0x9e, 0x8d, 0xd4, 0xeb,
+      0x27, 0x8b, 0x4c, 0xd5, 0xc3, 0x7e, 0xc7, 0x20},
+     {0x41, 0x5e, 0x75, 0x22, 0x27, 0xcb, 0x69, 0x65,
+      0x2e, 0x2a, 0xfa, 0x94, 0x81, 0x6f, 0x63, 0x0d,
+      0xce, 0xc1, 0xac, 0xdf, 0x3c, 0x3f, 0xb0, 0x2e,
+      0x1e, 0x6b, 0x04, 0x6e, 0x12, 0xa4, 0x31, 0x11},
+     {0x92, 0x76, 0xa5, 0xb7, 0x55, 0xa1, 0x54, 0x63,
+      0xab, 0x59, 0xf0, 0xe7, 0x22, 0x1f, 0x65, 0x80,
+      0x65, 0x7c, 0x05, 0x3f, 0xdb, 0x74, 0x40, 0x12,
+      0xb3, 0xc1, 0x64, 0x8c, 0x75, 0x78, 0xd1, 0x22},
+     {0xa8, 0x4f, 0x85, 0xd1, 0x57, 0xba, 0x71, 0x66,
+      0x5b, 0x31, 0x0b, 0xd2, 0x12, 0x15, 0xad, 0x58,
+      0x82, 0x3b, 0x29, 0x8f, 0x44, 0x98, 0xd5, 0x0d,
+      0x63, 0xad, 0xc9, 0x4d, 0x34, 0xeb, 0x93, 0x0a}},
+};
+
+/* Orchard raw receiver vectors generated with orchard 0.12.0. */
+struct OrchardReceiverAssemblyVector {
+  uint8_t ak[32];
+  uint8_t nk[32];
+  uint8_t rivk[32];
+  uint8_t dk[32];
+  uint8_t index[11];
+  uint8_t receiver[43];
+};
+
+static const OrchardReceiverAssemblyVector ORCHARD_RECEIVER_ASSEMBLY_VECTORS[] = {
+    {{0x05, 0x7a, 0xb0, 0x51, 0xd4, 0xfb, 0xb0, 0x20,
+      0x5d, 0x28, 0x64, 0x8b, 0xac, 0xbc, 0x64, 0x71,
+      0xb5, 0x33, 0x47, 0x6c, 0x27, 0xbe, 0xca, 0x33,
+      0xe5, 0xb9, 0xf5, 0x11, 0xd8, 0x55, 0x67, 0x2b},
+     {0x34, 0xa3, 0x5a, 0x0b, 0xda, 0x50, 0x27, 0x3b,
+      0x03, 0x19, 0xaf, 0xa7, 0xa7, 0x0f, 0x86, 0xb6,
+      0xb1, 0x62, 0xeb, 0x31, 0x1d, 0x26, 0x3d, 0x8f,
+      0x63, 0x21, 0xde, 0xf0, 0x02, 0x28, 0xba, 0x25},
+     {0x46, 0xbd, 0x2b, 0xd5, 0xe6, 0xec, 0xa5, 0xef,
+      0x03, 0xe1, 0x8c, 0xd7, 0x65, 0x95, 0x51, 0x9e,
+      0xa9, 0x67, 0x06, 0xc5, 0x82, 0x6a, 0x93, 0xba,
+      0x4d, 0xca, 0x94, 0x7d, 0x71, 0x1a, 0x7c, 0x0a},
+     {0xe8, 0x52, 0xed, 0xd7, 0x82, 0xd6, 0xeb, 0x92,
+      0x12, 0x82, 0x21, 0x9b, 0x8a, 0x9c, 0x38, 0x0e,
+      0x03, 0xfc, 0xc4, 0x76, 0x60, 0xfe, 0x67, 0xaf,
+      0x1b, 0xa4, 0x77, 0x80, 0x2b, 0xb0, 0x6c, 0xe7},
+     {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00},
+     {0xda, 0x97, 0x30, 0x31, 0x63, 0x4a, 0x89, 0x38,
+      0xad, 0x1c, 0x48, 0x0f, 0x97, 0x87, 0x80, 0x69,
+      0x3e, 0xc7, 0x70, 0x9b, 0xa5, 0xca, 0xf5, 0x8d,
+      0x8a, 0x7e, 0xb9, 0x45, 0x58, 0x6c, 0xbe, 0xd6,
+      0x45, 0x52, 0x0f, 0x17, 0x38, 0x74, 0x37, 0xbc,
+      0xfd, 0xc2, 0x16}},
+    {{0x05, 0x7a, 0xb0, 0x51, 0xd4, 0xfb, 0xb0, 0x20,
+      0x5d, 0x28, 0x64, 0x8b, 0xac, 0xbc, 0x64, 0x71,
+      0xb5, 0x33, 0x47, 0x6c, 0x27, 0xbe, 0xca, 0x33,
+      0xe5, 0xb9, 0xf5, 0x11, 0xd8, 0x55, 0x67, 0x2b},
+     {0x34, 0xa3, 0x5a, 0x0b, 0xda, 0x50, 0x27, 0x3b,
+      0x03, 0x19, 0xaf, 0xa7, 0xa7, 0x0f, 0x86, 0xb6,
+      0xb1, 0x62, 0xeb, 0x31, 0x1d, 0x26, 0x3d, 0x8f,
+      0x63, 0x21, 0xde, 0xf0, 0x02, 0x28, 0xba, 0x25},
+     {0x46, 0xbd, 0x2b, 0xd5, 0xe6, 0xec, 0xa5, 0xef,
+      0x03, 0xe1, 0x8c, 0xd7, 0x65, 0x95, 0x51, 0x9e,
+      0xa9, 0x67, 0x06, 0xc5, 0x82, 0x6a, 0x93, 0xba,
+      0x4d, 0xca, 0x94, 0x7d, 0x71, 0x1a, 0x7c, 0x0a},
+     {0xe8, 0x52, 0xed, 0xd7, 0x82, 0xd6, 0xeb, 0x92,
+      0x12, 0x82, 0x21, 0x9b, 0x8a, 0x9c, 0x38, 0x0e,
+      0x03, 0xfc, 0xc4, 0x76, 0x60, 0xfe, 0x67, 0xaf,
+      0x1b, 0xa4, 0x77, 0x80, 0x2b, 0xb0, 0x6c, 0xe7},
+     {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00},
+     {0xbb, 0x0c, 0x08, 0xc2, 0x0f, 0x07, 0x8f, 0x59,
+      0x89, 0x39, 0x1c, 0x36, 0x91, 0xb8, 0x97, 0xea,
+      0xcf, 0x28, 0x9a, 0x02, 0x02, 0x2f, 0x45, 0xb3,
+      0xb1, 0x3f, 0x5f, 0xa1, 0xaa, 0xd5, 0x95, 0x9f,
+      0xaa, 0x29, 0x01, 0x56, 0xc2, 0x40, 0xb8, 0xae,
+      0x1c, 0x07, 0x25}},
+    {{0x6e, 0xbb, 0x83, 0x3c, 0x1d, 0x2f, 0x84, 0x33,
+      0x08, 0x0a, 0xbc, 0xea, 0xbe, 0x47, 0x90, 0x60,
+      0x97, 0xf9, 0x06, 0x78, 0xd6, 0x03, 0xf5, 0x77,
+      0xd0, 0x48, 0x6c, 0x91, 0x11, 0x73, 0x7b, 0x07},
+     {0xf2, 0x26, 0xa3, 0xf8, 0x79, 0xeb, 0xe2, 0x1a,
+      0xbf, 0xaf, 0xcc, 0xb6, 0xc5, 0x21, 0xca, 0x74,
+      0x9e, 0x63, 0xac, 0x17, 0xfd, 0x2c, 0xd1, 0x78,
+      0x70, 0xaa, 0x72, 0xde, 0x12, 0xd8, 0x33, 0x0d},
+     {0x04, 0x7c, 0x00, 0xab, 0x5e, 0x0f, 0xec, 0xa6,
+      0x1a, 0x46, 0x18, 0x58, 0xbb, 0x0b, 0x15, 0xd5,
+      0x5f, 0x29, 0x76, 0x3a, 0x0a, 0x28, 0x28, 0x25,
+      0xac, 0xeb, 0xd5, 0x86, 0x98, 0x93, 0x7d, 0x24},
+     {0x6c, 0x50, 0x3c, 0x95, 0x19, 0x0a, 0x74, 0x1d,
+      0x5f, 0x54, 0x87, 0x59, 0xeb, 0x46, 0x4a, 0xa5,
+      0x36, 0x3b, 0xcd, 0xbc, 0x91, 0xa6, 0x98, 0x7b,
+      0xd0, 0x7f, 0x67, 0x7b, 0x37, 0x59, 0xc2, 0x08},
+     {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00},
+     {0x45, 0x59, 0x02, 0x9c, 0x0b, 0x5d, 0xbf, 0x94,
+      0x1c, 0x5a, 0xd1, 0x81, 0xa5, 0xfe, 0x8f, 0x45,
+      0xb3, 0x46, 0x30, 0xf2, 0x9d, 0x0c, 0x8d, 0xd8,
+      0xdc, 0x1c, 0xc3, 0x57, 0x33, 0x86, 0xf4, 0x16,
+      0xcb, 0x32, 0x41, 0x33, 0x15, 0x6d, 0x72, 0x3d,
+      0xf5, 0xe6, 0x2d}},
+    {{0xa4, 0x1c, 0xc0, 0xc3, 0x80, 0x0f, 0xf8, 0x9a,
+      0x88, 0xd7, 0xae, 0x02, 0xff, 0x33, 0x6f, 0xdb,
+      0xd5, 0xbc, 0xe8, 0x9d, 0x9e, 0x8d, 0xd4, 0xeb,
+      0x27, 0x8b, 0x4c, 0xd5, 0xc3, 0x7e, 0xc7, 0x20},
+     {0x41, 0x5e, 0x75, 0x22, 0x27, 0xcb, 0x69, 0x65,
+      0x2e, 0x2a, 0xfa, 0x94, 0x81, 0x6f, 0x63, 0x0d,
+      0xce, 0xc1, 0xac, 0xdf, 0x3c, 0x3f, 0xb0, 0x2e,
+      0x1e, 0x6b, 0x04, 0x6e, 0x12, 0xa4, 0x31, 0x11},
+     {0x92, 0x76, 0xa5, 0xb7, 0x55, 0xa1, 0x54, 0x63,
+      0xab, 0x59, 0xf0, 0xe7, 0x22, 0x1f, 0x65, 0x80,
+      0x65, 0x7c, 0x05, 0x3f, 0xdb, 0x74, 0x40, 0x12,
+      0xb3, 0xc1, 0x64, 0x8c, 0x75, 0x78, 0xd1, 0x22},
+     {0x41, 0xb7, 0x06, 0x56, 0xe2, 0x02, 0xaa, 0xcd,
+      0x0d, 0x92, 0x3b, 0x7c, 0x95, 0xc0, 0xfc, 0x17,
+      0xa2, 0x13, 0xaf, 0x97, 0x3a, 0xd4, 0xf8, 0x3f,
+      0xeb, 0x47, 0xdd, 0xf8, 0x3b, 0xb1, 0x68, 0xe4},
+     {0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00},
+     {0xcb, 0xd5, 0xfc, 0x34, 0xc7, 0x26, 0x1d, 0x3f,
+      0xdb, 0x23, 0xd2, 0xb8, 0x14, 0xad, 0xcb, 0xfc,
+      0x2d, 0x8e, 0x17, 0x2c, 0x79, 0xee, 0x8e, 0x2e,
+      0x3f, 0xe7, 0xd8, 0xb1, 0xda, 0xd5, 0xb6, 0x67,
+      0x8e, 0x22, 0x6c, 0xa7, 0xa3, 0x99, 0x6b, 0x1e,
+      0x62, 0x4f, 0x35}},
+};
+
+/* Orchard-only unified address vectors generated with zcash_address 0.10.1. */
+static const char ORCHARD_ONLY_UA_MAINNET_0[] =
+    "u1uzslnccvrw4r2y2kgjz7fm477xcnzge9z45scm4e6l6c63ren0ru29teedxw5vxu7c8xch"
+    "p3ec2pu3wkgldc5zphwtm4w3fchcwrl26c";
+static const char ORCHARD_ONLY_UA_TESTNET_0[] =
+    "utest1deyej6qvxfnewfhgdc987fgpq407u374vzvtvgjuv86vj0gs9tcej04hk7nr5msm5fzg"
+    "335j70mddjnqj48zjsj5zl2362w4zcd2ks8c";
+static const char ORCHARD_ONLY_UA_MAINNET_1[] =
+    "u19whtuck5ry2d53xa348ecvfgsudtk8vt2qexe9w50lzwkzxx3lxcn60ztjfe2m33e0jz4xd"
+    "4kxe3yhz65xq9jzvjcrtjrhvrf5mzat26";
+static const char ORCHARD_ONLY_UA_TESTNET_1[] =
+    "utest1ff5jzt4pr5hzgz8688052pjtq0plzk3va9hgssprp3ps2lluhy3u6ej7eh3njfgqp3"
+    "ar4lm8muxu352nmuqt2c5n92w4ngf44qwtjl0p";
+
+/* ── ZIP-32 Derivation Tests ─────────────────────────────────────── */
+
+TEST(Zcash, DeriveOrchardKeys_ReferenceVector_Account0) {
+  /*
+   * Reference vector test: derive keys from known "all" mnemonic seed
+   * and compare against values from the orchard Rust crate.
+   *
+   * The derivation bugs that caused prior mismatches were:
+   *   1. Child derivation used "ZcashIP32Orchard" instead of "Zcash_ExpandSeed"
+   *   2. Domain separator was 0x11 instead of 0x81
+   *   3. Index encoding was big-endian instead of little-endian
+   * All three are now fixed.
+   */
+  ZcashOrchardKeys keys;
+  ASSERT_TRUE(zcash_derive_orchard_keys(SEED_ALL, 64, 0, &keys));
+
+  /* nk must match reference */
+  EXPECT_TRUE(memcmp(keys.nk, EXPECTED_NK_ALL_0, 32) == 0)
+      << "nk mismatch for all-mnemonic account 0";
+
+  /* rivk must match reference */
+  EXPECT_TRUE(memcmp(keys.rivk, EXPECTED_RIVK_ALL_0, 32) == 0)
+      << "rivk mismatch for all-mnemonic account 0";
+
+  uint8_t ivk[32];
+  ASSERT_TRUE(zcash_orchard_derive_ivk(EXPECTED_AK_ALL_0, keys.nk, keys.rivk,
+                                       ivk));
+  EXPECT_TRUE(memcmp(ivk, EXPECTED_IVK_ALL_0, 32) == 0)
+      << "ivk mismatch for all-mnemonic account 0";
+
+  EXPECT_TRUE(memcmp(keys.dk, EXPECTED_DK_ALL_0, 32) == 0)
+      << "dk mismatch for all-mnemonic account 0";
+
+  uint8_t diversifier[11];
+  uint8_t index0[11] = {0};
+  ASSERT_TRUE(zcash_orchard_derive_diversifier(keys.dk, index0, diversifier));
+  EXPECT_TRUE(memcmp(diversifier, EXPECTED_DIVERSIFIER_ALL_0, 11) == 0)
+      << "default diversifier mismatch for all-mnemonic account 0";
+
+  /* Compute ak = [ask]*G and verify against reference */
+  bignum256 ask_scalar;
+  bn_read_le(keys.ask, &ask_scalar);
+  curve_point ak_point;
+  redpallas_scalar_mult_spendauth_G(&ask_scalar, &ak_point);
+
+  uint8_t ak_bytes[32];
+  bignum256 x_copy;
+  bn_copy(&ak_point.x, &x_copy);
+  bn_write_le(&x_copy, ak_bytes);
+  EXPECT_EQ(ak_bytes[31] & 0x80, 0)
+      << "ak sign bit must be 0 after ask normalization";
+
+  EXPECT_TRUE(memcmp(ak_bytes, EXPECTED_AK_ALL_0, 32) == 0)
+      << "ak mismatch for all-mnemonic account 0";
+
+  memzero(diversifier, sizeof(diversifier));
+  memzero(ivk, sizeof(ivk));
+  memzero(&keys, sizeof(keys));
+}
+
+TEST(Zcash, DeriveOrchardKeys_DifferentAccounts) {
+  ZcashOrchardKeys keys0, keys1;
+  ASSERT_TRUE(zcash_derive_orchard_keys(SEED_ALL, 64, 0, &keys0));
+  ASSERT_TRUE(zcash_derive_orchard_keys(SEED_ALL, 64, 1, &keys1));
+
+  /* Different accounts must produce different spending keys */
+  EXPECT_TRUE(memcmp(keys0.sk, keys1.sk, 32) != 0)
+      << "Account 0 and 1 must have different sk";
+  EXPECT_TRUE(memcmp(keys0.ask, keys1.ask, 32) != 0)
+      << "Account 0 and 1 must have different ask";
+  EXPECT_TRUE(memcmp(keys0.nk, keys1.nk, 32) != 0)
+      << "Account 0 and 1 must have different nk";
+
+  memzero(&keys0, sizeof(keys0));
+  memzero(&keys1, sizeof(keys1));
+}
+
+TEST(Zcash, DeriveOrchardKeys_DifferentSeeds) {
+  /* Use a different seed (all zeros) */
+  uint8_t zero_seed[64];
+  memset(zero_seed, 0, sizeof(zero_seed));
+
+  ZcashOrchardKeys keys_all, keys_zero;
+  ASSERT_TRUE(zcash_derive_orchard_keys(SEED_ALL, 64, 0, &keys_all));
+  ASSERT_TRUE(zcash_derive_orchard_keys(zero_seed, 64, 0, &keys_zero));
+
+  EXPECT_TRUE(memcmp(keys_all.sk, keys_zero.sk, 32) != 0)
+      << "Different seeds must produce different sk";
+
+  memzero(&keys_all, sizeof(keys_all));
+  memzero(&keys_zero, sizeof(keys_zero));
+}
+
+TEST(Zcash, DeriveOrchardKeys_Deterministic) {
+  ZcashOrchardKeys keys1, keys2;
+  ASSERT_TRUE(zcash_derive_orchard_keys(SEED_ALL, 64, 0, &keys1));
+  ASSERT_TRUE(zcash_derive_orchard_keys(SEED_ALL, 64, 0, &keys2));
+
+  EXPECT_TRUE(memcmp(keys1.sk, keys2.sk, 32) == 0);
+  EXPECT_TRUE(memcmp(keys1.ask, keys2.ask, 32) == 0);
+  EXPECT_TRUE(memcmp(keys1.nk, keys2.nk, 32) == 0);
+  EXPECT_TRUE(memcmp(keys1.rivk, keys2.rivk, 32) == 0);
+  EXPECT_TRUE(memcmp(keys1.dk, keys2.dk, 32) == 0);
+
+  memzero(&keys1, sizeof(keys1));
+  memzero(&keys2, sizeof(keys2));
+}
+
+TEST(Zcash, DeriveOrchardKeys_DerivesDiversifierKey) {
+  ZcashOrchardKeys keys0, keys1;
+  ASSERT_TRUE(zcash_derive_orchard_keys(SEED_ALL, 64, 0, &keys0));
+  ASSERT_TRUE(zcash_derive_orchard_keys(SEED_ALL, 64, 1, &keys1));
+
+  uint8_t zero[32] = {0};
+  EXPECT_TRUE(memcmp(keys0.dk, zero, 32) != 0)
+      << "Diversifier key must be populated";
+  EXPECT_TRUE(memcmp(keys0.dk, keys1.dk, 32) != 0)
+      << "Different accounts must produce different diversifier keys";
+
+  memzero(&keys0, sizeof(keys0));
+  memzero(&keys1, sizeof(keys1));
+}
+
+TEST(Zcash, OrchardDiversifier_FF1ReferenceVectors) {
+  for (const auto& tv : ORCHARD_FF1_VECTORS) {
+    uint8_t actual[11];
+    ASSERT_TRUE(zcash_orchard_derive_diversifier(tv.dk, tv.index, actual));
+    EXPECT_TRUE(memcmp(actual, tv.diversifier, sizeof(actual)) == 0);
+    memzero(actual, sizeof(actual));
+  }
+}
+
+TEST(Zcash, OrchardDiversifier_DeterministicAndDistinct) {
+  const uint8_t index0[11] = {0};
+  const uint8_t index1[11] = {1};
+  uint8_t d0[11], d0_again[11], d1[11];
+
+  ASSERT_TRUE(zcash_orchard_derive_diversifier(ORCHARD_FF1_VECTORS[2].dk,
+                                               index0, d0));
+  ASSERT_TRUE(zcash_orchard_derive_diversifier(ORCHARD_FF1_VECTORS[2].dk,
+                                               index0, d0_again));
+  ASSERT_TRUE(zcash_orchard_derive_diversifier(ORCHARD_FF1_VECTORS[2].dk,
+                                               index1, d1));
+
+  EXPECT_TRUE(memcmp(d0, d0_again, sizeof(d0)) == 0);
+  EXPECT_TRUE(memcmp(d0, d1, sizeof(d0)) != 0);
+
+  memzero(d0, sizeof(d0));
+  memzero(d0_again, sizeof(d0_again));
+  memzero(d1, sizeof(d1));
+}
+
+TEST(Zcash, ExpandMessageXmdBlake2b_ReferenceVector) {
+  const uint8_t msg[] = {'a', 'b', 'c'};
+  const uint8_t dst[] = "z.cash:test-pallas_XMD:BLAKE2b_SSWU_RO_";
+  uint8_t out[96];
+
+  ASSERT_EQ(pallas_expand_message_xmd_blake2b(msg, sizeof(msg), dst,
+                                              sizeof(dst) - 1, out,
+                                              sizeof(out)),
+            0);
+  EXPECT_TRUE(memcmp(out, XMD_ABC_96, sizeof(out)) == 0);
+}
+
+static void expect_bn_le(const bignum256* value, const uint8_t expected[32]) {
+  uint8_t actual[32];
+  bignum256 tmp;
+  bn_copy(value, &tmp);
+  bn_write_le(&tmp, actual);
+  EXPECT_TRUE(memcmp(actual, expected, 32) == 0);
+  memzero(actual, sizeof(actual));
+  memzero(&tmp, sizeof(tmp));
+}
+
+static void load_curve_point_from_xy(const uint8_t x[32], const uint8_t y[32],
+                                     curve_point* out) {
+  bn_read_le(x, &out->x);
+  bn_read_le(y, &out->y);
+  bn_normalize(&out->x);
+  bn_normalize(&out->y);
+}
+
+TEST(Zcash, PallasSimpleSwu_ReferenceVectors) {
+  uint8_t u0[32] = {0};
+  uint8_t u1[32] = {0};
+  u1[0] = 1;
+
+  pallas_jacobian_point p0, p1;
+  ASSERT_EQ(pallas_map_to_curve_simple_swu(u0, &p0), 0);
+  ASSERT_EQ(pallas_map_to_curve_simple_swu(u1, &p1), 0);
+
+  expect_bn_le(&p0.x, SWU_0_X_LE);
+  expect_bn_le(&p0.y, SWU_0_Y_LE);
+  expect_bn_le(&p0.z, SWU_0_Z_LE);
+  expect_bn_le(&p1.x, SWU_1_X_LE);
+  expect_bn_le(&p1.y, SWU_1_Y_LE);
+  expect_bn_le(&p1.z, SWU_1_Z_LE);
+
+  memzero(&p0, sizeof(p0));
+  memzero(&p1, sizeof(p1));
+}
+
+TEST(Zcash, PallasGroupHash_ReferenceVector) {
+  const uint8_t msg[] = "Trans rights now!";
+  curve_point p;
+  uint8_t encoded[32];
+
+  ASSERT_EQ(pallas_group_hash("z.cash:test", msg, sizeof(msg) - 1, &p), 0);
+  pallas_point_encode(&p, encoded);
+  EXPECT_TRUE(memcmp(encoded, HASH_ZCASH_TEST_TRANS_RIGHTS, sizeof(encoded)) ==
+              0);
+
+  memzero(&p, sizeof(p));
+  memzero(encoded, sizeof(encoded));
+}
+
+struct SinsemillaPrimitiveVector {
+  const uint8_t* msg;
+  size_t msg_bits;
+  const uint8_t* blind;
+  const uint8_t* hash_point;
+  const uint8_t* hash;
+  const uint8_t* commit_point;
+  const uint8_t* short_commit;
+};
+
+TEST(Zcash, SinsemillaPrimitives_ReferenceVectors) {
+  const SinsemillaPrimitiveVector vectors[] = {
+      {nullptr, 0, SINSEMILLA_ZERO_BLIND, SINSEMILLA_EMPTY_HASH_POINT,
+       SINSEMILLA_EMPTY_HASH, SINSEMILLA_EMPTY_HASH_POINT,
+       SINSEMILLA_EMPTY_HASH},
+      {SINSEMILLA_MSG_ONE_BIT, 1, SINSEMILLA_ZERO_BLIND,
+       SINSEMILLA_ONE_BIT_HASH_POINT, SINSEMILLA_ONE_BIT_HASH,
+       SINSEMILLA_ONE_BIT_HASH_POINT, SINSEMILLA_ONE_BIT_HASH},
+      {SINSEMILLA_MSG_TEN_BITS, 10, SINSEMILLA_ZERO_BLIND,
+       SINSEMILLA_TEN_BITS_HASH_POINT, SINSEMILLA_TEN_BITS_HASH,
+       SINSEMILLA_TEN_BITS_HASH_POINT, SINSEMILLA_TEN_BITS_HASH},
+      {SINSEMILLA_MSG_TWENTY_THREE_BITS, 23, SINSEMILLA_NONZERO_BLIND,
+       SINSEMILLA_TWENTY_THREE_BITS_HASH_POINT,
+       SINSEMILLA_TWENTY_THREE_BITS_HASH,
+       SINSEMILLA_TWENTY_THREE_BITS_COMMIT_POINT,
+       SINSEMILLA_TWENTY_THREE_BITS_SHORT_COMMIT},
+  };
+
+  curve_point q, r;
+  load_curve_point_from_xy(SINSEMILLA_COMMIT_IVK_Q_X,
+                           SINSEMILLA_COMMIT_IVK_Q_Y, &q);
+  load_curve_point_from_xy(SINSEMILLA_COMMIT_IVK_R_X,
+                           SINSEMILLA_COMMIT_IVK_R_Y, &r);
+
+  for (const auto& vector : vectors) {
+    curve_point hash_point, commit_point;
+    uint8_t encoded[32];
+    uint8_t hash[32];
+    uint8_t short_commit[32];
+
+    ASSERT_EQ(pallas_sinsemilla_hash_to_point(&q, vector.msg,
+                                              vector.msg_bits, &hash_point),
+              0);
+    pallas_point_encode(&hash_point, encoded);
+    EXPECT_TRUE(memcmp(encoded, vector.hash_point, sizeof(encoded)) == 0);
+
+    ASSERT_EQ(pallas_sinsemilla_hash(&q, vector.msg, vector.msg_bits, hash),
+              0);
+    EXPECT_TRUE(memcmp(hash, vector.hash, sizeof(hash)) == 0);
+
+    ASSERT_EQ(pallas_sinsemilla_commit(&q, &r, vector.msg, vector.msg_bits,
+                                       vector.blind, &commit_point),
+              0);
+    pallas_point_encode(&commit_point, encoded);
+    EXPECT_TRUE(memcmp(encoded, vector.commit_point, sizeof(encoded)) == 0);
+
+    ASSERT_EQ(pallas_sinsemilla_short_commit(
+                  &q, &r, vector.msg, vector.msg_bits, vector.blind,
+                  short_commit),
+              0);
+    EXPECT_TRUE(memcmp(short_commit, vector.short_commit,
+                       sizeof(short_commit)) == 0);
+
+    memzero(&hash_point, sizeof(hash_point));
+    memzero(&commit_point, sizeof(commit_point));
+    memzero(encoded, sizeof(encoded));
+    memzero(hash, sizeof(hash));
+    memzero(short_commit, sizeof(short_commit));
+  }
+
+  memzero(&q, sizeof(q));
+  memzero(&r, sizeof(r));
+}
+
+TEST(Zcash, SinsemillaPrimitives_RejectInvalidInputs) {
+  curve_point q, r, out;
+  load_curve_point_from_xy(SINSEMILLA_COMMIT_IVK_Q_X,
+                           SINSEMILLA_COMMIT_IVK_Q_Y, &q);
+  load_curve_point_from_xy(SINSEMILLA_COMMIT_IVK_R_X,
+                           SINSEMILLA_COMMIT_IVK_R_Y, &r);
+
+  EXPECT_EQ(pallas_sinsemilla_hash_to_point(
+                &q, SINSEMILLA_MSG_ONE_BIT,
+                PALLAS_SINSEMILLA_MAX_BITS + 1, &out),
+            -1);
+
+  curve_point identity = {};
+  EXPECT_EQ(pallas_sinsemilla_hash_to_point(
+                &identity, SINSEMILLA_MSG_ONE_BIT, 1, &out),
+            -1);
+  EXPECT_EQ(pallas_sinsemilla_commit(&q, &identity, SINSEMILLA_MSG_ONE_BIT, 1,
+                                     SINSEMILLA_ZERO_BLIND, &out),
+            -1);
+  EXPECT_EQ(pallas_sinsemilla_commit(&q, &r, SINSEMILLA_MSG_ONE_BIT, 1,
+                                     PALLAS_Q_LE, &out),
+            -1);
+
+  memzero(&q, sizeof(q));
+  memzero(&r, sizeof(r));
+  memzero(&out, sizeof(out));
+  memzero(&identity, sizeof(identity));
+}
+
+TEST(Zcash, Zip316F4Jumble_ReferenceVectors) {
+  uint8_t buf48[sizeof(F4JUMBLE_48_NORMAL)];
+  memcpy(buf48, F4JUMBLE_48_NORMAL, sizeof(buf48));
+  ASSERT_EQ(zcash_zip316_f4jumble(buf48, sizeof(buf48)), 0);
+  EXPECT_TRUE(memcmp(buf48, F4JUMBLE_48_JUMBLED, sizeof(buf48)) == 0);
+  ASSERT_EQ(zcash_zip316_f4jumble_inv(buf48, sizeof(buf48)), 0);
+  EXPECT_TRUE(memcmp(buf48, F4JUMBLE_48_NORMAL, sizeof(buf48)) == 0);
+
+  uint8_t buf64[sizeof(F4JUMBLE_64_NORMAL)];
+  memcpy(buf64, F4JUMBLE_64_NORMAL, sizeof(buf64));
+  ASSERT_EQ(zcash_zip316_f4jumble(buf64, sizeof(buf64)), 0);
+  EXPECT_TRUE(memcmp(buf64, F4JUMBLE_64_JUMBLED, sizeof(buf64)) == 0);
+  ASSERT_EQ(zcash_zip316_f4jumble_inv(buf64, sizeof(buf64)), 0);
+  EXPECT_TRUE(memcmp(buf64, F4JUMBLE_64_NORMAL, sizeof(buf64)) == 0);
+
+  memzero(buf48, sizeof(buf48));
+  memzero(buf64, sizeof(buf64));
+}
+
+TEST(Zcash, Zip316F4Jumble_RejectsInvalidLengths) {
+  uint8_t too_short[ZCASH_ZIP316_F4JUMBLE_MIN_LEN - 1] = {0};
+  EXPECT_EQ(zcash_zip316_f4jumble(too_short, sizeof(too_short)), -1);
+  EXPECT_EQ(zcash_zip316_f4jumble_inv(too_short, sizeof(too_short)), -1);
+  EXPECT_EQ(zcash_zip316_f4jumble(nullptr, ZCASH_ZIP316_F4JUMBLE_MIN_LEN),
+            -1);
+}
+
+TEST(Zcash, Zip316OrchardOnlyUnifiedAddress_ReferenceVectors) {
+  char address[ZCASH_ZIP316_ORCHARD_ONLY_MAX_ADDRESS_SIZE];
+
+  ASSERT_EQ(zcash_zip316_encode_orchard_unified_address(
+                "u", ORCHARD_RECEIVER_ASSEMBLY_VECTORS[0].receiver, address,
+                sizeof(address)),
+            0);
+  EXPECT_STREQ(address, ORCHARD_ONLY_UA_MAINNET_0);
+
+  ASSERT_EQ(zcash_zip316_encode_orchard_unified_address(
+                "utest", ORCHARD_RECEIVER_ASSEMBLY_VECTORS[0].receiver,
+                address, sizeof(address)),
+            0);
+  EXPECT_STREQ(address, ORCHARD_ONLY_UA_TESTNET_0);
+
+  ASSERT_EQ(zcash_zip316_encode_orchard_unified_address(
+                "u", ORCHARD_RECEIVER_ASSEMBLY_VECTORS[1].receiver, address,
+                sizeof(address)),
+            0);
+  EXPECT_STREQ(address, ORCHARD_ONLY_UA_MAINNET_1);
+
+  ASSERT_EQ(zcash_zip316_encode_orchard_unified_address(
+                "utest", ORCHARD_RECEIVER_ASSEMBLY_VECTORS[1].receiver,
+                address, sizeof(address)),
+            0);
+  EXPECT_STREQ(address, ORCHARD_ONLY_UA_TESTNET_1);
+
+  memzero(address, sizeof(address));
+}
+
+TEST(Zcash, Zip316OrchardOnlyUnifiedAddress_RejectsInvalidInputs) {
+  char address[ZCASH_ZIP316_ORCHARD_ONLY_MAX_ADDRESS_SIZE];
+  char too_small[16];
+  char long_hrp[ZCASH_ZIP316_PADDING_LEN + 2];
+  memset(long_hrp, 'a', sizeof(long_hrp) - 1);
+  long_hrp[sizeof(long_hrp) - 1] = 0;
+
+  EXPECT_EQ(zcash_zip316_encode_orchard_unified_address(
+                "u", ORCHARD_RECEIVER_ASSEMBLY_VECTORS[0].receiver,
+                too_small, sizeof(too_small)),
+            -1);
+  EXPECT_EQ(zcash_zip316_encode_orchard_unified_address(
+                long_hrp, ORCHARD_RECEIVER_ASSEMBLY_VECTORS[0].receiver,
+                address, sizeof(address)),
+            -1);
+  EXPECT_EQ(zcash_zip316_encode_orchard_unified_address(
+                "U", ORCHARD_RECEIVER_ASSEMBLY_VECTORS[0].receiver, address,
+                sizeof(address)),
+            -1);
+
+  memzero(address, sizeof(address));
+  memzero(too_small, sizeof(too_small));
+  memzero(long_hrp, sizeof(long_hrp));
+}
+
+TEST(Zcash, OrchardUnifiedAddress_FromDerivedKeys) {
+  ZcashOrchardKeys keys;
+  ASSERT_TRUE(zcash_derive_orchard_keys(SEED_ALL, 64, 0, &keys));
+
+  char address[ZCASH_ZIP316_ORCHARD_ONLY_MAX_ADDRESS_SIZE];
+  const uint8_t index0[11] = {0};
+  const uint8_t index1[11] = {1};
+
+  ASSERT_TRUE(zcash_orchard_derive_unified_address(
+      &keys, index0, "u", address, sizeof(address)));
+  EXPECT_STREQ(address, ORCHARD_ONLY_UA_MAINNET_0);
+
+  ASSERT_TRUE(zcash_orchard_derive_unified_address(
+      &keys, index0, "utest", address, sizeof(address)));
+  EXPECT_STREQ(address, ORCHARD_ONLY_UA_TESTNET_0);
+
+  ASSERT_TRUE(zcash_orchard_derive_unified_address(
+      &keys, index1, "u", address, sizeof(address)));
+  EXPECT_STREQ(address, ORCHARD_ONLY_UA_MAINNET_1);
+
+  ASSERT_TRUE(zcash_orchard_derive_unified_address(
+      &keys, index1, "utest", address, sizeof(address)));
+  EXPECT_STREQ(address, ORCHARD_ONLY_UA_TESTNET_1);
+
+  memzero(address, sizeof(address));
+  memzero(&keys, sizeof(keys));
+}
+
+TEST(Zcash, OrchardUnifiedAddress_FromSeedAccountAndIndex) {
+  char address[ZCASH_ZIP316_ORCHARD_ONLY_MAX_ADDRESS_SIZE];
+  const uint8_t index0[11] = {0};
+
+  ASSERT_TRUE(zcash_derive_orchard_unified_address(
+      SEED_ALL, 64, 0, index0, "u", address, sizeof(address)));
+  EXPECT_STREQ(address, ORCHARD_ONLY_UA_MAINNET_0);
+
+  ASSERT_TRUE(zcash_derive_orchard_unified_address(
+      SEED_ALL, 64, 0, index0, "utest", address, sizeof(address)));
+  EXPECT_STREQ(address, ORCHARD_ONLY_UA_TESTNET_0);
+
+  memzero(address, sizeof(address));
+}
+
+TEST(Zcash, OrchardUnifiedAddress_RejectsInvalidInputs) {
+  ZcashOrchardKeys keys;
+  ASSERT_TRUE(zcash_derive_orchard_keys(SEED_ALL, 64, 0, &keys));
+
+  char address[ZCASH_ZIP316_ORCHARD_ONLY_MAX_ADDRESS_SIZE];
+  char too_small[16];
+  const uint8_t index0[11] = {0};
+
+  EXPECT_FALSE(zcash_orchard_derive_unified_address(
+      nullptr, index0, "u", address, sizeof(address)));
+  EXPECT_FALSE(zcash_orchard_derive_unified_address(
+      &keys, nullptr, "u", address, sizeof(address)));
+  EXPECT_FALSE(zcash_orchard_derive_unified_address(
+      &keys, index0, nullptr, address, sizeof(address)));
+  EXPECT_FALSE(zcash_orchard_derive_unified_address(
+      &keys, index0, "u", nullptr, sizeof(address)));
+  EXPECT_FALSE(zcash_orchard_derive_unified_address(
+      &keys, index0, "u", too_small, sizeof(too_small)));
+
+  EXPECT_FALSE(zcash_derive_orchard_unified_address(
+      nullptr, 64, 0, index0, "u", address, sizeof(address)));
+
+  memzero(address, sizeof(address));
+  memzero(too_small, sizeof(too_small));
+  memzero(&keys, sizeof(keys));
+}
+
+TEST(Zcash, OrchardNoteCommitment_KnownVector) {
+  const uint8_t recipient[ZCASH_ORCHARD_RAW_RECEIVER_SIZE] = {
+      0x3c, 0x15, 0x0e, 0x60, 0x98, 0xb8, 0x61, 0x71, 0x6c, 0xc7, 0xf6,
+      0x28, 0x35, 0xf6, 0x9f, 0xeb, 0x30, 0x21, 0x93, 0xc9, 0x26, 0x60,
+      0x44, 0x4f, 0x26, 0x62, 0x4f, 0xd1, 0x3e, 0x00, 0xea, 0x7a, 0xc7,
+      0x74, 0xcd, 0x55, 0x07, 0x4d, 0x63, 0x67, 0xef, 0xef, 0x37};
+  const uint64_t value = 12345678;
+  const uint8_t rho[32] = {
+      0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+      0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00,
+      0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+      0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00};
+  const uint8_t rseed[32] = {
+      0xca, 0xfe, 0xba, 0xbe, 0xde, 0xad, 0xbe, 0xef,
+      0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+      0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+      0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18};
+  const uint8_t expected_cmx[32] = {
+      0x02, 0xde, 0xfb, 0x39, 0xc8, 0xf2, 0xe1, 0xec,
+      0xc9, 0x45, 0x18, 0x93, 0x73, 0xcf, 0x2a, 0x8e,
+      0x21, 0xd4, 0xe1, 0x54, 0x39, 0x8e, 0xfa, 0x16,
+      0x21, 0xd5, 0xfb, 0x98, 0x9e, 0x1d, 0xeb, 0x36};
+
+  uint8_t cmx[32];
+  ASSERT_TRUE(zcash_orchard_compute_cmx(recipient, value, rho, rseed, cmx));
+  EXPECT_TRUE(memcmp(cmx, expected_cmx, sizeof(cmx)) == 0);
+
+  uint8_t tampered[ZCASH_ORCHARD_RAW_RECEIVER_SIZE];
+  memcpy(tampered, recipient, sizeof(tampered));
+  tampered[0] ^= 0x01;
+  ASSERT_TRUE(zcash_orchard_compute_cmx(tampered, value, rho, rseed, cmx));
+  EXPECT_TRUE(memcmp(cmx, expected_cmx, sizeof(cmx)) != 0);
+
+  memzero(cmx, sizeof(cmx));
+  memzero(tampered, sizeof(tampered));
+}
+
+TEST(Zcash, OrchardReceiverToUnifiedAddress_KnownVector) {
+  const uint8_t recipient[ZCASH_ORCHARD_RAW_RECEIVER_SIZE] = {
+      0x3c, 0x15, 0x0e, 0x60, 0x98, 0xb8, 0x61, 0x71, 0x6c, 0xc7, 0xf6,
+      0x28, 0x35, 0xf6, 0x9f, 0xeb, 0x30, 0x21, 0x93, 0xc9, 0x26, 0x60,
+      0x44, 0x4f, 0x26, 0x62, 0x4f, 0xd1, 0x3e, 0x00, 0xea, 0x7a, 0xc7,
+      0x74, 0xcd, 0x55, 0x07, 0x4d, 0x63, 0x67, 0xef, 0xef, 0x37};
+  char address[ZCASH_ORCHARD_UNIFIED_ADDRESS_SIZE];
+
+  ASSERT_TRUE(zcash_orchard_receiver_to_unified_address(
+      recipient, "u", address, sizeof(address)));
+  EXPECT_STREQ(
+      address,
+      "u1ut4h93zg5670tyqss7tneru3t7h6dk62r9hhyxyrpv3nwwe9dnyj5l0ruwygf74gp5f3zklj5xly4h8h54un3asugt9mn6gwfqsq3wq7");
+
+  EXPECT_FALSE(zcash_orchard_receiver_to_unified_address(
+      recipient, "u", address, 16));
+  memzero(address, sizeof(address));
+}
+
+TEST(Zcash, OrchardDiversifyHash_ReferenceVectors) {
+  uint8_t gd[32];
+  ASSERT_TRUE(zcash_orchard_diversify_hash(EXPECTED_DIVERSIFIER_ALL_0, gd));
+  EXPECT_TRUE(memcmp(gd, ORCHARD_GD_ALL_ACCOUNT0_J0, sizeof(gd)) == 0);
+
+  ASSERT_TRUE(zcash_orchard_diversify_hash(ORCHARD_FF1_VECTORS[0].diversifier,
+                                           gd));
+  EXPECT_TRUE(memcmp(gd, ORCHARD_GD_FF1_ZERO_ZERO, sizeof(gd)) == 0);
+
+  curve_point empty;
+  ASSERT_EQ(pallas_group_hash("z.cash:Orchard-gd", NULL, 0, &empty), 0);
+  pallas_point_encode(&empty, gd);
+  EXPECT_TRUE(memcmp(gd, ORCHARD_GD_EMPTY, sizeof(gd)) == 0);
+
+  memzero(gd, sizeof(gd));
+  memzero(&empty, sizeof(empty));
+}
+
+TEST(Zcash, OrchardTransmissionKey_ReferenceVectors) {
+  for (const auto& vector : ORCHARD_RECEIVER_VECTORS) {
+    uint8_t gd[32];
+    uint8_t pkd[32];
+    ASSERT_TRUE(zcash_orchard_derive_transmission_key(
+        vector.ivk, vector.diversifier, gd, pkd));
+    EXPECT_TRUE(memcmp(gd, vector.gd, sizeof(gd)) == 0);
+    EXPECT_TRUE(memcmp(pkd, vector.pkd, sizeof(pkd)) == 0);
+
+    uint8_t pkd_without_gd[32];
+    ASSERT_TRUE(zcash_orchard_derive_transmission_key(
+        vector.ivk, vector.diversifier, nullptr, pkd_without_gd));
+    EXPECT_TRUE(memcmp(pkd_without_gd, vector.pkd, sizeof(pkd_without_gd)) ==
+                0);
+
+    memzero(gd, sizeof(gd));
+    memzero(pkd, sizeof(pkd));
+    memzero(pkd_without_gd, sizeof(pkd_without_gd));
+  }
+}
+
+TEST(Zcash, OrchardTransmissionKey_RejectsZeroIvk) {
+  uint8_t zero_ivk[32] = {0};
+  uint8_t gd[32];
+  uint8_t pkd[32];
+  EXPECT_FALSE(zcash_orchard_derive_transmission_key(
+      zero_ivk, ORCHARD_RECEIVER_VECTORS[0].diversifier, gd, pkd));
+}
+
+TEST(Zcash, OrchardIvk_ReferenceVectors) {
+  for (const auto& vector : ORCHARD_IVK_VECTORS) {
+    uint8_t ivk[32];
+    ASSERT_TRUE(
+        zcash_orchard_derive_ivk(vector.ak, vector.nk, vector.rivk, ivk));
+    EXPECT_TRUE(memcmp(ivk, vector.ivk, sizeof(ivk)) == 0);
+    memzero(ivk, sizeof(ivk));
+  }
+}
+
+TEST(Zcash, OrchardIvk_RejectsInvalidAkEncoding) {
+  uint8_t bad_ak[32];
+  memcpy(bad_ak, ORCHARD_IVK_VECTORS[0].ak, sizeof(bad_ak));
+  bad_ak[31] |= 0x80;
+
+  uint8_t ivk[32];
+  EXPECT_FALSE(zcash_orchard_derive_ivk(
+      bad_ak, ORCHARD_IVK_VECTORS[0].nk, ORCHARD_IVK_VECTORS[0].rivk, ivk));
+  memzero(bad_ak, sizeof(bad_ak));
+  memzero(ivk, sizeof(ivk));
+}
+
+TEST(Zcash, OrchardReceiver_ReferenceVectors) {
+  for (const auto& vector : ORCHARD_RECEIVER_ASSEMBLY_VECTORS) {
+    uint8_t receiver[43];
+    ASSERT_TRUE(zcash_orchard_derive_receiver(
+        vector.ak, vector.nk, vector.rivk, vector.dk, vector.index, receiver));
+    EXPECT_TRUE(memcmp(receiver, vector.receiver, sizeof(receiver)) == 0);
+    memzero(receiver, sizeof(receiver));
+  }
+}
+
+TEST(Zcash, OrchardReceiver_RejectsInvalidAkEncoding) {
+  uint8_t bad_ak[32];
+  memcpy(bad_ak, ORCHARD_RECEIVER_ASSEMBLY_VECTORS[0].ak, sizeof(bad_ak));
+  bad_ak[31] |= 0x80;
+
+  uint8_t receiver[43];
+  EXPECT_FALSE(zcash_orchard_derive_receiver(
+      bad_ak, ORCHARD_RECEIVER_ASSEMBLY_VECTORS[0].nk,
+      ORCHARD_RECEIVER_ASSEMBLY_VECTORS[0].rivk,
+      ORCHARD_RECEIVER_ASSEMBLY_VECTORS[0].dk,
+      ORCHARD_RECEIVER_ASSEMBLY_VECTORS[0].index, receiver));
+  memzero(bad_ak, sizeof(bad_ak));
+  memzero(receiver, sizeof(receiver));
+}
+
+/* ── Field Range Tests ───────────────────────────────────────────── */
+
+TEST(Zcash, DeriveOrchardKeys_FieldRanges) {
+  /* Test multiple accounts to increase coverage of edge cases */
+  for (uint32_t account = 0; account < 5; account++) {
+    ZcashOrchardKeys keys;
+    ASSERT_TRUE(zcash_derive_orchard_keys(SEED_ALL, 64, account, &keys));
+
+    /* nk must be < Pallas base field prime p */
+    EXPECT_LT(cmp_le256(keys.nk, PALLAS_P_LE), 0)
+        << "nk must be < p for account " << account;
+
+    /* rivk must be < Pallas scalar field order q */
+    EXPECT_LT(cmp_le256(keys.rivk, PALLAS_Q_LE), 0)
+        << "rivk must be < q for account " << account;
+
+    /* ask must be < Pallas scalar field order q */
+    EXPECT_LT(cmp_le256(keys.ask, PALLAS_Q_LE), 0)
+        << "ask must be < q for account " << account;
+
+    /* ask must be nonzero (astronomically unlikely, but verify) */
+    uint8_t zero[32] = {0};
+    EXPECT_TRUE(memcmp(keys.ask, zero, 32) != 0)
+        << "ask must be nonzero for account " << account;
+
+    memzero(&keys, sizeof(keys));
+  }
+}
+
+TEST(Zcash, AkSignBit_AlwaysClear) {
+  /*
+   * For every account, compute ak = [ask]*G and verify the sign bit
+   * is always clear. This is the invariant that the ask negation
+   * in zcash_derive_orchard_keys() is supposed to enforce.
+   */
+  for (uint32_t account = 0; account < 10; account++) {
+    ZcashOrchardKeys keys;
+    ASSERT_TRUE(zcash_derive_orchard_keys(SEED_ALL, 64, account, &keys));
+
+    bignum256 ask_scalar;
+    bn_read_le(keys.ask, &ask_scalar);
+    curve_point ak_point;
+    redpallas_scalar_mult_spendauth_G(&ask_scalar, &ak_point);
+
+    /* Check y parity: must be even (sign bit = 0) */
+    EXPECT_FALSE(bn_is_odd(&ak_point.y))
+        << "ak y-coordinate must be even for account " << account;
+
+    /* Check serialized sign bit */
+    uint8_t ak_bytes[32];
+    bignum256 x_copy;
+    bn_copy(&ak_point.x, &x_copy);
+    bn_write_le(&x_copy, ak_bytes);
+
+    EXPECT_EQ(ak_bytes[31] & 0x80, 0)
+        << "ak sign bit must be clear for account " << account;
+
+    memzero(&keys, sizeof(keys));
+  }
+}
+
+/* ── PCZT Signing Policy Tests ───────────────────────────────────── */
+
+static ZcashPCZTSigningRequestMeta clear_pczt_meta(void) {
+  ZcashPCZTSigningRequestMeta meta = {};
+  meta.has_header_digest = true;
+  meta.header_digest_size = 32;
+  meta.has_orchard_digest = true;
+  meta.orchard_digest_size = 32;
+  meta.has_orchard_flags = true;
+  meta.has_orchard_value_balance = true;
+  meta.has_orchard_anchor = true;
+  meta.orchard_anchor_size = 32;
+  meta.has_header_fields = true;
+  meta.n_transparent_inputs = 0;
+  meta.n_transparent_outputs = 0;
+  return meta;
+}
+
+TEST(Zcash, PCZTSigningPolicy_AcceptsVerifiedShieldedOnlyRequest) {
+  ZcashPCZTSigningRequestMeta meta = clear_pczt_meta();
+
+  EXPECT_EQ(zcash_pczt_signing_request_status(&meta),
+            ZCASH_PCZT_SIGNING_REQUEST_OK);
+  EXPECT_TRUE(zcash_pczt_signing_request_is_clear(&meta));
+}
+
+TEST(Zcash, PCZTSigningPolicy_RejectsMissingTransactionDigests) {
+  ZcashPCZTSigningRequestMeta meta = clear_pczt_meta();
+
+  meta.has_header_digest = false;
+  EXPECT_EQ(zcash_pczt_signing_request_status(&meta),
+            ZCASH_PCZT_SIGNING_REQUEST_MISSING_TX_DIGESTS);
+  EXPECT_FALSE(zcash_pczt_signing_request_is_clear(&meta));
+
+  meta = clear_pczt_meta();
+  meta.orchard_digest_size = 31;
+  EXPECT_EQ(zcash_pczt_signing_request_status(&meta),
+            ZCASH_PCZT_SIGNING_REQUEST_INVALID_DIGEST_SIZE);
+  EXPECT_FALSE(zcash_pczt_signing_request_is_clear(&meta));
+}
+
+TEST(Zcash, PCZTSigningPolicy_RejectsMissingPlaintextHeaderFields) {
+  ZcashPCZTSigningRequestMeta meta = clear_pczt_meta();
+
+  meta.has_header_fields = false;
+  EXPECT_EQ(zcash_pczt_signing_request_status(&meta),
+            ZCASH_PCZT_SIGNING_REQUEST_MISSING_HEADER_FIELDS);
+  EXPECT_FALSE(zcash_pczt_signing_request_is_clear(&meta));
+}
+
+TEST(Zcash, PCZTSigningPolicy_RejectsMissingOrchardMetadata) {
+  ZcashPCZTSigningRequestMeta meta = clear_pczt_meta();
+
+  meta.has_orchard_anchor = false;
+  EXPECT_EQ(zcash_pczt_signing_request_status(&meta),
+            ZCASH_PCZT_SIGNING_REQUEST_MISSING_ORCHARD_METADATA);
+  EXPECT_FALSE(zcash_pczt_signing_request_is_clear(&meta));
+
+  meta = clear_pczt_meta();
+  meta.has_orchard_flags = false;
+  EXPECT_EQ(zcash_pczt_signing_request_status(&meta),
+            ZCASH_PCZT_SIGNING_REQUEST_MISSING_ORCHARD_METADATA);
+  EXPECT_FALSE(zcash_pczt_signing_request_is_clear(&meta));
+}
+
+TEST(Zcash, PCZTSigningPolicy_RejectsInvalidOptionalDigests) {
+  ZcashPCZTSigningRequestMeta meta = clear_pczt_meta();
+
+  meta.has_transparent_digest = true;
+  meta.transparent_digest_size = 31;
+  EXPECT_EQ(zcash_pczt_signing_request_status(&meta),
+            ZCASH_PCZT_SIGNING_REQUEST_INVALID_DIGEST_SIZE);
+  EXPECT_FALSE(zcash_pczt_signing_request_is_clear(&meta));
+}
+
+TEST(Zcash, PCZTSigningPolicy_RejectsSaplingComponent) {
+  ZcashPCZTSigningRequestMeta meta = clear_pczt_meta();
+
+  meta.has_sapling_digest = true;
+  meta.sapling_digest_size = 32;
+  EXPECT_EQ(zcash_pczt_signing_request_status(&meta),
+            ZCASH_PCZT_SIGNING_REQUEST_UNSUPPORTED_SAPLING_COMPONENT);
+  EXPECT_FALSE(zcash_pczt_signing_request_is_clear(&meta));
+}
+
+TEST(Zcash, PCZTSigningPolicy_RejectsTransparentComponentsWithoutDigest) {
+  ZcashPCZTSigningRequestMeta meta = clear_pczt_meta();
+  meta.n_transparent_inputs = 1;
+
+  EXPECT_EQ(zcash_pczt_signing_request_status(&meta),
+            ZCASH_PCZT_SIGNING_REQUEST_MISSING_TRANSPARENT_DIGEST);
+  EXPECT_FALSE(zcash_pczt_signing_request_is_clear(&meta));
+
+  meta.has_transparent_digest = true;
+  meta.transparent_digest_size = 32;
+  EXPECT_EQ(zcash_pczt_signing_request_status(&meta),
+            ZCASH_PCZT_SIGNING_REQUEST_OK);
+  EXPECT_TRUE(zcash_pczt_signing_request_is_clear(&meta));
+
+  meta = clear_pczt_meta();
+  meta.n_transparent_outputs = 1;
+  EXPECT_EQ(zcash_pczt_signing_request_status(&meta),
+            ZCASH_PCZT_SIGNING_REQUEST_MISSING_TRANSPARENT_DIGEST);
+  EXPECT_FALSE(zcash_pczt_signing_request_is_clear(&meta));
+
+  meta.has_transparent_digest = true;
+  meta.transparent_digest_size = 32;
+  EXPECT_EQ(zcash_pczt_signing_request_status(&meta),
+            ZCASH_PCZT_SIGNING_REQUEST_OK);
+  EXPECT_TRUE(zcash_pczt_signing_request_is_clear(&meta));
+}
+
+static const uint8_t ZIP244_EXPECTED_HEADER_DIGEST[32] = {
+    0x44, 0x4b, 0xe9, 0x38, 0x88, 0x1d, 0xc9, 0xf2,
+    0x0a, 0xed, 0x88, 0x0c, 0x3a, 0x05, 0x94, 0xe5,
+    0xc1, 0x22, 0x3e, 0xff, 0xc5, 0x75, 0xef, 0x05,
+    0xda, 0xae, 0xe3, 0x45, 0x1b, 0xa2, 0xf4, 0x93};
+
+static const uint8_t ZIP244_EXPECTED_EMPTY_TRANSPARENT_DIGEST[32] = {
+    0xc3, 0x3f, 0x2e, 0x95, 0x70, 0x5f, 0xaa, 0xb3,
+    0x5f, 0x8d, 0x53, 0x3f, 0xa6, 0x1e, 0x95, 0xc3,
+    0xb7, 0xaa, 0xba, 0x07, 0x76, 0xb8, 0x74, 0xa9,
+    0xf7, 0x4f, 0xc1, 0x27, 0x84, 0x37, 0x6a, 0x59};
+
+static const uint8_t ZIP244_EXPECTED_TRANSPARENT_DIGEST[32] = {
+    0xfa, 0xe5, 0x37, 0x7f, 0xa9, 0x3c, 0xc0, 0xc3,
+    0x1d, 0x30, 0x39, 0x42, 0x21, 0x57, 0xce, 0x4b,
+    0x9e, 0x7b, 0x12, 0x57, 0x00, 0x9f, 0x15, 0x90,
+    0xe1, 0x62, 0x95, 0x62, 0x55, 0xbb, 0x2e, 0x84};
+
+static const uint8_t ZIP244_EXPECTED_TRANSPARENT_SIGHASH_0[32] = {
+    0x37, 0xa9, 0xc4, 0xec, 0x61, 0x87, 0x07, 0x20,
+    0x5b, 0xcb, 0x47, 0x7b, 0xea, 0x4f, 0xda, 0x6d,
+    0x61, 0x01, 0x62, 0xea, 0xaa, 0x5c, 0x9f, 0x33,
+    0xe5, 0x59, 0x69, 0x02, 0x6e, 0x47, 0x6f, 0x23};
+
+static const uint8_t ZIP244_EXPECTED_TRANSPARENT_SIGHASH_1[32] = {
+    0x29, 0x4d, 0xb7, 0xaa, 0xf1, 0x65, 0x37, 0x4e,
+    0x02, 0xda, 0xe1, 0x6f, 0xf3, 0xdd, 0x97, 0x78,
+    0x8f, 0x4f, 0x5e, 0x2d, 0xc4, 0xe1, 0xb3, 0xf6,
+    0x62, 0x73, 0x9e, 0xd3, 0x5b, 0x82, 0x08, 0x2f};
+
+static const uint8_t ZIP244_P2PKH_SCRIPT_11[25] = {
+    0x76, 0xa9, 0x14, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+    0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+    0x11, 0x11, 0x11, 0x11, 0x11, 0x88, 0xac};
+
+static const uint8_t ZIP244_P2SH_SCRIPT_22[23] = {
+    0xa9, 0x14, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
+    0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
+    0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x87};
+
+static const uint8_t ZIP244_P2PKH_SCRIPT_33[25] = {
+    0x76, 0xa9, 0x14, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33,
+    0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33,
+    0x33, 0x33, 0x33, 0x33, 0x33, 0x88, 0xac};
+
+static const uint8_t ZIP244_P2SH_SCRIPT_44[23] = {
+    0xa9, 0x14, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44,
+    0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44,
+    0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x87};
+
+static void fill_zip244_txids(uint8_t txid0[32], uint8_t txid1[32]) {
+  for (size_t i = 0; i < 32; i++) {
+    txid0[i] = (uint8_t)i;
+    txid1[i] = (uint8_t)(i + 32);
+  }
+}
+
+static void make_zip244_transparent_fixture(
+    ZcashTransparentInputDigestInfo inputs[2],
+    ZcashTransparentOutputDigestInfo outputs[2], uint8_t txid0[32],
+    uint8_t txid1[32]) {
+  fill_zip244_txids(txid0, txid1);
+
+  inputs[0].prevout_txid = txid0;
+  inputs[0].prevout_index = 2;
+  inputs[0].sequence = 0xfffffffe;
+  inputs[0].value = 1234567890ULL;
+  inputs[0].script_pubkey = ZIP244_P2PKH_SCRIPT_11;
+  inputs[0].script_pubkey_size = sizeof(ZIP244_P2PKH_SCRIPT_11);
+
+  inputs[1].prevout_txid = txid1;
+  inputs[1].prevout_index = 7;
+  inputs[1].sequence = 0xfffffffd;
+  inputs[1].value = 987654321ULL;
+  inputs[1].script_pubkey = ZIP244_P2SH_SCRIPT_22;
+  inputs[1].script_pubkey_size = sizeof(ZIP244_P2SH_SCRIPT_22);
+
+  outputs[0].value = 2000000000ULL;
+  outputs[0].script_pubkey = ZIP244_P2PKH_SCRIPT_33;
+  outputs[0].script_pubkey_size = sizeof(ZIP244_P2PKH_SCRIPT_33);
+
+  outputs[1].value = 1111111ULL;
+  outputs[1].script_pubkey = ZIP244_P2SH_SCRIPT_44;
+  outputs[1].script_pubkey_size = sizeof(ZIP244_P2SH_SCRIPT_44);
+}
+
+TEST(Zcash, ComputeHeaderDigest_FromPlaintextFields) {
+  uint8_t digest[32] = {0};
+
+  ASSERT_TRUE(zcash_compute_header_digest(
+      5, 0x26a7270a, 0xc2d6d0b4, 123456, 987654, digest));
+  EXPECT_TRUE(memcmp(digest, ZIP244_EXPECTED_HEADER_DIGEST, 32) == 0);
+}
+
+TEST(Zcash, ComputeTransparentDigest_DistinctFromPerInputSighash) {
+  ZcashTransparentInputDigestInfo inputs[2] = {};
+  ZcashTransparentOutputDigestInfo outputs[2] = {};
+  uint8_t txid0[32], txid1[32];
+  make_zip244_transparent_fixture(inputs, outputs, txid0, txid1);
+
+  uint8_t digest[32] = {0};
+  uint8_t sighash0[32] = {0};
+  uint8_t sighash1[32] = {0};
+
+  ASSERT_TRUE(zcash_compute_transparent_digest(inputs, 2, outputs, 2, digest));
+  ASSERT_TRUE(zcash_compute_transparent_sighash_digest(
+      inputs, 2, outputs, 2, 0, 0x01, sighash0));
+  ASSERT_TRUE(zcash_compute_transparent_sighash_digest(
+      inputs, 2, outputs, 2, 1, 0x01, sighash1));
+
+  EXPECT_TRUE(memcmp(digest, ZIP244_EXPECTED_TRANSPARENT_DIGEST, 32) == 0);
+  EXPECT_TRUE(memcmp(sighash0, ZIP244_EXPECTED_TRANSPARENT_SIGHASH_0, 32) ==
+              0);
+  EXPECT_TRUE(memcmp(sighash1, ZIP244_EXPECTED_TRANSPARENT_SIGHASH_1, 32) ==
+              0);
+  EXPECT_TRUE(memcmp(digest, sighash0, 32) != 0);
+  EXPECT_TRUE(memcmp(sighash0, sighash1, 32) != 0);
+}
+
+TEST(Zcash, ComputeTransparentDigest_EmptyBundle) {
+  uint8_t digest[32] = {0};
+
+  ASSERT_TRUE(zcash_compute_transparent_digest(NULL, 0, NULL, 0, digest));
+  EXPECT_TRUE(memcmp(digest, ZIP244_EXPECTED_EMPTY_TRANSPARENT_DIGEST, 32) ==
+              0);
+}
+
+TEST(Zcash, ComputeTransparentSighash_RejectsUnsupportedRequest) {
+  ZcashTransparentInputDigestInfo inputs[2] = {};
+  ZcashTransparentOutputDigestInfo outputs[2] = {};
+  uint8_t txid0[32], txid1[32], digest[32];
+  make_zip244_transparent_fixture(inputs, outputs, txid0, txid1);
+
+  EXPECT_FALSE(zcash_compute_transparent_sighash_digest(
+      inputs, 2, outputs, 2, 2, 0x01, digest));
+  EXPECT_FALSE(zcash_compute_transparent_sighash_digest(
+      inputs, 2, outputs, 2, 0, 0x02, digest));
+}
+
+TEST(Zcash, ComputeTransparentSighash_CommitsToOutputScriptAndValue) {
+  ZcashTransparentInputDigestInfo inputs[2] = {};
+  ZcashTransparentOutputDigestInfo outputs[2] = {};
+  uint8_t txid0[32], txid1[32];
+  make_zip244_transparent_fixture(inputs, outputs, txid0, txid1);
+
+  uint8_t original[32] = {0};
+  uint8_t changed_script[32] = {0};
+  uint8_t changed_value[32] = {0};
+
+  ASSERT_TRUE(zcash_compute_transparent_sighash_digest(
+      inputs, 2, outputs, 2, 0, 0x01, original));
+
+  outputs[0].script_pubkey = ZIP244_P2SH_SCRIPT_44;
+  outputs[0].script_pubkey_size = sizeof(ZIP244_P2SH_SCRIPT_44);
+  ASSERT_TRUE(zcash_compute_transparent_sighash_digest(
+      inputs, 2, outputs, 2, 0, 0x01, changed_script));
+  EXPECT_TRUE(memcmp(original, changed_script, 32) != 0);
+
+  outputs[0].script_pubkey = ZIP244_P2PKH_SCRIPT_33;
+  outputs[0].script_pubkey_size = sizeof(ZIP244_P2PKH_SCRIPT_33);
+  outputs[0].value++;
+  ASSERT_TRUE(zcash_compute_transparent_sighash_digest(
+      inputs, 2, outputs, 2, 0, 0x01, changed_value));
+  EXPECT_TRUE(memcmp(original, changed_value, 32) != 0);
+}
+
+/* ── Sighash Computation Tests ───────────────────────────────────── */
+
+TEST(Zcash, ComputeShieldedSighash_Deterministic) {
+  uint8_t header[32], transparent[32], sapling[32], orchard[32];
+  memset(header, 0x01, 32);
+  memset(transparent, 0x02, 32);
+  memset(sapling, 0x03, 32);
+  memset(orchard, 0x04, 32);
+
+  uint32_t branch_id = 0x37519621;  /* NU5 */
+
+  uint8_t sighash1[32], sighash2[32];
+  ASSERT_TRUE(zcash_compute_shielded_sighash(
+      header, transparent, sapling, orchard, branch_id, sighash1));
+  ASSERT_TRUE(zcash_compute_shielded_sighash(
+      header, transparent, sapling, orchard, branch_id, sighash2));
+
+  EXPECT_TRUE(memcmp(sighash1, sighash2, 32) == 0)
+      << "Sighash must be deterministic";
+}
+
+TEST(Zcash, ComputeShieldedSighash_DifferentInputs) {
+  uint8_t header[32], transparent[32], sapling[32], orchard[32];
+  memset(header, 0x01, 32);
+  memset(transparent, 0x02, 32);
+  memset(sapling, 0x03, 32);
+  memset(orchard, 0x04, 32);
+
+  uint32_t branch_id = 0x37519621;
+  uint8_t sighash_a[32], sighash_b[32];
+
+  ASSERT_TRUE(zcash_compute_shielded_sighash(
+      header, transparent, sapling, orchard, branch_id, sighash_a));
+
+  /* Change one byte in the orchard digest */
+  orchard[0] ^= 0xff;
+  ASSERT_TRUE(zcash_compute_shielded_sighash(
+      header, transparent, sapling, orchard, branch_id, sighash_b));
+
+  EXPECT_TRUE(memcmp(sighash_a, sighash_b, 32) != 0)
+      << "Different orchard digests must produce different sighashes";
+}
+
+TEST(Zcash, ComputeShieldedSighash_DifferentBranchId) {
+  uint8_t header[32], transparent[32], sapling[32], orchard[32];
+  memset(header, 0x01, 32);
+  memset(transparent, 0x02, 32);
+  memset(sapling, 0x03, 32);
+  memset(orchard, 0x04, 32);
+
+  uint8_t sighash_nu5[32], sighash_nu6[32];
+
+  ASSERT_TRUE(zcash_compute_shielded_sighash(
+      header, transparent, sapling, orchard, 0x37519621, sighash_nu5));
+  ASSERT_TRUE(zcash_compute_shielded_sighash(
+      header, transparent, sapling, orchard, 0xC4D97411, sighash_nu6));
+
+  EXPECT_TRUE(memcmp(sighash_nu5, sighash_nu6, 32) != 0)
+      << "Different branch IDs must produce different sighashes";
+}
+
+TEST(Zcash, ComputeShieldedSighash_KnownVector) {
+  /*
+   * ZIP-244 sighash test vector.
+   *
+   * The sighash personalization is "ZcashTxHash_" || branch_id_LE.
+   * For NU5 (branch_id = 0x37519621):
+   *   personalization = "ZcashTxHash_" || 0x21965137
+   *
+   * Input: BLAKE2b-256(personalization, header || transparent || sapling || orchard)
+   * where each digest is 32 bytes of zeros.
+   */
+  uint8_t header[32] = {0};
+  uint8_t transparent[32] = {0};
+  uint8_t sapling[32] = {0};
+  uint8_t orchard[32] = {0};
+  uint32_t branch_id = 0x37519621;
+
+  uint8_t sighash[32];
+  ASSERT_TRUE(zcash_compute_shielded_sighash(
+      header, transparent, sapling, orchard, branch_id, sighash));
+
+  /*
+   * Independently verified: BLAKE2b-256 with personalization
+   * "ZcashTxHash_\x21\x96\x51\x37" over 128 zero bytes.
+   *
+   * This is a self-consistency check — the value was computed by
+   * running the same BLAKE2b-256 offline. If the sighash function
+   * changes its algorithm, this test will catch it.
+   */
+  uint8_t expected[32];
+  BLAKE2B_CTX ctx;
+  uint8_t personal[16];
+  memcpy(personal, "ZcashTxHash_", 12);
+  memcpy(personal + 12, &branch_id, 4);
+  blake2b_InitPersonal(&ctx, 32, personal, 16);
+  blake2b_Update(&ctx, header, 32);
+  blake2b_Update(&ctx, transparent, 32);
+  blake2b_Update(&ctx, sapling, 32);
+  blake2b_Update(&ctx, orchard, 32);
+  blake2b_Final(&ctx, expected, 32);
+
+  EXPECT_TRUE(memcmp(sighash, expected, 32) == 0)
+      << "Sighash must match direct BLAKE2b computation";
+}
+
+/* ── RedPallas Signing Smoke Test ────────────────────────────────── */
+
+TEST(Zcash, RedPallasSign_ProducesVerifiableSignature) {
+  ZcashOrchardKeys keys;
+  ASSERT_TRUE(zcash_derive_orchard_keys(SEED_ALL, 64, 0, &keys));
+
+  /* Construct a fake sighash and alpha */
+  uint8_t sighash[32];
+  memset(sighash, 0xAB, 32);
+
+  uint8_t alpha[32];
+  memset(alpha, 0x01, 32);
+  /* Ensure alpha is a valid scalar (< q) */
+  alpha[31] = 0x00;
+
+  uint8_t signature[64];
+  int ret = redpallas_sign_digest(keys.ask, alpha, sighash, signature);
+  EXPECT_EQ(ret, 0) << "RedPallas signing must succeed";
+
+  /* Signature must be nonzero */
+  uint8_t zero[64] = {0};
+  EXPECT_TRUE(memcmp(signature, zero, 64) != 0)
+      << "Signature must be nonzero";
+
+  /*
+   * Verify the signature against the randomized verification key rk.
+   * rk = [ask + alpha]*G_spendauth (Pallas SpendAuth basepoint)
+   */
+  bignum256 ask_scalar, alpha_scalar, rk_scalar;
+  bn_read_le(keys.ask, &ask_scalar);
+  bn_read_le(alpha, &alpha_scalar);
+
+  /* rk_scalar = ask + alpha mod q */
+  bn_copy(&ask_scalar, &rk_scalar);
+  pallas_add_mod_q(&rk_scalar, &alpha_scalar);
+
+  curve_point rk_point;
+  redpallas_scalar_mult_spendauth_G(&rk_scalar, &rk_point);
+
+  /* Serialize rk as Pallas point (LE x-coord + sign bit) */
+  uint8_t rk_bytes[32];
+  bignum256 rk_x;
+  bn_copy(&rk_point.x, &rk_x);
+  bn_write_le(&rk_x, rk_bytes);
+  if (bn_is_odd(&rk_point.y)) {
+    rk_bytes[31] |= 0x80;
+  }
+
+  /* Verify: redpallas_verify_digest(rk, sighash, sig) == 0 */
+  EXPECT_EQ(redpallas_verify_digest(rk_bytes, sighash, signature), 0)
+      << "Signature must verify against rk = [ask+alpha]*G";
+
+  /* Verify fails with wrong sighash */
+  uint8_t wrong_sighash[32];
+  memset(wrong_sighash, 0xCC, 32);
+  EXPECT_NE(redpallas_verify_digest(rk_bytes, wrong_sighash, signature), 0)
+      << "Signature must NOT verify with wrong sighash";
+
+  memzero(&keys, sizeof(keys));
+}
+
+TEST(Zcash, RedPallasSign_MultipleCallsSucceed) {
+  /*
+   * RedPallas uses randomized nonces — signatures are intentionally
+   * non-deterministic. Verify that multiple calls all succeed and
+   * produce valid (nonzero) 64-byte signatures.
+   */
+  ZcashOrchardKeys keys;
+  ASSERT_TRUE(zcash_derive_orchard_keys(SEED_ALL, 64, 0, &keys));
+
+  uint8_t sighash[32];
+  memset(sighash, 0xCD, 32);
+  uint8_t alpha[32];
+  memset(alpha, 0x02, 32);
+  alpha[31] = 0x00;
+
+  uint8_t zero[64] = {0};
+  for (int i = 0; i < 3; i++) {
+    uint8_t sig[64];
+    ASSERT_EQ(redpallas_sign_digest(keys.ask, alpha, sighash, sig), 0)
+        << "Signing must succeed on call " << i;
+    EXPECT_TRUE(memcmp(sig, zero, 64) != 0)
+        << "Signature must be nonzero on call " << i;
+  }
+
+  memzero(&keys, sizeof(keys));
+}
+
+TEST(Zcash, RedPallasSign_DifferentSighash) {
+  ZcashOrchardKeys keys;
+  ASSERT_TRUE(zcash_derive_orchard_keys(SEED_ALL, 64, 0, &keys));
+
+  uint8_t alpha[32];
+  memset(alpha, 0x01, 32);
+  alpha[31] = 0x00;
+
+  uint8_t sighash_a[32], sighash_b[32];
+  memset(sighash_a, 0xAA, 32);
+  memset(sighash_b, 0xBB, 32);
+
+  uint8_t sig_a[64], sig_b[64];
+  ASSERT_EQ(redpallas_sign_digest(keys.ask, alpha, sighash_a, sig_a), 0);
+  ASSERT_EQ(redpallas_sign_digest(keys.ask, alpha, sighash_b, sig_b), 0);
+
+  EXPECT_TRUE(memcmp(sig_a, sig_b, 64) != 0)
+      << "Different sighash must produce different signatures";
+
+  memzero(&keys, sizeof(keys));
+}
+
+/* ─── Seed Fingerprint (ZIP-32 §6.1) ─────────────────────────────── */
+
+/* Reference vector: matches keystone3-firmware
+ *   rust/keystore/src/algorithms/zcash/mod.rs test_keystore_derive_zcash_ufvk
+ * Seed:        000102...1f (32 bytes)
+ * Fingerprint: deff604c246710f7176dead02aa746f2fd8d5389f7072556dcb555fdbe5e3ae3
+ */
+TEST(Zcash, SeedFingerprint_ReferenceVector) {
+  uint8_t seed[32];
+  for (int i = 0; i < 32; i++) seed[i] = (uint8_t)i;
+
+  uint8_t expected[32] = {
+      0xde, 0xff, 0x60, 0x4c, 0x24, 0x67, 0x10, 0xf7,
+      0x17, 0x6d, 0xea, 0xd0, 0x2a, 0xa7, 0x46, 0xf2,
+      0xfd, 0x8d, 0x53, 0x89, 0xf7, 0x07, 0x25, 0x56,
+      0xdc, 0xb5, 0x55, 0xfd, 0xbe, 0x5e, 0x3a, 0xe3,
+  };
+
+  uint8_t fp[32];
+  ASSERT_TRUE(zcash_calculate_seed_fingerprint(seed, 32, fp));
+  EXPECT_EQ(memcmp(fp, expected, 32), 0);
+}
+
+TEST(Zcash, SeedFingerprint_RejectAllZero) {
+  uint8_t seed[32] = {0};
+  uint8_t fp[32];
+  EXPECT_FALSE(zcash_calculate_seed_fingerprint(seed, 32, fp));
+}
+
+TEST(Zcash, SeedFingerprint_RejectAllFF) {
+  uint8_t seed[32];
+  memset(seed, 0xFF, 32);
+  uint8_t fp[32];
+  EXPECT_FALSE(zcash_calculate_seed_fingerprint(seed, 32, fp));
+}
+
+TEST(Zcash, SeedFingerprint_RejectShortSeed) {
+  uint8_t seed[31];
+  for (int i = 0; i < 31; i++) seed[i] = (uint8_t)(i + 1);
+  uint8_t fp[32];
+  EXPECT_FALSE(zcash_calculate_seed_fingerprint(seed, 31, fp));
+}
+
+TEST(Zcash, SeedFingerprint_RejectLongSeed) {
+  uint8_t seed[253];
+  for (int i = 0; i < 253; i++) seed[i] = (uint8_t)(i & 0xFF);
+  uint8_t fp[32];
+  EXPECT_FALSE(zcash_calculate_seed_fingerprint(seed, 253, fp));
+}
+
+TEST(Zcash, SeedFingerprint_DeterministicAcrossCalls) {
+  uint8_t seed[64];
+  for (int i = 0; i < 64; i++) seed[i] = (uint8_t)(0xAA ^ i);
+
+  uint8_t fp_a[32], fp_b[32];
+  ASSERT_TRUE(zcash_calculate_seed_fingerprint(seed, 64, fp_a));
+  ASSERT_TRUE(zcash_calculate_seed_fingerprint(seed, 64, fp_b));
+  EXPECT_EQ(memcmp(fp_a, fp_b, 32), 0);
+}
+
+TEST(Zcash, SeedFingerprint_DiffersForDifferentSeeds) {
+  uint8_t seed_a[64];
+  uint8_t seed_b[64];
+  for (int i = 0; i < 64; i++) {
+    seed_a[i] = (uint8_t)i;
+    seed_b[i] = (uint8_t)(i + 1);
+  }
+
+  uint8_t fp_a[32], fp_b[32];
+  ASSERT_TRUE(zcash_calculate_seed_fingerprint(seed_a, 64, fp_a));
+  ASSERT_TRUE(zcash_calculate_seed_fingerprint(seed_b, 64, fp_b));
+  EXPECT_NE(memcmp(fp_a, fp_b, 32), 0);
+}


### PR DESCRIPTION
**2/5 of the 7.15 stack.** Stacks on 1/5 (`release/7.15.0-pr1-evm-clearsign-core`).

New chain families, independent of the EVM clear-signing in 1/5.

- **Hive (SLIP-0048)** — `HiveGetPublicKey(s)`, `HiveSignTx`, `HiveAccountCreate` / `Update`. Hive's nanopb generation is split into its own protoc command so it doesn't collide with the shared dispatch.
- **Zcash Orchard** — shielded support: PCZT signing, FVK export, unified addresses. Needs the trezor-firmware bump to `0ea97b09` (Pallas / Sinsemilla / RedPallas / ZIP-316).
- **Ripple** — memo / `Memos` field support so XRP can route through THORChain.
- **THORChain any-denom** — `ThorchainMsgSend` accepts any denom (TCY, RUJIRA, …); denom charset/format is validated before display, with separate amount / asset screens. Four SignTx vectors built on a zero-key fixture are disabled — the fixture was invalid, not the feature.

Same base pins as 1/5, plus trezor-firmware → `0ea97b09`. Builds green (kkemu + firmware-unit).

> Hive and Zcash land in one commit here: their message dispatch and nanopb build wiring (`fsm.c`, `messagemap.def`, `CMakeLists.txt`) are interleaved, so a clean per-chain split isn't possible without hunk surgery.
