### PR TITLE
7.15 (3/5): Device robustness — BIP-85, BIP-39 recovery validation, fault-injection hardening

### DIFF
--- a/docs/firmware/reviews/7.15.0-review-round2-remediation.md
+++ b/docs/firmware/reviews/7.15.0-review-round2-remediation.md
@@ -19,9 +19,9 @@ bonus. All numbers below reference the reviewer's file:line.
 | B1 | #447 | ARM firmware won't link — `rom` overflowed by 2136 bytes | ⧗ |
 | B2 | #448 | `unit-tests (zcash-privacy)` segfault — `Storage.BitcoinOnlyBandRefused` feeds 64-byte buffer to V17 reader → 16 KB OOB read (storage.cpp:523) | ☐ |
 | B3 | #444 | Clear-signing silently defeated mid-tx: `EthereumTxMetadata` handler has no "signing in progress" guard; `signed_metadata_process()` clears binding → attacker streams unseen calldata, blind-sign gate stays suppressed (fsm_msg_ethereum.h:24, ethereum.c:304) | ☑ guard added: handler aborts if `ethereum_signing_isInProgress()` |
-| B4 | #446 | `recovery_cipher.c:612` guard flipped `!enforce_wordlist` → `enforce_wordlist`, deleting the only wordlist check on the default path → mistyped cipher stored as seed, "Device recovered" | ☐ |
-| B5 | #446 | `recovery_cipher.c:483` per-word BIP-39 validation reads `decoded_word` that `recovery_delete_character` never clears → backspace-fix wipes a real recovery | ☐ |
-| B6 | #446 | `recovery_cipher.c:379` "previous word" indicator snapshots every keystroke → shows current partial word mislabeled | ☐ |
+| B4 | #446 | `recovery_cipher.c:612` guard flipped `!enforce_wordlist` → `enforce_wordlist`, deleting the only wordlist check on the default path → mistyped cipher stored as seed, "Device recovered" | ☑ guard now `if (!auto_completed)` — fails in both modes (cipher recovery is always BIP-39) |
+| B5 | #446 | `recovery_cipher.c:483` per-word BIP-39 validation reads `decoded_word` that `recovery_delete_character` never clears → backspace-fix wipes a real recovery | ☑ `recovery_delete_character` resyncs decoded_word (from mnemonic) + coded_word (reverse-cipher) after every edit |
+| B6 | #446 | `recovery_cipher.c:379` "previous word" indicator snapshots every keystroke → shows current partial word mislabeled | ☑ snapshot moved to the word-boundary (space) handler; stores the auto-expanded completed word |
 | B7 | #446 | `keepkey_main.c:189` replaced `signatures_ok()` (sha256+ecdsa) with spoofable sig-index presence check → forged metadata reads SIG_OK | ☑ (fixed pre-review as task #5) |
 | B8 | #445 | `hive.c:194` `ecdsa_sign_digest(..., NULL)` — no canonical callback; Graphene rejects ~50% of sigs. Fix: reuse `eos_is_canonic` (eos.c:488) | ☑ added `hive_is_canonic` (same Graphene rule) and passed it to `ecdsa_sign_digest` |
 | B9 | #445 | `fsm_msg_hive.h:147` confirm hardcodes `amount/1000` (3 dp) while serializer signs `msg->decimals` → shows 1000× wrong amount | ☑ display now uses serializer's precision via `bn_format_uint64`; rejects precision > 18 |
@@ -56,7 +56,7 @@ bonus. All numbers below reference the reviewer's file:line.
 
 | # | Home | Finding | Status |
 |---|------|---------|--------|
-| L1 | #446 | `fsm_msg_bip85.h:5` handler re-validates word_count/index already checked in callee | ☐ |
+| L1 | #446 | `fsm_msg_bip85.h:5` handler re-validates word_count/index already checked in callee | ✔ keep: handler check rejects before CHECK_PIN/confirm so an invalid request never prompts for a PIN — intentional early defense, not dead duplication |
 | L2 | #448 | `storage.c:95` comment says `btc_only_locked` "never set in bitcoin-only builds" but new path sets it | ☐ |
 | L3 | #448 | `storage.c:1397` locked path returns before `storage_readMeta` → locked device reports empty device_id | ☐ |
 

--- a/include/keepkey/firmware/app_layout.h
+++ b/include/keepkey/firmware/app_layout.h
@@ -124,7 +124,8 @@ void layout_zcash_address_text_notification(const char* desc,
                                             const char* address,
                                             NotificationType type);
 void layout_pin(const char* str, char* pin);
-void layout_cipher(const char* current_word, const char* cipher);
+void layout_cipher(const char* current_word, const char* cipher,
+                   const char* prev_word_info);
 void layout_address(const char* address, QRSize qr_size);
 void set_leaving_handler(leaving_handler_t leaving_func);
 

--- a/include/keepkey/firmware/bip85.h
+++ b/include/keepkey/firmware/bip85.h
@@ -1,0 +1,22 @@
+#ifndef BIP85_H
+#define BIP85_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * Derive a child BIP-39 mnemonic via BIP-85.
+ *
+ * Path: m/83696968'/39'/0'/<word_count>'/<index>'
+ *
+ * @param word_count  Number of words: 12, 18, or 24.
+ * @param index       Child index (0-based).
+ * @param mnemonic    Output buffer (must be at least 241 bytes).
+ * @param mnemonic_len Size of the output buffer.
+ * @return true on success, false on error.
+ */
+bool bip85_derive_mnemonic(uint32_t word_count, uint32_t index, char *mnemonic,
+                           size_t mnemonic_len);
+
+#endif

--- a/include/keepkey/firmware/fsm.h
+++ b/include/keepkey/firmware/fsm.h
@@ -156,4 +156,6 @@ void fsm_msgFlashWrite(FlashWrite* msg);
 void fsm_msgFlashHash(FlashHash* msg);
 void fsm_msgSoftReset(SoftReset* msg);
 
+void fsm_msgGetBip85Mnemonic(const GetBip85Mnemonic* msg);
+
 #endif

--- a/lib/board/signatures.c
+++ b/lib/board/signatures.c
@@ -20,7 +20,9 @@
 #include "trezor/crypto/sha2.h"
 #include "trezor/crypto/ecdsa.h"
 #include "trezor/crypto/secp256k1.h"
+#include "trezor/crypto/memzero.h"
 #include "keepkey/board/memory.h"
+#include "keepkey/board/memcmp_s.h"
 #include "keepkey/board/signatures.h"
 #include "keepkey/board/pubkeys.h"
 
@@ -68,23 +70,51 @@ int signatures_ok(void) {
     return KEY_EXPIRED;
   } /* Expired signing key */
 
+  /* F3 hardening: double-compute SHA-256, compare in constant time */
+  uint8_t firmware_fingerprint2[32];
   sha256_Raw((uint8_t*)FLASH_APP_START, codelen, firmware_fingerprint);
+  asm volatile("" ::: "memory");
+  sha256_Raw((uint8_t*)FLASH_APP_START, codelen, firmware_fingerprint2);
 
-  if (ecdsa_verify_digest(&secp256k1, pubkey[sigindex1 - 1],
-                          (uint8_t*)FLASH_META_SIG1,
-                          firmware_fingerprint) != 0) { /* Failure */
+  if (memcmp_s(firmware_fingerprint, firmware_fingerprint2, 32) != 0) {
+    memzero(firmware_fingerprint, sizeof(firmware_fingerprint));
+    memzero(firmware_fingerprint2, sizeof(firmware_fingerprint2));
+    return SIG_FAIL;
+  }
+  memzero(firmware_fingerprint2, sizeof(firmware_fingerprint2));
+
+  /* F3 hardening: infective aggregation — accumulate all three ECDSA
+   * results instead of early-returning on each. Forces attacker to
+   * corrupt all three verify calls, not just skip one branch. */
+  volatile int verify_acc = 0;
+  volatile int verify_sentinel = 0;
+
+  verify_acc |=
+      ecdsa_verify_digest(&secp256k1, pubkey[sigindex1 - 1],
+                          (uint8_t*)FLASH_META_SIG1, firmware_fingerprint);
+  verify_sentinel++;
+  asm volatile("" ::: "memory");
+
+  verify_acc |=
+      ecdsa_verify_digest(&secp256k1, pubkey[sigindex2 - 1],
+                          (uint8_t*)FLASH_META_SIG2, firmware_fingerprint);
+  verify_sentinel++;
+  asm volatile("" ::: "memory");
+
+  verify_acc |=
+      ecdsa_verify_digest(&secp256k1, pubkey[sigindex3 - 1],
+                          (uint8_t*)FLASH_META_SIG3, firmware_fingerprint);
+  verify_sentinel++;
+  asm volatile("" ::: "memory");
+
+  memzero(firmware_fingerprint, sizeof(firmware_fingerprint));
+
+  /* All three verifies must have executed and all must have passed */
+  if (verify_sentinel != 3) {
     return SIG_FAIL;
   }
 
-  if (ecdsa_verify_digest(&secp256k1, pubkey[sigindex2 - 1],
-                          (uint8_t*)FLASH_META_SIG2,
-                          firmware_fingerprint) != 0) { /* Failure */
-    return SIG_FAIL;
-  }
-
-  if (ecdsa_verify_digest(&secp256k1, pubkey[sigindex3 - 1],
-                          (uint8_t*)FLASH_META_SIG3,
-                          firmware_fingerprint) != 0) { /* Failure */
+  if (verify_acc != 0) {
     return SIG_FAIL;
   }
 

--- a/lib/firmware/CMakeLists.txt
+++ b/lib/firmware/CMakeLists.txt
@@ -2,6 +2,7 @@ set(sources
     app_confirm.c
     app_layout.c
     authenticator.c
+    bip85.c
     binance.c
     coins.c
     crypto.c

--- a/lib/firmware/app_layout.c
+++ b/lib/firmware/app_layout.c
@@ -766,7 +766,8 @@ void layout_pin(const char* str, char pin[]) {
  * OUTPUT
  *     none
  */
-void layout_cipher(const char* current_word, const char* cipher) {
+void layout_cipher(const char* current_word, const char* cipher,
+                   const char* prev_word_info) {
   DrawableParams sp;
   const Font* title_font = get_body_font();
   Canvas* canvas = layout_get_canvas();
@@ -774,8 +775,18 @@ void layout_cipher(const char* current_word, const char* cipher) {
   call_leaving_handler();
   layout_clear();
 
-  /* Draw prompt */
-  sp.y = 11;
+  /* Draw previous word info at top-left -- must be x < 76 to avoid
+   * being wiped by cipher animation which clears x >= CIPHER_START_X */
+  if (prev_word_info && prev_word_info[0]) {
+    sp.y = 2;
+    sp.x = 4;
+    sp.color = CIPHER_FONT_COLOR; /* gray -- less prominent than current word */
+    draw_string(canvas, title_font, prev_word_info, &sp, 68,
+                font_height(title_font));
+  }
+
+  /* Draw prompt -- push down when prev word is shown */
+  sp.y = (prev_word_info && prev_word_info[0]) ? 14 : 11;
   sp.x = 4;
   sp.color = BODY_COLOR;
   draw_string(canvas, title_font, "Recovery Cipher:", &sp, 58,

--- a/lib/firmware/bip85.c
+++ b/lib/firmware/bip85.c
@@ -1,0 +1,105 @@
+#include "keepkey/firmware/bip85.h"
+#include "keepkey/firmware/storage.h"
+#include "trezor/crypto/bip32.h"
+#include "trezor/crypto/bip39.h"
+#include "trezor/crypto/curves.h"
+#include "trezor/crypto/hmac.h"
+#include "trezor/crypto/memzero.h"
+
+#include <string.h>
+
+/*
+ * BIP-85: Deterministic Entropy From BIP32 Keychains
+ *
+ * For BIP-39 mnemonic derivation:
+ *   path = m / 83696968' / 39' / 0' / <word_count>' / <index>'
+ *   k    = derived_node.private_key  (32 bytes)
+ *   hmac = HMAC-SHA512(key="bip-entropy-from-k", msg=k)
+ *   entropy = hmac[0 : entropy_bytes]
+ *     12 words -> 16 bytes, 18 words -> 24 bytes, 24 words -> 32 bytes
+ *   mnemonic = bip39_from_entropy(entropy)
+ */
+
+/* BIP-85 application number for deriving entropy from a key */
+static const uint8_t BIP85_HMAC_KEY[] = "bip-entropy-from-k";
+#define BIP85_HMAC_KEY_LEN 18
+
+bool bip85_derive_mnemonic(uint32_t word_count, uint32_t index, char *mnemonic,
+                           size_t mnemonic_len) {
+  /* Reject index >= 0x80000000 to avoid hardened-bit collision */
+  if (index & 0x80000000) {
+    return false;
+  }
+
+  /* Validate word count and compute entropy length */
+  int entropy_bytes;
+  switch (word_count) {
+    case 12:
+      entropy_bytes = 16;
+      break;
+    case 18:
+      entropy_bytes = 24;
+      break;
+    case 24:
+      entropy_bytes = 32;
+      break;
+    default:
+      return false;
+  }
+
+  /* BIP-85 derivation path: m/83696968'/39'/0'/<word_count>'/<index>' */
+  uint32_t address_n[5];
+  address_n[0] = 0x80000000 | 83696968;   /* purpose (hardened) */
+  address_n[1] = 0x80000000 | 39;         /* BIP-39 app (hardened) */
+  address_n[2] = 0x80000000;              /* English language 0 (hardened) */
+  address_n[3] = 0x80000000 | word_count; /* word count (hardened) */
+  address_n[4] = 0x80000000 | index;      /* child index (hardened) */
+
+  /* Get the master node from storage (respects passphrase) */
+  static CONFIDENTIAL HDNode node;
+  if (!storage_getRootNode(SECP256K1_NAME, true, &node)) {
+    memzero(&node, sizeof(node));
+    return false;
+  }
+
+  /* Derive to the BIP-85 path */
+  for (int i = 0; i < 5; i++) {
+    if (hdnode_private_ckd(&node, address_n[i]) == 0) {
+      memzero(&node, sizeof(node));
+      return false;
+    }
+  }
+
+  /* HMAC-SHA512(key="bip-entropy-from-k", msg=private_key) */
+  static CONFIDENTIAL uint8_t hmac_out[64];
+  hmac_sha512(BIP85_HMAC_KEY, BIP85_HMAC_KEY_LEN, node.private_key, 32,
+              hmac_out);
+
+  /* We no longer need the derived node */
+  memzero(&node, sizeof(node));
+
+  /* Truncate HMAC output to the required entropy length */
+  static CONFIDENTIAL uint8_t entropy[32];
+  memcpy(entropy, hmac_out, entropy_bytes);
+  memzero(hmac_out, sizeof(hmac_out));
+
+  /* Convert entropy to BIP-39 mnemonic */
+  const char *words = mnemonic_from_data(entropy, entropy_bytes);
+  memzero(entropy, sizeof(entropy));
+
+  if (!words) {
+    return false;
+  }
+
+  /* Copy to output buffer */
+  size_t words_len = strlen(words);
+  if (words_len >= mnemonic_len) {
+    mnemonic_clear();
+    return false;
+  }
+
+  memcpy(mnemonic, words, words_len + 1);
+  mnemonic_clear();
+
+  return true;
+}

--- a/lib/firmware/fsm.c
+++ b/lib/firmware/fsm.c
@@ -35,6 +35,7 @@
 #include "keepkey/firmware/app_confirm.h"
 #include "keepkey/firmware/app_layout.h"
 #include "keepkey/firmware/authenticator.h"
+#include "keepkey/firmware/bip85.h"
 #include "keepkey/firmware/coins.h"
 #include "keepkey/firmware/cosmos.h"
 #include "keepkey/firmware/binance.h"
@@ -301,3 +302,4 @@ void fsm_msgClearSession(ClearSession* msg) {
 #include "fsm_msg_solana.h"
 #include "fsm_msg_hive.h"
 #include "fsm_msg_zcash.h"
+#include "fsm_msg_bip85.h"

--- a/lib/firmware/fsm_msg_bip85.h
+++ b/lib/firmware/fsm_msg_bip85.h
@@ -1,0 +1,143 @@
+void fsm_msgGetBip85Mnemonic(const GetBip85Mnemonic *msg) {
+  CHECK_INITIALIZED
+
+  /* Validate word count (required field, always present in nanopb) */
+  if (msg->word_count != 12 && msg->word_count != 18 && msg->word_count != 24) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    "word_count must be 12, 18, or 24");
+    layoutHome();
+    return;
+  }
+
+  /* Reject index >= 0x80000000 (hardened-bit collision) */
+  if (msg->index & 0x80000000) {
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    "index must be less than 2147483648");
+    layoutHome();
+    return;
+  }
+
+  CHECK_PIN
+
+  /* User confirmation */
+  char desc[80];
+  snprintf(desc, sizeof(desc), "Derive %lu-word child seed at index %lu?",
+           (unsigned long)msg->word_count, (unsigned long)msg->index);
+
+  if (!confirm(ButtonRequestType_ButtonRequest_Other, "BIP-85 Derive Seed",
+               "%s", desc)) {
+    fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                    "BIP-85 derivation cancelled");
+    layoutHome();
+    return;
+  }
+
+  layout_simple_message("Deriving child seed...");
+
+  /* Derive the mnemonic */
+  static CONFIDENTIAL char mnemonic_buf[241];
+  if (!bip85_derive_mnemonic(msg->word_count, msg->index, mnemonic_buf,
+                             sizeof(mnemonic_buf))) {
+    memzero(mnemonic_buf, sizeof(mnemonic_buf));
+    fsm_sendFailure(FailureType_Failure_Other, "BIP-85 derivation failed");
+    layoutHome();
+    return;
+  }
+
+  /*
+   * Display mnemonic on device screen only — never send over USB.
+   * Uses the same paginated display as the backup flow in reset.c.
+   */
+  uint32_t word_count = 0, page_count = 0;
+  static char CONFIDENTIAL tokened_mnemonic[TOKENED_MNEMONIC_BUF];
+  static char CONFIDENTIAL
+      formatted_mnemonic[MAX_PAGES][FORMATTED_MNEMONIC_BUF];
+  static char CONFIDENTIAL mnemonic_display[FORMATTED_MNEMONIC_BUF];
+  static char CONFIDENTIAL formatted_word[MAX_WORD_LEN + ADDITIONAL_WORD_PAD];
+
+  strlcpy(tokened_mnemonic, mnemonic_buf, TOKENED_MNEMONIC_BUF);
+  memzero(mnemonic_buf, sizeof(mnemonic_buf));
+
+  /* Clear formatting buffers */
+  memzero(formatted_mnemonic, sizeof(formatted_mnemonic));
+  memzero(mnemonic_display, sizeof(mnemonic_display));
+
+  const char *tok = strtok(tokened_mnemonic, " ");
+
+  while (tok) {
+    snprintf(formatted_word, MAX_WORD_LEN + ADDITIONAL_WORD_PAD,
+             (word_count & 1) ? "%lu.%s\n" : "%lu.%s",
+             (unsigned long)(word_count + 1), tok);
+
+    /* Check that we have enough room on display to show word */
+    snprintf(mnemonic_display, FORMATTED_MNEMONIC_BUF, "%s   %s",
+             formatted_mnemonic[page_count], formatted_word);
+
+    if (calc_str_line(get_body_font(), mnemonic_display, BODY_WIDTH) > 3) {
+      page_count++;
+
+      if (MAX_PAGES <= page_count) {
+        memzero(tokened_mnemonic, sizeof(tokened_mnemonic));
+        memzero(formatted_mnemonic, sizeof(formatted_mnemonic));
+        memzero(mnemonic_display, sizeof(mnemonic_display));
+        memzero(formatted_word, sizeof(formatted_word));
+        fsm_sendFailure(FailureType_Failure_Other,
+                        "Too many pages of mnemonic words");
+        layoutHome();
+        return;
+      }
+
+      snprintf(mnemonic_display, FORMATTED_MNEMONIC_BUF, "%s   %s",
+               formatted_mnemonic[page_count], formatted_word);
+    }
+
+    strlcpy(formatted_mnemonic[page_count], mnemonic_display,
+            FORMATTED_MNEMONIC_BUF);
+
+    tok = strtok(NULL, " ");
+    word_count++;
+  }
+
+  /* Switch from 0-indexing to 1-indexing */
+  page_count++;
+
+  display_constant_power(true);
+
+  /* Show each page of the mnemonic on screen */
+  for (uint32_t current_page = 0; current_page < page_count; current_page++) {
+    char title[MEDIUM_STR_BUF];
+
+    if (page_count > 1) {
+      snprintf(title, MEDIUM_STR_BUF, "BIP-85 Seed %" PRIu32 "/%" PRIu32,
+               current_page + 1, page_count);
+    } else {
+      snprintf(title, MEDIUM_STR_BUF, "BIP-85 Seed");
+    }
+
+    if (!confirm_constant_power(ButtonRequestType_ButtonRequest_ConfirmWord,
+                                title, "%s",
+                                formatted_mnemonic[current_page])) {
+      memzero(tokened_mnemonic, sizeof(tokened_mnemonic));
+      memzero(formatted_mnemonic, sizeof(formatted_mnemonic));
+      memzero(mnemonic_display, sizeof(mnemonic_display));
+      memzero(formatted_word, sizeof(formatted_word));
+      display_constant_power(false);
+      fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                      "BIP-85 display cancelled");
+      layoutHome();
+      return;
+    }
+  }
+
+  display_constant_power(false);
+
+  /* Wipe all sensitive buffers */
+  memzero(tokened_mnemonic, sizeof(tokened_mnemonic));
+  memzero(formatted_mnemonic, sizeof(formatted_mnemonic));
+  memzero(mnemonic_display, sizeof(mnemonic_display));
+  memzero(formatted_word, sizeof(formatted_word));
+
+  /* Send success — mnemonic is NOT sent over the wire */
+  fsm_sendSuccess("BIP-85 seed displayed on device");
+  layoutHome();
+}

--- a/lib/firmware/messagemap.def
+++ b/lib/firmware/messagemap.def
@@ -73,6 +73,9 @@
     MSG_IN(MessageType_MessageType_MayachainSignTx,                 MayachainSignTx,             fsm_msgMayachainSignTx)
     MSG_IN(MessageType_MessageType_MayachainMsgAck,                 MayachainMsgAck,             fsm_msgMayachainMsgAck)
 
+    MSG_IN(MessageType_MessageType_GetBip85Mnemonic,               GetBip85Mnemonic,            fsm_msgGetBip85Mnemonic)
+    MSG_OUT(MessageType_MessageType_Bip85Mnemonic,                  Bip85Mnemonic,               NO_PROCESS_FUNC)
+
     /* Normal Out Messages */
     MSG_OUT(MessageType_MessageType_Success,                        Success,                     NO_PROCESS_FUNC)
     MSG_OUT(MessageType_MessageType_Failure,                        Failure,                     NO_PROCESS_FUNC)

--- a/lib/firmware/recovery_cipher.c
+++ b/lib/firmware/recovery_cipher.c
@@ -53,6 +53,13 @@ static CONFIDENTIAL char mnemonic[MNEMONIC_BUF];
 static char english_alphabet[ENGLISH_ALPHABET_BUF] =
     "abcdefghijklmnopqrstuvwxyz";
 static CONFIDENTIAL char cipher[ENGLISH_ALPHABET_BUF];
+/* Accumulators for the word currently being entered. File-scope so
+ * recovery_delete_character() can keep them in sync with backspaces —
+ * otherwise stale bytes make a re-entered word fail validation and wipe a
+ * real recovery. last_completed_word backs the "previous word" indicator. */
+static CONFIDENTIAL char coded_word[12];
+static CONFIDENTIAL char decoded_word[12];
+static CONFIDENTIAL char last_completed_word[12];
 
 #if DEBUG_LINK
 static char auto_completed_word[CURRENT_WORD_BUF];
@@ -74,6 +81,9 @@ void recovery_cipher_abort(void) {
   word_count = 0;
   memzero(mnemonic, sizeof(mnemonic));
   memzero(cipher, sizeof(cipher));
+  memzero(coded_word, sizeof(coded_word));
+  memzero(decoded_word, sizeof(decoded_word));
+  memzero(last_completed_word, sizeof(last_completed_word));
 }
 
 /// Formats the passed word to show position in mnemonic as well as characters
@@ -371,14 +381,6 @@ void next_character(void) {
   }
 #endif
 
-  /* Save word so we can show it as "prev" on next word.
-   * When auto-complete fires, current_word holds the full expanded word
-   * (e.g. "alcohol" not "alc"). Otherwise save the typed prefix. */
-  static char CONFIDENTIAL last_completed_word[12];
-  if (strlen(current_word) > 0) {
-    strlcpy(last_completed_word, current_word, sizeof(last_completed_word));
-  }
-
   /* Format current word and display it along with cipher */
   static char CONFIDENTIAL formatted_word[CURRENT_WORD_BUF + 10];
   format_current_word(word_pos, current_word, auto_completed, &formatted_word);
@@ -436,14 +438,13 @@ void recovery_character(const char* character) {
   // Count of words we think the user has entered without using the cipher:
   static int uncyphered_word_count = 0;
   static bool definitely_using_cipher = false;
-  static CONFIDENTIAL char coded_word[12];
-  static CONFIDENTIAL char decoded_word[12];
 
   if (!mnemonic[0]) {
     uncyphered_word_count = 0;
     definitely_using_cipher = false;
     memzero(coded_word, sizeof(coded_word));
     memzero(decoded_word, sizeof(decoded_word));
+    memzero(last_completed_word, sizeof(last_completed_word));
   }
 
   char decoded_character[2] = " ";
@@ -479,13 +480,15 @@ void recovery_character(const char* character) {
     }
   } else {
     /* Per-word BIP39 validation: reject immediately if the decoded word
-     * doesn't match any entry in the wordlist. */
-    if (enforce_wordlist && strlen(decoded_word) > 0) {
+     * doesn't match any entry in the wordlist. decoded_word is kept in sync
+     * with backspaces by recovery_delete_character(), so a corrected word is
+     * validated on its real (post-edit) value. */
+    if (strlen(decoded_word) > 0) {
       static CONFIDENTIAL char check_word[CURRENT_WORD_BUF];
       strlcpy(check_word, decoded_word, sizeof(check_word));
       bool valid = attempt_auto_complete(check_word);
-      memzero(check_word, sizeof(check_word));
-      if (!valid) {
+      if (enforce_wordlist && !valid) {
+        memzero(check_word, sizeof(check_word));
         memzero(coded_word, sizeof(coded_word));
         memzero(decoded_word, sizeof(decoded_word));
         recovery_cipher_abort();
@@ -494,6 +497,10 @@ void recovery_character(const char* character) {
         layout_warning_static("Word not in wordlist");
         return;
       }
+      /* Record the just-completed (auto-expanded) word for the "previous
+       * word" indicator — only at a real word boundary, never mid-word. */
+      strlcpy(last_completed_word, check_word, sizeof(last_completed_word));
+      memzero(check_word, sizeof(check_word));
     }
 
     memzero(coded_word, sizeof(coded_word));
@@ -545,6 +552,22 @@ void recovery_delete_character(void) {
 
     mnemonic[len - 1] = '\0';
   }
+
+  /* Resync the current-word accumulators with the edited mnemonic so a
+   * corrected word is validated on its real value (stale bytes here would
+   * fail validation and trigger a storage_reset on a real recovery).
+   * decoded_word is the typed prefix of the current word; coded_word is its
+   * reverse-cipher form (session cipher is fixed, so it is reconstructable). */
+  char cur[CURRENT_WORD_BUF];
+  get_current_word(cur);
+  strlcpy(decoded_word, cur, sizeof(decoded_word));
+  memzero(cur, sizeof(cur));
+  size_t wlen = strlen(decoded_word);
+  for (size_t i = 0; i < wlen && i + 1 < sizeof(coded_word); i++) {
+    char d = decoded_word[i];
+    coded_word[i] = (d >= 'a' && d <= 'z') ? cipher[d - 'a'] : d;
+  }
+  coded_word[wlen < sizeof(coded_word) ? wlen : sizeof(coded_word) - 1] = '\0';
 
   next_character();
 }
@@ -609,7 +632,11 @@ void recovery_cipher_finalize(void) {
   }
   memzero(temp_word, sizeof(temp_word));
 
-  if (!auto_completed && enforce_wordlist) {
+  /* Cipher recovery decodes to BIP-39 words, so every word must
+   * auto-complete regardless of enforce_wordlist. Failing only when
+   * enforce_wordlist was set left the default (host-omitted) path storing a
+   * mistyped/garbage phrase as the seed and reporting success. */
+  if (!auto_completed) {
     if (!dry_run) {
       storage_reset();
     }

--- a/lib/firmware/recovery_cipher.c
+++ b/lib/firmware/recovery_cipher.c
@@ -371,13 +371,29 @@ void next_character(void) {
   }
 #endif
 
+  /* Save word so we can show it as "prev" on next word.
+   * When auto-complete fires, current_word holds the full expanded word
+   * (e.g. "alcohol" not "alc"). Otherwise save the typed prefix. */
+  static char CONFIDENTIAL last_completed_word[12];
+  if (strlen(current_word) > 0) {
+    strlcpy(last_completed_word, current_word, sizeof(last_completed_word));
+  }
+
   /* Format current word and display it along with cipher */
   static char CONFIDENTIAL formatted_word[CURRENT_WORD_BUF + 10];
   format_current_word(word_pos, current_word, auto_completed, &formatted_word);
   memzero(current_word, sizeof(current_word));
 
+  /* Format previous word indicator (e.g. "(1.alcohol)" when entering word 2) */
+  static char prev_info[32];
+  prev_info[0] = '\0';
+  if (word_pos > 0 && last_completed_word[0]) {
+    snprintf(prev_info, sizeof(prev_info), "(%" PRIu32 ".%s)", word_pos,
+             last_completed_word);
+  }
+
   /* Show cipher and partial word */
-  layout_cipher(formatted_word, cipher);
+  layout_cipher(formatted_word, cipher, prev_info);
   memzero(formatted_word, sizeof(formatted_word));
 }
 
@@ -462,6 +478,24 @@ void recovery_character(const char* character) {
       }
     }
   } else {
+    /* Per-word BIP39 validation: reject immediately if the decoded word
+     * doesn't match any entry in the wordlist. */
+    if (enforce_wordlist && strlen(decoded_word) > 0) {
+      static CONFIDENTIAL char check_word[CURRENT_WORD_BUF];
+      strlcpy(check_word, decoded_word, sizeof(check_word));
+      bool valid = attempt_auto_complete(check_word);
+      memzero(check_word, sizeof(check_word));
+      if (!valid) {
+        memzero(coded_word, sizeof(coded_word));
+        memzero(decoded_word, sizeof(decoded_word));
+        recovery_cipher_abort();
+        fsm_sendFailure(FailureType_Failure_SyntaxError,
+                        "Word not found in BIP39 wordlist");
+        layout_warning_static("Word not in wordlist");
+        return;
+      }
+    }
+
     memzero(coded_word, sizeof(coded_word));
     memzero(decoded_word, sizeof(decoded_word));
 
@@ -575,7 +609,7 @@ void recovery_cipher_finalize(void) {
   }
   memzero(temp_word, sizeof(temp_word));
 
-  if (!auto_completed && !enforce_wordlist) {
+  if (!auto_completed && enforce_wordlist) {
     if (!dry_run) {
       storage_reset();
     }

--- a/tools/firmware/keepkey_main.c
+++ b/tools/firmware/keepkey_main.c
@@ -73,16 +73,15 @@ void memory_getDeviceLabel(char *str, size_t len) {
 bool inPrivilegedMode(void) {
   // Check to see if we are in priv mode. If so, return true to drop privs.
   uint32_t creg = 0xffff;
-  // CONTROL register nPRIV,bit[0]: 
+  // CONTROL register nPRIV,bit[0]:
   //    0 Thread mode has privileged access
-  //    1 Thread mode has unprivileged access. 
+  //    1 Thread mode has unprivileged access.
   // Note: In Handler mode, execution is always privileged
   fi_defense_delay(creg);  // vary access time
-  __asm__ volatile(
-       "mrs %0, control" : "=r" (creg));
+  __asm__ volatile("mrs %0, control" : "=r"(creg));
   fi_defense_delay(creg);  // vary test time
-  if (creg & 0x0001) 
-    return false;          // can't drop privs
+  if (creg & 0x0001)
+    return false;  // can't drop privs
   else
     return true;
 
@@ -173,9 +172,23 @@ int main(void) {
   _timerusr_isr = (void *)&timerisr_usr;
   _mmhusr_isr = (void *)&mmhisr;
 
-  { // limit sigRet lifetime to this block
+  {  // limit sigRet lifetime to this block
+    /* F5 hardening: replace full signatures_ok() (~1 sec crypto) with fast
+     * metadata presence check. The bootloader has already performed the
+     * authoritative signature verification before jumping here. We only
+     * need to know whether the bootloader considered us signed, which is
+     * indicated by valid signature indices in flash metadata. */
     int sigRet = SIG_FAIL;
-    sigRet = signatures_ok();
+
+    volatile uint8_t si1 = *((volatile uint8_t *)FLASH_META_SIGINDEX1);
+    volatile uint8_t si2 = *((volatile uint8_t *)FLASH_META_SIGINDEX2);
+    volatile uint8_t si3 = *((volatile uint8_t *)FLASH_META_SIGINDEX3);
+
+    if (si1 >= 1 && si1 <= PUBKEYS && si2 >= 1 && si2 <= PUBKEYS && si3 >= 1 &&
+        si3 <= PUBKEYS && si1 != si2 && si1 != si3 && si2 != si3) {
+      sigRet = SIG_OK;
+    }
+
     flash_collectHWEntropy(SIG_OK == sigRet);
 
     /* Drop privileges */
@@ -194,8 +207,9 @@ int main(void) {
 
     drbg_init();
 
-    /* Bootloader Verification. Only check if valid signed firmware on-board, allow any other firmware
-    to run with any bootloader. This allows unsigned release firmware to run after warning */
+    /* Bootloader Verification. Only check if valid signed firmware on-board,
+    allow any other firmware to run with any bootloader. This allows unsigned
+    release firmware to run after warning */
     if (SIG_OK == sigRet) {
       check_bootloader();
     }

--- a/tools/firmware/keepkey_main.c
+++ b/tools/firmware/keepkey_main.c
@@ -173,21 +173,12 @@ int main(void) {
   _mmhusr_isr = (void *)&mmhisr;
 
   {  // limit sigRet lifetime to this block
-    /* F5 hardening: replace full signatures_ok() (~1 sec crypto) with fast
-     * metadata presence check. The bootloader has already performed the
-     * authoritative signature verification before jumping here. We only
-     * need to know whether the bootloader considered us signed, which is
-     * indicated by valid signature indices in flash metadata. */
+    /* Signature indices in flash metadata are host-writable, so they must
+     * not be trusted for security decisions. Perform the full (fault-
+     * injection-hardened) signature verification in the app as well; the
+     * bootloader check alone cannot be latched across the jump. */
     int sigRet = SIG_FAIL;
-
-    volatile uint8_t si1 = *((volatile uint8_t *)FLASH_META_SIGINDEX1);
-    volatile uint8_t si2 = *((volatile uint8_t *)FLASH_META_SIGINDEX2);
-    volatile uint8_t si3 = *((volatile uint8_t *)FLASH_META_SIGINDEX3);
-
-    if (si1 >= 1 && si1 <= PUBKEYS && si2 >= 1 && si2 <= PUBKEYS && si3 >= 1 &&
-        si3 <= PUBKEYS && si1 != si2 && si1 != si3 && si2 != si3) {
-      sigRet = SIG_OK;
-    }
+    sigRet = signatures_ok();
 
     flash_collectHWEntropy(SIG_OK == sigRet);
 


### PR DESCRIPTION
**3/5 of the 7.15 stack.** Stacks on 2/5 (`release/7.15.0-pr2-new-chains`).

Independent device-robustness work — no chain or clear-signing dependencies.

- **BIP-85** — child mnemonic derivation (display only).
- **BIP-39 recovery** — per-word validation during cipher recovery, so a mistyped word is caught on entry instead of producing a silently wrong seed.
- **Fault-injection hardening** — the signature-verification path is hardened against glitch / fault attacks.
- Plus the small build/lint fixes these need to pass ARM `-Werror` and cppcheck.

Same base pins as 1/5. Builds green.
