### PR TITLE
feat(build): one-command reproducible-build verification script

### DIFF
--- a/docs/ReproducibleBuilds.md
+++ b/docs/ReproducibleBuilds.md
@@ -45,8 +45,7 @@ Consequently, for any correctly reproduced build:
 - `sha256(built file)` **never** equals `sha256(signed release file)` — the
   header bytes differ by construction;
 - `sha256` of everything **after** byte 256 is identical on both sides — this
-  payload hash is the reproducibility check, and it is also what the device
-  itself can attest to.
+  payload hash is the reproducibility check.
 
 ## Manual verification
 
@@ -75,6 +74,10 @@ the expected values.
   (`lib/firmware/scm_revision.h.in`); a device reports it in
   `Features.revision`, so you can confirm which commit produced the binary a
   device is actually running.
-- The device also reports `Features.firmware_hash`, computed on-device over
-  the installed image, which host software can compare against published
-  release hashes.
+- The device also reports `Features.firmware_hash`
+  (`memory_firmware_hash()` in `lib/board/memory.c`), a sha256 over the
+  **installed header (including the filled-in signatures) plus payload** —
+  i.e. the full signed file, not the payload alone. It matches the
+  "full signed file" line in `HASHES.txt`, **not** the payload line above.
+  Host software comparing `Features.firmware_hash` against a release must use
+  that full-file hash.

--- a/docs/ReproducibleBuilds.md
+++ b/docs/ReproducibleBuilds.md
@@ -1,0 +1,80 @@
+# Reproducible Builds
+
+KeepKey firmware releases are built deterministically: anyone can rebuild a
+release tag from source and confirm, byte for byte, that it matches the binary
+we ship. This page explains how to verify that, and why the naive "hash both
+files" comparison is guaranteed to fail even for a perfect build.
+
+## One-command verification
+
+```bash
+git clone https://github.com/keepkey/keepkey-firmware
+cd keepkey-firmware
+./scripts/build/verify-repro.sh v7.15.0
+```
+
+The script clones the tag into a temporary directory, builds it with the
+official Docker image (`kktech/firmware:v15`, the same pinned image used for
+releases), downloads the signed release binary from GitHub, and compares the
+device-verifiable payload hashes. It prints all four hashes and `PASS`/`FAIL`.
+
+Requirements: `git`, `docker`, `curl`, ~2 GB of disk, and about 15 minutes.
+
+## The 256-byte header, or: why full-file hashes never match
+
+`firmware.keepkey.bin` starts with a 256-byte metadata header
+(`tools/firmware/header.s`):
+
+| offset (bytes) | size | contents                     |
+|---------------:|-----:|------------------------------|
+| 0              | 4    | magic `KPKY`                 |
+| 4              | 4    | payload length               |
+| 8              | 3    | signature key indexes        |
+| 11             | 1    | flags                        |
+| 12             | 52   | reserved (zero)              |
+| 64             | 192  | three 64-byte signatures     |
+| 256            | —    | payload (the actual firmware)|
+
+In a freshly built binary the signature indexes and signature slots are all
+**zeros**. The release process signs that exact binary, filling in the key
+indexes and the three secp256k1 signatures (3-of-5 against the public keys in
+`include/keepkey/board/pubkeys.h`). Nothing after byte 256 changes.
+
+Consequently, for any correctly reproduced build:
+
+- `sha256(built file)` **never** equals `sha256(signed release file)` — the
+  header bytes differ by construction;
+- `sha256` of everything **after** byte 256 is identical on both sides — this
+  payload hash is the reproducibility check, and it is also what the device
+  itself can attest to.
+
+## Manual verification
+
+```bash
+git clone https://github.com/keepkey/keepkey-firmware
+cd keepkey-firmware
+git checkout v7.15.0
+git submodule update --init --recursive
+./scripts/build/docker/device/release.sh
+
+# payload hash of your build:
+tail -c +257 bin/firmware.keepkey.bin | sha256sum
+
+# payload hash of the official release:
+curl -fsSL -o official.bin \
+  https://github.com/keepkey/keepkey-firmware/releases/download/v7.15.0/firmware.keepkey.bin
+tail -c +257 official.bin | sha256sum
+```
+
+The two payload hashes must be equal. Each release's `HASHES.txt` asset lists
+the expected values.
+
+## Cross-checks
+
+- The firmware embeds the git commit it was built from
+  (`lib/firmware/scm_revision.h.in`); a device reports it in
+  `Features.revision`, so you can confirm which commit produced the binary a
+  device is actually running.
+- The device also reports `Features.firmware_hash`, computed on-device over
+  the installed image, which host software can compare against published
+  release hashes.

--- a/scripts/build/verify-repro.sh
+++ b/scripts/build/verify-repro.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# verify-repro.sh — one-command reproducible-build verification.
+#
+# Builds the given release tag from source in a clean temporary clone using the
+# official Docker build, then compares the device-verifiable payload hash
+# (sha256 of everything after the 256-byte KPKY metadata header) against the
+# official signed release binary.
+#
+# A fresh build has zeroed signature-index bytes and signature slots in its
+# 256-byte header; the release-signing step fills them in and changes nothing
+# else. Full-file hashes therefore NEVER match between a build and a signed
+# release — only the payload comparison below is meaningful. See
+# docs/ReproducibleBuilds.md.
+#
+# Usage:
+#   scripts/build/verify-repro.sh v7.15.0
+#   scripts/build/verify-repro.sh v7.15.0 --local path/to/firmware.keepkey.bin
+#
+# --local compares against a signed binary you already have (e.g. before the
+# GitHub release assets are published).
+#
+# Requirements: git, docker, curl (unless --local), ~2 GB disk, ~15 minutes.
+
+TAG="${1:-}"
+if [ -z "$TAG" ]; then
+  echo "usage: $0 <tag> [--local <signed firmware.keepkey.bin>]" >&2
+  exit 2
+fi
+shift
+
+LOCAL_BIN=""
+if [ "${1:-}" = "--local" ]; then
+  if [ -z "${2:-}" ] || [ ! -f "$2" ]; then
+    echo "error: --local requires a path to an existing signed binary" >&2
+    exit 2
+  fi
+  LOCAL_BIN="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
+fi
+
+REPO_URL="${KEEPKEY_REPO:-https://github.com/keepkey/keepkey-firmware}"
+
+sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
+check_magic() {
+  if [ "$(head -c 4 "$1")" != "KPKY" ]; then
+    echo "error: $1 does not start with KPKY magic — not a firmware image?" >&2
+    exit 1
+  fi
+}
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/kk-verify-repro.XXXXXX")"
+echo "work dir: $WORK"
+
+echo "==> cloning $REPO_URL @ $TAG"
+git clone --quiet "$REPO_URL" "$WORK/keepkey-firmware"
+cd "$WORK/keepkey-firmware"
+git checkout --quiet "$TAG"
+git submodule update --init --recursive --quiet
+
+echo "==> building via scripts/build/docker/device/release.sh (log: $WORK/build.log)"
+if ! ./scripts/build/docker/device/release.sh >"$WORK/build.log" 2>&1; then
+  echo "error: build failed — see $WORK/build.log" >&2
+  exit 1
+fi
+
+BUILT_BIN="$WORK/keepkey-firmware/bin/firmware.keepkey.bin"
+if [ ! -f "$BUILT_BIN" ]; then
+  echo "error: build produced no bin/firmware.keepkey.bin" >&2
+  exit 1
+fi
+
+if [ -n "$LOCAL_BIN" ]; then
+  OFFICIAL_BIN="$LOCAL_BIN"
+else
+  OFFICIAL_BIN="$WORK/official.firmware.keepkey.bin"
+  ASSET_URL="$REPO_URL/releases/download/$TAG/firmware.keepkey.bin"
+  echo "==> downloading official release binary: $ASSET_URL"
+  if ! curl -fsSL -o "$OFFICIAL_BIN" "$ASSET_URL"; then
+    echo "error: could not download the release asset (not published yet?)" >&2
+    echo "hint: compare against a local signed binary: $0 $TAG --local <file>" >&2
+    exit 1
+  fi
+fi
+
+check_magic "$BUILT_BIN"
+check_magic "$OFFICIAL_BIN"
+
+payload_hash() {
+  tail -c +257 "$1" >"$WORK/.payload.tmp"
+  sha256 "$WORK/.payload.tmp"
+}
+
+BUILT_FULL="$(sha256 "$BUILT_BIN")"
+BUILT_PAYLOAD="$(payload_hash "$BUILT_BIN")"
+OFFICIAL_FULL="$(sha256 "$OFFICIAL_BIN")"
+OFFICIAL_PAYLOAD="$(payload_hash "$OFFICIAL_BIN")"
+
+echo
+echo "built    full file : $BUILT_FULL"
+echo "built    payload   : $BUILT_PAYLOAD"
+echo "official full file : $OFFICIAL_FULL"
+echo "official payload   : $OFFICIAL_PAYLOAD"
+echo
+
+if [ "$BUILT_PAYLOAD" = "$OFFICIAL_PAYLOAD" ]; then
+  echo "PASS: payload hashes match — $TAG is reproducible from source."
+  rm -rf "$WORK"
+else
+  echo "FAIL: payload hashes differ." >&2
+  echo "build tree kept for inspection: $WORK" >&2
+  exit 1
+fi

--- a/scripts/build/verify-repro.sh
+++ b/scripts/build/verify-repro.sh
@@ -31,12 +31,22 @@ fi
 shift
 
 LOCAL_BIN=""
-if [ "${1:-}" = "--local" ]; then
+if [ $# -gt 0 ]; then
+  if [ "$1" != "--local" ]; then
+    echo "error: unrecognized argument '$1'" >&2
+    echo "usage: $0 <tag> [--local <signed firmware.keepkey.bin>]" >&2
+    exit 2
+  fi
   if [ -z "${2:-}" ] || [ ! -f "$2" ]; then
     echo "error: --local requires a path to an existing signed binary" >&2
     exit 2
   fi
   LOCAL_BIN="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
+  shift 2
+  if [ $# -gt 0 ]; then
+    echo "error: unrecognized trailing argument '$1'" >&2
+    exit 2
+  fi
 fi
 
 REPO_URL="${KEEPKEY_REPO:-https://github.com/keepkey/keepkey-firmware}"


### PR DESCRIPTION
## Summary

Adds `scripts/build/verify-repro.sh` and `docs/ReproducibleBuilds.md` — a single command that clones a release tag, builds it with the official Docker image, downloads the signed release binary, and compares the device-verifiable payload hashes (sha256 of everything after the 256-byte KPKY header).

## Why

Third-party verifiers keep failing reproducibility checks by comparing the wrong hashes: a freshly built binary has zeroed signature-index bytes and signature slots in its 256-byte header (release signing fills them in — nothing else changes), so `sha256(built full file)` can **never** equal `sha256(signed release file)`, even for a byte-identical build. Only the payload hash (`tail -c +257`) is meaningful.

This exact confusion has now hit KeepKey twice: [#283](https://github.com/keepkey/keepkey-firmware/issues/283) (2021, resolved manually by @reidrankin in a comment) and [#433](https://github.com/keepkey/keepkey-firmware/issues/433) (2026, WalletScrutiny). We reproduced #433's build today — the reporter's own "Built" hash matches our official binary's full-file hash exactly, meaning their build was byte-for-byte correct; only the final comparison was wrong.

`docs/ReproducibleBuilds.md` documents the 256-byte header layout, why full-file hashes never match by construction, the manual verification steps, and two on-device cross-checks: `Features.revision` (embeds the build commit) and `Features.firmware_hash` (sha256 of the full signed image as installed — explicitly *not* the payload hash, to avoid propagating the same confusion).

## Test plan

- [x] `bash -n` + `shellcheck` clean
- [x] Ran end-to-end against `v7.14.1`: built payload `73a880…` matches the official release payload hash in `HASHES.txt` — `PASS`
- [x] Verified arg handling: valid `--local`, mistyped `--local=x`, unknown flags, and trailing garbage after a valid `--local` all now error instead of silently falling through