### PR TITLE
release(rc18): hardening and two-product firmware release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@
 #   └─ check-submodules   verify all deps present
 #
 # Stage 2: BUILD (parallel, gated by Stage 1)
-#   ├─ build-emulator     Docker image → artifact  [matrix: full / bitcoin-only / zcash-privacy]
+#   ├─ build-emulator     Docker image → artifact  [matrix: full / bitcoin-only]
 #   └─ build-arm-firmware cross-compile → .bin/.elf (downloadable)  [same matrix]
 #
 # Stage 3: TEST (parallel, gated by Stage 2)
@@ -221,21 +221,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # The emulator CMake default is KK_ZCASH_PRIVACY=ON (what the published
-          # dylib/Docker image include), so an empty-flag full leg builds
-          # byte-identical to the zcash-privacy leg and the SHIPPED device
-          # configuration (multi-coin, privacy OFF) is never unit-tested. Pin the
-          # full leg to the shipped config; publish-emulator ships the
-          # zcash-privacy image (the same bytes the old full leg produced).
+          # Regular/full includes every supported chain, including Zcash
+          # shielded/Orchard. Bitcoin-only is the sole reduced build.
           - variant: full
             label: ""
-            cmake_flags: "-DKK_ZCASH_PRIVACY=OFF"
+            cmake_flags: ""
           - variant: bitcoin-only
             label: " (bitcoin-only)"
             cmake_flags: "-DKK_BITCOIN_ONLY=ON"
-          - variant: zcash-privacy
-            label: " (zcash-privacy)"
-            cmake_flags: "-DKK_ZCASH_PRIVACY=ON"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -304,9 +297,6 @@ jobs:
           - variant: bitcoin-only
             label: " (bitcoin-only)"
             cmake_flags: "-DKK_BITCOIN_ONLY=ON"
-          - variant: zcash-privacy
-            label: " (zcash-privacy)"
-            cmake_flags: "-DKK_ZCASH_PRIVACY=ON"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -367,7 +357,7 @@ jobs:
               find . -name '*.su' -print0 | tar czf /root/keepkey-firmware/bin/stack-usage.tgz --null -T - && \
               chmod -R a+rw /root/keepkey-firmware/bin"
 
-      # SRAM budget gate — RC7's zcash-privacy variant hard-faulted on boot
+      # SRAM budget gate — RC7's privacy-enabled build hard-faulted on boot
       # because static SRAM left an 11.2 KB gap while msg_write() carried a
       # 12.4 KB stack frame. keepkey.ld now ASSERTs a 16 KiB reserve at link
       # time; this step reports the numbers and enforces the frame margin
@@ -426,9 +416,6 @@ jobs:
           - variant: bitcoin-only
             label: " (bitcoin-only)"
             cmake_flags: "-DKK_BITCOIN_ONLY=ON"
-          - variant: zcash-privacy
-            label: " (zcash-privacy)"
-            cmake_flags: "-DKK_ZCASH_PRIVACY=ON"
     steps:
       - name: Download emulator image
         uses: actions/download-artifact@v8
@@ -755,9 +742,8 @@ jobs:
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
-          # Report covers the full/default variant only — bitcoin-only and
-          # zcash-privacy are built and unit-tested in their own matrix legs
-          # but don't get a PDF (see unit-tests / build-arm-firmware).
+          # Report covers the regular/full build. Bitcoin-only is built and
+          # unit-tested in its own matrix leg but does not get a PDF.
           name: unit-test-results-full
           path: test-reports/firmware-unit/
 
@@ -818,11 +804,8 @@ jobs:
       - name: Download emulator image
         uses: actions/download-artifact@v8
         with:
-          # Publish the zcash-privacy variant: it matches the emulator's CMake
-          # default (privacy engine ON — what vault and auditors run), which
-          # the "full" leg no longer builds now that it pins the shipped
-          # device configuration (privacy OFF).
-          name: emu-image-zcash-privacy
+          # Publish the regular/full image, including Zcash privacy support.
+          name: emu-image-full
           path: /tmp
 
       - name: Load emulator image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,8 +74,6 @@ jobs:
             cmake_flags: ""
           - variant: bitcoin-only
             cmake_flags: "-DKK_BITCOIN_ONLY=ON"
-          - variant: zcash-privacy
-            cmake_flags: "-DKK_ZCASH_PRIVACY=ON"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -175,8 +173,6 @@ jobs:
             cmake_flags: ""
           - variant: bitcoin-only
             cmake_flags: "-DKK_BITCOIN_ONLY=ON"
-          - variant: zcash-privacy
-            cmake_flags: "-DKK_ZCASH_PRIVACY=ON"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -234,17 +230,15 @@ jobs:
           ## KeepKey Firmware v${VER}
 
           ### Variants
-          - **full** — \`firmware.keepkey.v${VER}-full.bin\` — all supported chains
+          - **full (regular)** — \`firmware.keepkey.v${VER}-full.bin\` — all supported chains, including Zcash shielded/Orchard
           - **bitcoin-only** — \`firmware.keepkey.v${VER}-bitcoin-only.bin\` — BTC-only, non-BTC coins stripped
-          - **zcash-privacy** — \`firmware.keepkey.v${VER}-zcash-privacy.bin\` — adds the Zcash shielded/Orchard engine
 
           ### Reproducible Build Verification
           \`\`\`bash
           ./scripts/build/docker/device/release.sh
           tail -c +257 bin/firmware.keepkey.bin | shasum -a 256
-          # bitcoin-only / zcash-privacy variants:
+          # bitcoin-only:
           #   ./scripts/build/docker/device/release.sh -DKK_BITCOIN_ONLY=ON
-          #   ./scripts/build/docker/device/release.sh -DKK_ZCASH_PRIVACY=ON
           # (extra args pass through to cmake) and compare against the
           # matching HASHES-<variant>.txt
           \`\`\`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,16 +21,14 @@ option(KK_BUILD_DYLIB "Build libkkemu shared library (.dylib/.so)" OFF)
 option(KK_DEBUG_LINK "Build with debug-link enabled" OFF)
 option(KK_BUILD_FUZZERS "Build the fuzzers?" OFF)
 option(KK_BITCOIN_ONLY "Build Bitcoin-only firmware (strip all non-BTC coins)" OFF)
-# The emulator runs on a host with no flash/SRAM budget, so it defaults the
-# Zcash shielded/Orchard privacy engine ON -- this is what makes the published
-# libkkemu dylib and Docker image (what vault and auditors actually run)
-# include it. Device firmware keeps the OFF default and only ships the engine
-# via an explicit -DKK_ZCASH_PRIVACY=ON. Bitcoin-only can never enable it
-# (mutually exclusive, see below), so it forces the OFF default too.
-if(KK_EMULATOR AND NOT KK_BITCOIN_ONLY)
-  option(KK_ZCASH_PRIVACY "Build the Zcash shielded/Orchard privacy engine" ON)
+# Zcash shielded/Orchard support is part of the regular firmware. It is an
+# internal compile selection, not a third release variant: bitcoin-only strips
+# the Zcash coin and privacy engine; every regular device/emulator build ships
+# both. Keep the value macro below so bitcoin-only can compile the sources out.
+if(KK_BITCOIN_ONLY)
+  set(KK_ZCASH_PRIVACY OFF)
 else()
-  option(KK_ZCASH_PRIVACY "Build the Zcash shielded/Orchard privacy engine" OFF)
+  set(KK_ZCASH_PRIVACY ON)
 endif()
 
 # When building the dylib, every static lib it links (kkfirmware, kkboard,
@@ -150,24 +148,14 @@ add_definitions(-DBIP39_WORDLIST_PADDED=1)
 
 add_definitions(-DAES_128=1)
 
-# NOTE: AES table size is selected per-variant below. This PR splits Zcash
-# (and its Pallas curve arithmetic) into the zcash-privacy variant, so the
-# default and bitcoin-only images regain flash headroom and keep the fast
-# FOUR_TABLES AES; only zcash-privacy opts into AES_SMALL_TABLES.
+# NOTE: AES table size is selected per release product below. The regular
+# image includes Zcash and its Pallas curve arithmetic, so it uses the smaller
+# AES tables to preserve flash headroom. Bitcoin-only keeps FOUR_TABLES AES.
 
 if(${KK_DEBUG_LINK})
   add_definitions(-DDEBUG_LINK=1)
 else()
   add_definitions(-DDEBUG_LINK=0)
-endif()
-
-# Bitcoin-only removes the Zcash coin entirely, which the shielded/Orchard
-# privacy engine depends on -- the two flags cannot coexist.
-if(${KK_BITCOIN_ONLY} AND ${KK_ZCASH_PRIVACY})
-  message(
-    FATAL_ERROR
-      "KK_BITCOIN_ONLY and KK_ZCASH_PRIVACY are mutually exclusive: bitcoin-only strips the Zcash coin that the privacy engine requires."
-  )
 endif()
 
 # Value macros (always defined 0/1) -- device builds use -Wundef -Werror, so an
@@ -180,9 +168,9 @@ endif()
 
 if(${KK_ZCASH_PRIVACY})
   add_definitions(-DZCASH_PRIVACY=1)
-  # The Orchard engine leaves this variant tightest on flash; shrink the
+  # The Orchard engine leaves the regular image tightest on flash; shrink the
   # Gladman AES lookup tables from 4KB to 1KB each (-15,360 bytes ROM,
-  # slightly slower AES). full/bitcoin-only keep the fast FOUR_TABLES.
+  # slightly slower AES). Bitcoin-only keeps the fast FOUR_TABLES.
   add_definitions(-DAES_SMALL_TABLES)
 else()
   add_definitions(-DZCASH_PRIVACY=0)

--- a/docs/Generalized-Tendermint-Signing.md
+++ b/docs/Generalized-Tendermint-Signing.md
@@ -1,0 +1,537 @@
+# Generalized Cosmos and Tendermint signing
+
+Status: future design proposal
+
+This document describes a path to full Cosmos SDK `SIGN_MODE_DIRECT` support,
+generalized Tendermint/CometBFT-family signing, and IBC transfers across supported
+chains. It is not part of the 7.15.0-rc17 release scope and does not change that
+release's acceptance criteria.
+
+The name "Tendermint" is retained where it refers to the existing KeepKey
+protocol. New code should use the more precise terms "Cosmos SDK" and
+"CometBFT-family."
+
+## Product position
+
+Blind signing with an explicit warning is a valid first support tier for a new
+chain or message type. KeepKey already uses this phased model for Ethereum
+contract data and opaque Solana, TRON, TON, and EOS operations. Generalized
+Cosmos support should follow the same model:
+
+1. Sign the exact transaction bytes in Advanced Mode after an unmistakable blind
+   signing warning.
+2. Parse and display transaction envelope fields that can be bound to those
+   exact bytes.
+3. Add clear-signing adapters for common messages over time.
+4. Automatically replace blind review with clear review as message adapters
+   become available.
+
+Unknown does not mean forbidden. It means the device must never present an
+unknown message as understood.
+
+This distinction makes broad compatibility practical:
+
+- A Cosmos SDK transaction using a supported key algorithm and
+  `SIGN_MODE_DIRECT` can be signed even when one or more `Any` message values are
+  not understood by the firmware.
+- Recognized messages receive semantic clear-signing screens.
+- Unrecognized messages receive blind-signing screens and an exact transaction
+  commitment.
+- A non-Cosmos application built on Tendermint or CometBFT can reuse the
+  generalized byte-signing engine, but still needs an adapter defining its
+  signing domain, preimage, and key algorithm. A Cosmos `SignDoc` is not a
+  universal transaction format for every CometBFT application.
+
+The target is therefore universal signing compatibility for supported
+algorithms and defined signing domains, not a claim that the firmware
+semantically understands every application.
+
+## Goals
+
+- Implement Cosmos SDK protobuf `SIGN_MODE_DIRECT`.
+- Preserve legacy Amino support for chains that still require it.
+- Blind-sign otherwise valid, unsupported Cosmos messages behind Advanced Mode.
+- Progressively clear-sign known bank, staking, distribution, governance, IBC,
+  authz, feegrant, CosmWasm, and chain-specific messages.
+- Derive and display addresses for arbitrary compatible chains without
+  conflating display names, registry identities, and Bech32 prefixes.
+- Support arbitrary Cosmos coin denoms, canonical integer amounts, multiple
+  coins, fee grants, and fee payers within explicit resource limits.
+- Clear-sign ICS-20 transfers for all valid routes and assets, including
+  voucher, factory, and long trace-derived denoms.
+- Reuse a bounded, session-oriented byte-signing core for non-Cosmos
+  CometBFT-family adapters.
+- Keep every reviewed value cryptographically bound to the exact signed
+  preimage.
+
+## Non-goals and boundaries
+
+- The firmware does not discover IBC paths, channels, counterparty chains, or
+  relayers. The host builds the route; the device reviews the source-chain
+  transaction.
+- Blind signing does not provide semantic verification. A digest and byte count
+  prove which bytes were approved, not what an unknown message will do.
+- Host-provided labels, symbols, decimals, recipients, or amounts must never
+  substitute for values parsed from the signed bytes.
+- `SIGN_MODE_DIRECT` does not cover every non-Cosmos CometBFT application.
+  Applications with different signing preimages or algorithms require explicit
+  adapters.
+- Multisig, `SIGN_MODE_DIRECT_AUX`, `SIGN_MODE_TEXTUAL`, and non-secp256k1 keys
+  are not implied by the first implementation. They require explicit protocol
+  and UX decisions.
+
+## Current implementation and gaps
+
+The existing generic Tendermint protocol is a legacy Amino implementation. It is
+useful compatibility code, but it is not a base for universal support.
+
+| Area | Current behavior | Required v2 behavior |
+| --- | --- | --- |
+| Sign mode | Legacy Amino JSON only | Exact protobuf `SignDoc` bytes for `SIGN_MODE_DIRECT`, plus legacy Amino |
+| Generic messages | Wire schema advertises several message types; firmware handler accepts only `send` | Known messages clear-sign; every other valid `Any` can blind-sign |
+| IBC | Generic IBC schema has no amount field | Bind token, sender, receiver, port, channel, timeouts, and memo |
+| Amounts | Message amount is `uint64`; fee is `uint32` | Canonical unsigned decimal strings with an explicit maximum |
+| Denoms | Generic denom is limited to 9 characters | Long exact denoms, including `ibc/<64-hex>` and factory denoms |
+| Fees | One session-wide denom is reused | Repeated fee coins, independent message coins, gas, payer, and granter |
+| Chain identity | `chain_name` is both coin lookup name and address HRP; `address_prefix` is ignored | Immutable, separate chain ID, registry ID, display name, and HRPs |
+| Address support | Limited by the compiled coin registry | Validated chain descriptors and explicit path policy |
+| Tests | Generic coverage is primarily session/config binding | Cross-SDK vectors, parser adversarial tests, emulator UX, and hardware QA |
+| Host integration | Generic address support is partial; generic signing is not end-to-end | Protocol, hdwallet, Vault, registry, builder, and broadcast support |
+
+The existing `Tendermint*`, `Cosmos*`, and `Osmosis*` message IDs must remain
+compatible. The new design should use new v2 message IDs and implementation
+state rather than changing the meaning or size limits of old fields.
+
+## Signing and review tiers
+
+The transaction is assigned the least-trusted tier required by any component.
+One unknown message downgrades the transaction to blind or mixed review; it must
+not inherit a clear-sign label from neighboring known messages.
+
+### Tier A: clear signing
+
+All security-relevant fields are parsed from the exact signed bytes and displayed:
+
+- chain ID and signing account;
+- message actions, senders, recipients, validators, contracts, and parameters;
+- exact coin amounts and denoms;
+- memo and timeout values;
+- fees, gas, payer, granter, and sequence as applicable.
+
+Friendly symbols or decimal conversion may supplement raw values only when the
+metadata is trusted and the exact denom remains reviewable.
+
+### Tier B: mixed review
+
+The firmware understands the transaction envelope and some messages, but at
+least one message or extension is opaque. It:
+
+- clearly labels the whole transaction as containing unverified actions;
+- displays all safely parsed envelope and known-message fields;
+- displays each unknown `type_url`, value byte count, and value digest;
+- displays an overall signing-preimage digest and byte count;
+- requires Advanced Mode and explicit blind-sign confirmation.
+
+### Tier C: blind signing
+
+The adapter can validate the signing domain and sign the exact preimage, but
+cannot semantically parse the application payload. It:
+
+- requires Advanced Mode;
+- displays a prominent "Blind Sign" warning;
+- displays the chain/signing domain, derivation path or derived address, exact
+  byte count, and full transaction digest;
+- never displays host side-channel values as if they came from the transaction;
+- signs only after an explicit final confirmation.
+
+Malformed framing, an unsupported key algorithm, a path that cannot be bound to
+the signer, an oversized payload, or an ambiguous/non-canonical clear-sign parse
+is rejected. Unsupported semantics alone may fall back to Tier B or C.
+
+Advanced Mode is a hard gate, not the only warning. Enabling it once does not
+silently approve future blind signatures.
+
+## Exact-byte invariant
+
+The principal invariant is:
+
+> The device hashes and signs exactly the bytes whose properties and digest it
+> reviewed.
+
+For `SIGN_MODE_DIRECT`, the secp256k1 signature is over the SHA-256 digest of the
+serialized `cosmos.tx.v1beta1.SignDoc`:
+
+- `body_bytes`
+- `auth_info_bytes`
+- `chain_id`
+- `account_number`
+
+The preferred protocol streams the serialized `SignDoc` bytes to the device.
+The device simultaneously:
+
+1. validates ordered chunk framing and the declared total length;
+2. hashes the exact incoming bytes;
+3. parses display information from those same immutable bytes;
+4. binds the selected key and signer information;
+5. performs the required review flow;
+6. signs the accumulated digest without reconstructing a different `SignDoc`.
+
+Hashing host-provided structured fields and later reserializing them creates an
+avoidable display/signature mismatch risk. If structured transport is retained
+for memory reasons, the framing itself must define one canonical serialized
+preimage and the firmware must both parse and hash that exact stream.
+
+For Tier A clear signing, protobuf handling must reject encodings whose meaning
+could differ between the firmware and a node, including ambiguous duplicate
+singular fields, malformed or overlong varints, invalid lengths, truncated
+submessages, conflicting signer modes, and unsupported critical extension
+options. A structurally valid unknown `Any` is not malformed and may use the
+blind tier.
+
+For Tier B or C, the transaction digest should be shown in full using the
+existing exact-byte pager. The digest is an exact commitment, not a semantic
+summary.
+
+## Proposed v2 protocol
+
+Exact names and field numbers require a device-protocol review. The logical flow
+is:
+
+```text
+CosmosSignDirectInit
+  -> CosmosSignDirectRequest(offset, max_chunk)
+  -> CosmosSignDirectChunk(offset, bytes)
+  -> ... repeat ...
+  -> device review
+  -> CosmosSignedDirect(public_key, signature, sign_doc_hash)
+```
+
+`CosmosSignDirectInit` should bind at least:
+
+- derivation path;
+- expected serialized `SignDoc` length;
+- expected SHA-256 digest, used only as a transport cross-check;
+- requested signing mode and key algorithm;
+- optional registry identity and descriptor version;
+- host-declared review expectation, which the device may only downgrade.
+
+The device owns the running offset, remaining length, parser state, and hash.
+Chunks must be contiguous and accepted exactly once. Any unexpected message,
+offset, length, initialization attempt, cancellation, USB reset, or parser error
+aborts and wipes the session.
+
+The response returns the compressed public key, compact 64-byte signature, and
+the device-computed `SignDoc` digest so the host can cross-check the exact
+preimage.
+
+The implementation should not accept a host-computed digest as the only thing
+to sign. A future prehashed expert primitive, if ever required by a distinct
+application, must be a separately named domain, use a stronger warning, and
+display the complete digest.
+
+## Direct-mode parser
+
+The parser operates incrementally with bounded memory. It recognizes:
+
+- `TxBody.messages` as repeated `Any { type_url, value }`;
+- memo and timeout height;
+- extension and non-critical extension options;
+- `AuthInfo.signer_infos`, public keys, `ModeInfo`, and sequence;
+- `Fee.amount`, gas limit, payer, and granter;
+- tip fields where the target SDK supports them.
+
+Initial scope should require one signer and `SIGN_MODE_DIRECT`. The firmware
+derives the public key, verifies that the signer info and account address belong
+to that key where those values are available, and rejects a mode substitution.
+Multisig and multi-signer transactions should remain unsupported until the
+review flow and signature assembly contract are specified.
+
+Message adapters consume the exact `Any.value` bytes. They may promote a message
+to clear signing only after:
+
+- the `type_url` is an exact supported value;
+- required fields and canonical encodings validate;
+- signer/owner/sender fields bind to the derived key where applicable;
+- all security-relevant fields fit and are reviewable;
+- unknown critical fields cannot change the reviewed meaning.
+
+An adapter failure caused by unknown semantics downgrades to blind review. A
+failure caused by malformed or contradictory encoding rejects the transaction.
+
+## Chain descriptors and addresses
+
+A v2 chain descriptor separates values that the legacy protocol conflates:
+
+- immutable registry ID and descriptor version;
+- network chain ID;
+- display name;
+- account, validator, and consensus Bech32 HRPs;
+- derivation path policy and SLIP-0044 coin type;
+- public-key/signature algorithm;
+- allowed sign modes;
+- trusted native asset metadata, if any.
+
+The transaction-bound chain ID is always displayed. A friendly chain name cannot
+replace it.
+
+Descriptors may be firmware-curated or supplied by a host registry with an
+authenticated provenance model. Until that trust model is implemented,
+host-supplied metadata is untrusted: display raw chain ID, HRP, path, exact denom,
+and atomic amount. An unknown descriptor may still use blind signing when its
+algorithm and address construction are supported.
+
+Address requests must use the explicit account HRP, not a coin lookup name.
+Non-standard paths require the existing path warning policy. The displayed
+address and the signing key must be derived from the same descriptor and path.
+
+The first algorithm target is Cosmos-style secp256k1. Ethermint
+`ethsecp256k1`, ed25519, and other application key types require explicit
+derivation, address, signature, and test-vector support; they must not be
+silently treated as standard Cosmos secp256k1.
+
+## Coins, amounts, and fees
+
+The v2 schema should model Cosmos `Coin` directly:
+
+```text
+Coin {
+  string denom
+  string amount
+}
+```
+
+- `amount` is a canonical unsigned base-10 integer string: digits only, no sign,
+  whitespace, decimal point, exponent, or leading zeroes except `"0"`.
+- Firmware defines and tests an explicit maximum digit count. A 256-bit ceiling
+  is a reasonable initial engineering target, subject to SDK compatibility and
+  OLED/resource tests.
+- `denom` has a documented byte maximum large enough for IBC and factory denoms
+  and validates the relevant Cosmos SDK grammar.
+- Every message owns its own coin list; fee coins are independent and repeated.
+- Unknown metadata displays atomic amount plus exact denom. Trusted metadata may
+  add a decimal rendering but cannot hide the atomic pair.
+
+## IBC support
+
+The first clear-sign IBC adapter should support the protobuf
+`ibc.applications.transfer.v1.MsgTransfer` forms used by target SDK versions.
+Review must bind and show:
+
+- source port and channel;
+- token amount and exact denom;
+- sender and receiver;
+- timeout height revision number and revision height;
+- timeout timestamp;
+- memo, including packet-forwarding JSON as exact text unless a separately
+  validated adapter interprets it.
+
+This works for native denoms, `ibc/<hash>` voucher denoms, factory denoms, and
+other valid source-chain denominations. The firmware does not need a compiled
+pairwise matrix of every source and destination chain.
+
+"IBC between all supported chains" means the host may construct any valid
+source-chain ICS-20 route and the device can sign it. It does not mean the device
+asserts that a channel reaches the host-claimed destination. Without trusted,
+fresh channel proofs, the device should display the exact port/channel and
+receiver rather than invent a destination-chain guarantee.
+
+IBC messages from unknown modules remain viable through the blind tier.
+
+## Legacy Amino
+
+Legacy Amino remains available for older chains but should also receive a v2
+transport rather than extending the current fixed-width schema.
+
+Two safe approaches are possible:
+
+1. stream the exact canonical Amino JSON sign bytes and blind-sign them; or
+2. stream typed fields while the firmware constructs one canonical JSON
+   preimage and clear-signs supported message adapters.
+
+The first approach provides broad compatibility sooner. The second provides
+stronger semantic review. They can coexist, with exact-byte blind support first
+and structured adapters added incrementally.
+
+The v2 Amino model must separate message and fee denoms, use string amounts,
+support long denoms and multiple coins, and bind all configuration to one
+session. The old protocol continues unchanged for compatibility.
+
+## Non-Cosmos CometBFT applications
+
+The generalized core should expose an internal adapter contract:
+
+```text
+domain identifier
+preimage framing rules
+hash function
+key/signature algorithm
+optional bounded parser
+review classification
+```
+
+A new application can begin at Tier C by defining and testing its exact signing
+preimage. Later parser adapters can promote its operations to Tier B or A. This
+is the path to genuinely broad Tendermint/CometBFT support without pretending
+all applications share Cosmos protobuf transaction semantics.
+
+Every external protocol gets a distinct domain identifier. Cross-domain ACKs,
+chunks, finalization calls, and session reuse are rejected.
+
+## Rollout
+
+### Phase 0: specification and vectors
+
+- Freeze v2 threat model, wire flow, limits, canonical protobuf policy, and abort
+  behavior.
+- Collect `SIGN_MODE_DIRECT` golden vectors from Cosmos SDK and at least one
+  independent host implementation.
+- Choose an initial descriptor trust model and supported key algorithms.
+
+### Phase 1: universal Cosmos direct blind signing
+
+- Stream and hash exact `SignDoc` bytes on device.
+- Validate the envelope enough to establish domain, chain ID, signer mode,
+  signer key, and resource safety.
+- Permit unknown `Any` messages through Tier B/C in Advanced Mode.
+- Show the blind warning, path/address, byte count, and full digest.
+- Return signature, public key, and device-computed digest.
+
+This phase deliberately provides useful new-chain support before every module
+has a clear-signing adapter.
+
+### Phase 2: envelope clear signing
+
+- Clear-sign chain ID, account number, sequence, memo, timeout, fee coins, gas,
+  payer, and granter when parsed unambiguously.
+- Add trusted/untrusted chain descriptor UX.
+- Downgrade extension options that are valid but not understood.
+
+### Phase 3: common message clear signing
+
+- Bank send and multi-send.
+- Staking delegate, undelegate, redelegate, and cancel-unbonding.
+- Distribution rewards and validator commission.
+- Governance vote, deposit, and proposal variants.
+- ICS-20 transfer.
+
+### Phase 4: application adapters
+
+- CosmWasm execute/instantiate/migrate, with contract payload remaining blind
+  until schema-aware review exists.
+- Authz and feegrant, including nested-message downgrade rules.
+- Chain-specific modules chosen by use and risk.
+- Additional CometBFT signing domains and key algorithms.
+
+### Phase 5: default clear signing
+
+- Promote well-tested chains and message families to Tier A by default.
+- Keep Advanced Mode fallback for valid unknown additions so protocol upgrades
+  do not make the chain unusable.
+
+## Workstreams
+
+| Repository/layer | Work |
+| --- | --- |
+| device-protocol | Add v2 init/chunk/request/response messages, limits, generated bindings, and message IDs |
+| firmware transport | Session isolation, ordered streaming, abort/wipe behavior, and response framing |
+| firmware crypto | Exact-byte hashing, secp256k1 signing, key/signer binding, and domain separation |
+| firmware parser | Bounded `SignDoc`, `TxBody`, `AuthInfo`, `Any`, `Coin`, and message adapters |
+| firmware UX | Tier labels, blind warning, digest/byte count, exact-value paging, and cancellation |
+| hdwallet | Generic address and sign APIs, chunk driver, registry plumbing, and signature cross-checks |
+| Vault | Generic address/sign endpoints, policy errors, transport recovery, and no metadata substitution |
+| chain registry | Versioned descriptors, HRPs, paths, algorithms, assets, and provenance |
+| host integrations | Transaction building, IBC route discovery, broadcast, and chain test vectors |
+| QA/release | Unit, emulator, hardware OLED, fuzzing, interoperability, and downgrade tests |
+
+## Test and release gates
+
+### Cryptographic and interoperability
+
+- Device signatures match Cosmos SDK and independent host vectors.
+- The returned digest equals SHA-256 of the exact serialized `SignDoc`.
+- Signatures verify and broadcast on representative SDK versions and chains.
+- Legacy Amino behavior remains byte-for-byte compatible.
+
+### Parser and transport adversarial tests
+
+- truncated fields and submessages;
+- oversized lengths, integer overflow, and resource-limit boundaries;
+- non-minimal/overlong varints and duplicate singular fields;
+- unknown fields, unknown `Any` values, and extension options;
+- chunk replay, gaps, overlap, reordering, early finalization, and excess bytes;
+- session replacement, cross-domain ACKs, stale chunks, and USB interruption;
+- signer-mode, public-key, path, chain-ID, fee, and sequence substitution;
+- cancellation from every screen, proving that no signature is returned.
+
+### Review classification
+
+- fully known transactions are Tier A;
+- any opaque nested or top-level action forces Tier B/C;
+- unknown semantics can blind-sign in Advanced Mode;
+- malformed transactions never downgrade to blind signing;
+- no host-only label is presented as signed data;
+- blind review always shows warning, byte count, and full digest;
+- disabling Advanced Mode blocks every blind path.
+
+### Asset and IBC matrix
+
+- native, IBC voucher, factory, slash-containing, and maximum-length denoms;
+- maximum amount values and multiple message/fee coins;
+- native and non-native fee denoms;
+- IBC timeout height, timeout timestamp, memo, and no-timeout edge cases;
+- receivers with different valid HRPs and maximum supported length;
+- packet-forwarding memos and unknown IBC module messages;
+- representative Cosmos Hub, Osmosis, THORChain/MAYAChain-style legacy, and
+  additional SDK chains.
+
+### Device evidence
+
+- full firmware and constrained configurations fit ROM/SRAM budgets;
+- parser stack frames retain the required reserve;
+- fuzz targets and sanitizer builds pass on the host;
+- emulator and physical OLED captures prove every maximum-length field can be
+  reviewed;
+- cancellation and blind-sign policy behavior pass on physical hardware.
+
+## Open decisions
+
+- Stream a complete serialized `SignDoc`, or stream its exact field framing?
+  Complete exact bytes are preferred if the incremental parser can meet memory
+  limits.
+- Require canonical protobuf for all tiers, or only for clear signing? The
+  safest initial policy is canonical envelope encoding for every tier.
+- Use only global Advanced Mode, or add a per-session blind-sign capability?
+  Initial recommendation: Advanced Mode plus confirmation on every transaction.
+- What descriptor provenance is trusted enough for symbols and decimals?
+- What exact maxima apply to transaction bytes, nesting, messages, denoms,
+  amounts, HRPs, and type URLs?
+- Which Ethermint key/address variants are in the first supported algorithm set?
+- How should multisig, multiple signer infos, tips, fee payers, authz nesting,
+  and fee grants be reviewed?
+- When should `SIGN_MODE_DIRECT_AUX` and `SIGN_MODE_TEXTUAL` be added?
+- Which legacy Amino chains require exact JSON streaming before direct-mode
+  support?
+
+## Definition of done
+
+The generalized Cosmos milestone is complete when:
+
+- any structurally valid, resource-bounded Cosmos SDK `SIGN_MODE_DIRECT`
+  transaction using a supported key algorithm can be signed through an explicit
+  Advanced Mode blind path, even when its messages are unknown;
+- known message adapters clear-sign only values parsed from the exact signed
+  bytes;
+- arbitrary valid coin denoms and integer amounts work within documented limits;
+- any valid host-constructed ICS-20 source-chain transfer can be signed, without
+  a compiled pairwise chain matrix;
+- the address, signer key, signing mode, chain ID, and signed preimage are bound
+  to one isolated session;
+- malformed data, ambiguous clear-sign encodings, and unsupported algorithms
+  fail closed;
+- cancellation never produces a signature;
+- protocol, firmware, hdwallet, Vault, registry, and hardware QA are delivered
+  together.
+
+The broader CometBFT-family milestone is complete only when each additional
+application has an explicit, tested signing-domain adapter. Its initial adapter
+may be blind-only; semantic clear signing can follow.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,4 @@
 * [Supported Coins](Coins.md)
 * [Host Communications](Host.md)
 * [Release Process](Release.md)
+* [Generalized Cosmos and Tendermint Signing](Generalized-Tendermint-Signing.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,4 +5,5 @@
 * [Supported Coins](Coins.md)
 * [Host Communications](Host.md)
 * [Release Process](Release.md)
+* [7.15.0 RC18 Release Shape](security/7.15.0-rc18-release-shape.md)
 * [Generalized Cosmos and Tendermint Signing](Generalized-Tendermint-Signing.md)

--- a/docs/security/7.15.0-rc17-hardening.md
+++ b/docs/security/7.15.0-rc17-hardening.md
@@ -16,6 +16,11 @@ physical-device checklist below are both green. Automated evidence in this
 document qualifies the remediated head for hardware QA; it does not authorize
 merge, tagging, or release.
 
+Qualified candidate head: `f746c52b2c0e5584fde9df04471eeb36ebbbf03b`.
+Its pull-request CI matrix completed successfully in GitHub Actions run
+`29980175333` on 2026-07-23. The physical-device checklist remains the release
+gate.
+
 ## Follow-up audit block
 
 The original candidate head
@@ -69,7 +74,7 @@ display/signature hardening defect.
 
 | Finding | Severity | Remediation |
 | --- | --- | --- |
-| Osmosis `MsgSend` displayed a host denomination but always signed `uosmo` | P1 | Require an explicit `uosmo` denomination in the wire handler and independently enforce the same invariant in the serializer |
+| Osmosis `MsgSend` displayed a host denomination but always signed `uosmo` | P1 | Validate and review the supplied canonical denomination, then serialize that exact denomination; native and non-native fixtures must produce different signatures |
 | Maximum Send/Swap fields wrapped below the three-row OLED body | P1 | Review each signed amount, denomination, destination, and minimum independently with renderer-measured exact-length pages; hard-wrap overlong identifiers that the legacy renderer would horizontally clip |
 | `base_to_precision()` wrote one byte out of bounds and omitted the final LP digit | P1 | Compute the exact destination length, copy every digit without `strlcpy()`, terminate inside the caller's buffer, and fail closed when the output does not fit |
 | Noncanonical or overflowing decimal strings displayed a different value than the signed string | P2 | Accept only the canonical unsigned-decimal spelling, enforce protobuf bounds, and reject native `uosmo` values above `UINT64_MAX` before confirmation or hashing |
@@ -166,10 +171,11 @@ display/signature hardening defect.
 
 ### Osmosis signer invariants
 
-- Fence legacy Amino `MsgSend` to `uosmo` in firmware, including direct
-  `OsmosisMsgAck` traffic that bypasses the Python client's early check. Pass
-  the denomination into the serializer and revalidate it at the hashing
-  boundary.
+- Bind legacy Amino `MsgSend` denominations end-to-end, including direct
+  `OsmosisMsgAck` traffic that bypasses high-level clients. Validate and review
+  the supplied denomination, pass it into the serializer, and revalidate it at
+  the hashing boundary so a non-native denomination cannot be displayed while
+  a hardcoded `uosmo` value is signed.
 - Validate every displayed amount as a canonical, schema-bounded unsigned
   decimal. Preserve unknown asset amounts exactly, and require native `uosmo`
   amounts to fit the supported 64-bit range.
@@ -206,8 +212,9 @@ Additional gates:
 - Four new firmware regressions cover canonical and overflow amount rejection,
   exact maximum LP formatting with a stack canary, truncation rejection, and
   maximum Swap renderer boundaries. Three Python regressions exercise raw-wire
-  non-`uosmo` rejection, raw-wire noncanonical/overflow rejection, and the full
-  maximum-length Swap review/signing sequence.
+  native/non-native denomination signature separation, raw-wire
+  noncanonical/overflow rejection, and the full maximum-length Swap
+  review/signing sequence.
 - The full Python emulator suite passes 574 tests with 16 expected skips. Its
   settled OLED capture shows both 32-digit Swap values and both complete
   68-character IBC denominations before signing.
@@ -216,6 +223,36 @@ Additional gates:
 - `git diff --check` passes.
 - Every variant exceeds the 16,384-byte SRAM reserve floor and 4,096-byte
   reserve-after-largest-frame margin.
+
+## Physical-device evidence — 2026-07-23
+
+The following checks were repeated against a connected physical KeepKey running
+the exact candidate revision
+`f746c52b2c0e5584fde9df04471eeb36ebbbf03b`. The device reported firmware
+`7.15.0`, variant `KeepKey`, and the repository's public disposable QA address
+`osmo1rs7fckgznkaxs4sq02pexwjgar43p5wnkx9s92`. Requests were signed locally
+through Vault and were not broadcast.
+
+- Otherwise-identical `MsgSend` transactions using `uosmo` and `uatom` both
+  returned 64-byte signatures, and the signatures differed. This proves the
+  supplied denomination reaches the signed digest instead of a hardcoded
+  `uosmo` value.
+- Amount strings `01`, `-1`, ` 1`, and `18446744073709551616` each failed with
+  `Invalid Osmosis amount or denomination` and returned no signature.
+- A maximum Swap with two 32-digit amounts and two 68-character IBC
+  denominations completed and returned a signature.
+- Maximum 32-digit LP-add and LP-remove share amounts completed and returned
+  signatures. The device remained connected, initialized, and on the same
+  candidate revision after the runs; no reset or memory fault was observed.
+
+The transport results above do not, by themselves, prove the final OLED
+character was visually inspected. Record explicit operator confirmation for
+the two maximum Swap disclosures and the LP share disclosure before closing
+items 14–15. LP-remove cancellation also remains open: the attempted manual
+runs were approved and returned signatures, while the production-style image's
+enumerated debug interface did not answer `DebugLinkGetState`; no negative
+decision was injected and no conclusion about the cancellation path should be
+drawn from those attempts.
 
 ## Final hardware QA checklist
 
@@ -262,9 +299,12 @@ Use a disposable test seed and verify on a physical KeepKey:
     a reset or signature.
 12. Run upgrade, reboot, PIN/passphrase, transaction-signing, and recovery smoke
     tests for full, Bitcoin-only, and Zcash-privacy firmware artifacts.
-13. Send a raw Osmosis `MsgSend` ACK with a non-`uosmo` denomination and confirm
-    rejection occurs before any signature. Repeat with leading zero, sign,
-    whitespace, and greater-than-`UINT64_MAX` amount strings.
+13. Send otherwise-identical raw Osmosis `MsgSend` ACKs using `uosmo` and a
+    canonical non-native denomination such as `uatom`. Confirm the exact
+    denomination is reviewable, both transactions sign, and their signatures
+    differ. Repeat with leading-zero, signed, whitespace-prefixed, and
+    greater-than-`UINT64_MAX` amount strings and confirm each fails before a
+    signature.
 14. Review maximum-length accepted Osmosis Send and Swap fixtures. Confirm the
     Send amount and destination and both Swap assets are on distinct screens,
     every 68-character Swap denomination is visible through its final

--- a/docs/security/7.15.0-rc17-hardening.md
+++ b/docs/security/7.15.0-rc17-hardening.md
@@ -7,9 +7,9 @@ test-client submodule updates)
 
 This candidate applies focused hardening passes to security-sensitive parsing,
 confirmation, clear-signing, and signing-policy paths. It includes remediation
-for two follow-up reviews, including a full-tree static reachability pass. The
-`rc17` suffix is a release-candidate branch/tag; the firmware protocol version
-remains `7.15.0`.
+for three follow-up reviews, including two full-tree static reachability
+passes. The `rc17` suffix is a release-candidate branch/tag; the firmware
+protocol version remains `7.15.0`.
 
 The release decision remains **NO-GO** until the pull-request CI matrix and the
 physical-device checklist below are both green. Automated evidence in this
@@ -58,6 +58,21 @@ display/signature binding, and blind-signing policy enforcement.
 | Cosmos IBC receiver omitted from review | P1 | Require and page the exact receiver and sender, require the signed `uatom` denomination, and retain channel/port/timeout review |
 | Tendermint ACK could substitute asset/protocol fields | P1 | Bind every ACK to the initialized protocol, chain name, denomination, and message-type prefix and review the exact signed configuration |
 | Binance/Tendermint/Cosmos/Osmosis memo suffixes hidden | P1 | Route all four through one renderer-measured exact-length pager |
+
+## Third full-surface re-audit block
+
+The second-pass remediated head
+`a8ec50a72e12741f0a1b9878b863959385fe02a3` is also release-blocked. A
+full-surface re-audit confirmed that the prior 20 exploit paths were closed,
+then found three additional P1 blockers in the Osmosis signer plus one related
+display/signature hardening defect.
+
+| Finding | Severity | Remediation |
+| --- | --- | --- |
+| Osmosis `MsgSend` displayed a host denomination but always signed `uosmo` | P1 | Require an explicit `uosmo` denomination in the wire handler and independently enforce the same invariant in the serializer |
+| Maximum Send/Swap fields wrapped below the three-row OLED body | P1 | Review each signed amount, denomination, destination, and minimum independently with renderer-measured exact-length pages; hard-wrap overlong identifiers that the legacy renderer would horizontally clip |
+| `base_to_precision()` wrote one byte out of bounds and omitted the final LP digit | P1 | Compute the exact destination length, copy every digit without `strlcpy()`, terminate inside the caller's buffer, and fail closed when the output does not fit |
+| Noncanonical or overflowing decimal strings displayed a different value than the signed string | P2 | Accept only the canonical unsigned-decimal spelling, enforce protobuf bounds, and reject native `uosmo` values above `UINT64_MAX` before confirmation or hashing |
 
 ## Remediated findings
 
@@ -149,15 +164,37 @@ display/signature binding, and blind-signing policy enforcement.
 - Review the initialized chain ID, chain name, denomination, and message-type
   prefix before final signature approval.
 
+### Osmosis signer invariants
+
+- Fence legacy Amino `MsgSend` to `uosmo` in firmware, including direct
+  `OsmosisMsgAck` traffic that bypasses the Python client's early check. Pass
+  the denomination into the serializer and revalidate it at the hashing
+  boundary.
+- Validate every displayed amount as a canonical, schema-bounded unsigned
+  decimal. Preserve unknown asset amounts exactly, and require native `uosmo`
+  amounts to fit the supported 64-bit range.
+- Validate denomination length and identifier grammar before using it in a
+  display string or Amino JSON.
+- Put Send amount/destination and Swap input/minimum output on independent
+  renderer-measured confirmations. Force pixel-width hard breaks for long IBC
+  identifiers so the display behavior matches the pager's three-row model.
+- Repair LP share conversion so a maximum 32-digit input retains its final
+  digit, fits a 34-byte destination, and cannot write beyond the stack buffer.
+  Make LP maximum/minimum assets and share amounts separately reviewable.
+- Apply the same fail-closed amount review to delegate, undelegate,
+  redelegate, liquidity, Swap, and IBC paths. Require the receiver and amount
+  fields for Osmosis IBC and fence redelegation to its serialized `uosmo`
+  denomination.
+
 ## Automated evidence
 
 All builds used the pinned `kktech/firmware:v15` toolchain image.
 
 | Configuration | Firmware tests | ARM build | SRAM reserve | Largest frame | Reserve after frame |
 | --- | ---: | --- | ---: | ---: | ---: |
-| Full, shipped (`KK_ZCASH_PRIVACY=OFF`) | 299/299 | Pass | 23,364 B | 7,664 B | 15,700 B |
+| Full, shipped (`KK_ZCASH_PRIVACY=OFF`) | 303/303 | Pass | 23,364 B | 7,664 B | 15,700 B |
 | Bitcoin-only | 28/28 | Pass | 32,908 B | 7,664 B | 25,244 B |
-| Zcash privacy | 358/358 | Pass | 19,064 B | 7,664 B | 11,400 B |
+| Zcash privacy | 362/362 | Pass | 19,064 B | 7,664 B | 11,400 B |
 
 Additional gates:
 
@@ -166,6 +203,14 @@ Additional gates:
 - 19 new or updated regressions directly exercise the second-pass Binance,
   exact-byte pager, EIP-712, EOS, Tendermint, and policy remediations. A broader
   34-test security filter covering the affected suites also passes.
+- Four new firmware regressions cover canonical and overflow amount rejection,
+  exact maximum LP formatting with a stack canary, truncation rejection, and
+  maximum Swap renderer boundaries. Three Python regressions exercise raw-wire
+  non-`uosmo` rejection, raw-wire noncanonical/overflow rejection, and the full
+  maximum-length Swap review/signing sequence.
+- The full Python emulator suite passes 574 tests with 16 expected skips. Its
+  settled OLED capture shows both 32-digit Swap values and both complete
+  68-character IBC denominations before signing.
 - Cppcheck completes with zero findings.
 - Changed production files pass the pinned Clang Format 20 gate.
 - `git diff --check` passes.
@@ -217,6 +262,16 @@ Use a disposable test seed and verify on a physical KeepKey:
     a reset or signature.
 12. Run upgrade, reboot, PIN/passphrase, transaction-signing, and recovery smoke
     tests for full, Bitcoin-only, and Zcash-privacy firmware artifacts.
+13. Send a raw Osmosis `MsgSend` ACK with a non-`uosmo` denomination and confirm
+    rejection occurs before any signature. Repeat with leading zero, sign,
+    whitespace, and greater-than-`UINT64_MAX` amount strings.
+14. Review maximum-length accepted Osmosis Send and Swap fixtures. Confirm the
+    Send amount and destination and both Swap assets are on distinct screens,
+    every 68-character Swap denomination is visible through its final
+    character, and the signed minimum output is never below the OLED boundary.
+15. Exercise maximum 32-digit Osmosis LP add/remove share amounts. Confirm the
+    final decimal digit is present, cancellation returns no signature, and the
+    device neither resets nor reports a memory fault.
 
 RC17 should be promoted only after the pull request CI matrix and this physical
 device checklist are both green.

--- a/docs/security/7.15.0-rc17-hardening.md
+++ b/docs/security/7.15.0-rc17-hardening.md
@@ -244,15 +244,15 @@ through Vault and were not broadcast.
 - Maximum 32-digit LP-add and LP-remove share amounts completed and returned
   signatures. The device remained connected, initialized, and on the same
   candidate revision after the runs; no reset or memory fault was observed.
+- With exclusive WebUSB access, a direct LP-remove run approved Minimum Output
+  A, Minimum Output B, and Pool ID, then sent protocol `Cancel` on button
+  request four (`LP Shares to Redeem`). Firmware returned cancellation with no
+  signature, remained initialized, and reported the same candidate revision.
 
 The transport results above do not, by themselves, prove the final OLED
 character was visually inspected. Record explicit operator confirmation for
 the two maximum Swap disclosures and the LP share disclosure before closing
-items 14–15. LP-remove cancellation also remains open: the attempted manual
-runs were approved and returned signatures, while the production-style image's
-enumerated debug interface did not answer `DebugLinkGetState`; no negative
-decision was injected and no conclusion about the cancellation path should be
-drawn from those attempts.
+items 14–15.
 
 ## Final hardware QA checklist
 

--- a/docs/security/7.15.0-rc17-hardening.md
+++ b/docs/security/7.15.0-rc17-hardening.md
@@ -249,10 +249,10 @@ through Vault and were not broadcast.
   request four (`LP Shares to Redeem`). Firmware returned cancellation with no
   signature, remained initialized, and reported the same candidate revision.
 
-The transport results above do not, by themselves, prove the final OLED
-character was visually inspected. Record explicit operator confirmation for
-the two maximum Swap disclosures and the LP share disclosure before closing
-items 14–15.
+The operator explicitly confirmed after the run that both maximum Swap
+disclosures showed their complete 68-character denominations through the final
+`A`, and that the LP share disclosure showed the complete converted value
+through its final `...789012`. No OLED truncation or hidden suffix was observed.
 
 ## Final hardware QA checklist
 

--- a/docs/security/7.15.0-rc17-hardening.md
+++ b/docs/security/7.15.0-rc17-hardening.md
@@ -10,6 +10,28 @@ parsing, confirmation, and clear-signing paths. It does not claim to be a new
 whole-firmware audit. The `rc17` suffix is a release-candidate branch/tag;
 the firmware protocol version remains `7.15.0`.
 
+## Follow-up audit block
+
+The original candidate head
+`f7eacc3862fd391bd9e9421474efeaba464d1334` is release-blocked. A follow-up
+review found five P1 release blockers, four P2 defects, and one P3 cleanup
+defect. It must not be merged, promoted, tagged, or installed for final QA.
+Only a later head containing the remediations below may be reconsidered after
+its complete CI matrix and physical-device checks pass.
+
+| Finding | Severity | Remediation |
+| --- | --- | --- |
+| Hive `custom_json` could wrap below the visible body | P1 | Select every page boundary with the renderer's actual font, width, word-wrap, and three-row limit |
+| Uniswap deadline displayed only the low 64 bits | P1 | Reject a deadline with any nonzero upper 192 bits before clear-signing |
+| Arbitrary contracts could masquerade as LP approvals | P1 | Require the transaction target to equal a mainnet factory-derived WETH pair for a known token |
+| Liquidity recognition was not chain-bound | P1 | Require an explicit Ethereum mainnet chain ID for liquidity and LP approval recognition |
+| `removeLiquidityETH` mislabeled LP liquidity as the underlying token | P1 | Parse add/remove independently and format remove word 1 as an 18-decimal LP amount |
+| `bn_format()` overflow produced a blank amount | P2 | Use 96-byte amount buffers, check every formatter return, and require the result to fit three rendered rows |
+| ABI address words accepted nonzero upper bytes | P2 | Require canonical zero-padded token, recipient, and spender address words |
+| Duplicate authenticator identities survived deletion | P2 | Reject new duplicates and remove every legacy matching slot in one confirmed mutation |
+| Brute-forceable short TOTP secrets were accepted | P2 | Require at least 16 decoded secret bytes |
+| Partial TOTP decode output survived a decode error | P3 | Route every post-decode exit through one `memzero()` cleanup path |
+
 ## Remediated findings
 
 ### Hive raw-operation review
@@ -21,8 +43,9 @@ the firmware protocol version remains `7.15.0`.
 - Bound `custom_json` authorization sets to four accounts, require canonical
   ordering and uniqueness, retain every account in the parsed operation, and
   confirm each account individually.
-- Page the complete custom JSON ID and JSON payload instead of showing only a
-  truncated authorization summary.
+- Page the complete custom JSON ID and JSON payload using measured rendered
+  lines rather than byte-count chunks. The adversarial 69-byte `%`/space
+  payload from the follow-up audit is covered by a regression test.
 
 ### Authenticator mutations
 
@@ -32,6 +55,9 @@ the firmware protocol version remains `7.15.0`.
   display, or mutation.
 - Put the TOTP secret on its own confirmation screen so it cannot overflow the
   domain/account screen, and wipe the decoded secret from the stack after use.
+- Require at least 128 bits of decoded TOTP secret material, reject duplicate
+  identities, remove all matching legacy duplicates, and wipe partial decoder
+  output on failure.
 
 ### Legacy Ethereum Uniswap V2 clear-signing
 
@@ -42,8 +68,13 @@ the firmware protocol version remains `7.15.0`.
 - Reject unknown token contracts rather than formatting a misleading amount.
 - Require the exact fixed ABI length and declared protobuf field shape before
   any selector or fixed-offset read; trailing calldata is not clear-signed.
-- Display the deadline as an exact Unix integer and wipe the derived HD node
-  after the recipient-address comparison.
+- Require Ethereum mainnet, canonical ABI address padding, a deadline that fits
+  the displayed 64-bit Unix value, and a factory-derived known LP pair for
+  approval clear-signing.
+- Parse add/remove amount semantics separately, display liquidity burned as an
+  18-decimal LP amount, check all amount-formatting returns, and keep every
+  formatted uint256 within the OLED body budget.
+- Wipe the derived HD node after the recipient-address comparison.
 
 ## Automated evidence
 
@@ -51,13 +82,14 @@ All builds used the pinned `kktech/firmware:v15` toolchain image.
 
 | Configuration | Firmware tests | ARM build | SRAM reserve | Largest frame | Reserve after frame |
 | --- | ---: | --- | ---: | ---: | ---: |
-| Full, shipped (`KK_ZCASH_PRIVACY=OFF`) | 277/277 | Pass | 23,372 B | 7,664 B | 15,708 B |
+| Full, shipped (`KK_ZCASH_PRIVACY=OFF`) | 285/285 | Pass | 23,372 B | 7,664 B | 15,708 B |
 | Bitcoin-only | 28/28 | Pass | 32,908 B | 7,664 B | 25,244 B |
-| Zcash privacy | 336/336 | Pass | 19,072 B | 7,664 B | 11,408 B |
+| Zcash privacy | 344/344 | Pass | 19,072 B | 7,664 B | 11,408 B |
 
 Additional gates:
 
-- 35 focused Hive, authenticator, and Ethereum regression tests pass.
+- 43 focused Hive, authenticator, and Ethereum regression tests pass,
+  including 14 directly covering the follow-up remediation cluster.
 - Cppcheck completes with zero findings.
 - Changed production files pass the pinned Clang Format 20 gate.
 - `git diff --check` passes.
@@ -71,13 +103,17 @@ Use a disposable test seed and verify on a physical KeepKey:
 1. Cancel authenticator add, remove, and wipe at every confirmation screen;
    reconnect and confirm that storage did not change.
 2. Add a valid TOTP account, compare generated codes with an independent
-   authenticator, remove it, then wipe the authenticator store.
+   authenticator, verify duplicate and sub-128-bit secrets are rejected, remove
+   it, then wipe the authenticator store.
 3. Sign representative Hive transfer, comment, and multi-authorization
    `custom_json` operations. Confirm every authorization, ID byte, and JSON
-   byte is reviewable; malformed account names and overlong varints must fail.
+   byte is reviewable, including the adversarial `%`/space payload across page
+   boundaries; malformed account names and overlong varints must fail.
 4. Exercise supported Uniswap V2 add/remove liquidity fixtures. Confirm token
-   amount, minimums, native value, recipient, and deadline; cancel each screen
-   in a separate run and confirm that no signature is returned.
+   amount, LP burn amount, minimums, native value, recipient, and deadline.
+   Confirm Polygon/router reuse, dirty ABI address words, high deadline bits,
+   and arbitrary approval targets never receive a Uniswap protocol label.
+   Cancel each screen in a separate run and confirm no signature is returned.
 5. Run upgrade, reboot, PIN/passphrase, transaction-signing, and recovery smoke
    tests for full, Bitcoin-only, and Zcash-privacy firmware artifacts.
 

--- a/docs/security/7.15.0-rc17-hardening.md
+++ b/docs/security/7.15.0-rc17-hardening.md
@@ -1,14 +1,20 @@
 # Firmware 7.15.0 RC17 security hardening
 
-Date: 2026-07-21
+Date: 2026-07-22
 Integration baseline: `develop` at
 `d18571307a2f5bad3ec2949c7b27fd06e6914a8c` (RC16 firmware code plus
 test-client submodule updates)
 
-This candidate applies three focused hardening passes to security-sensitive
-parsing, confirmation, and clear-signing paths. It does not claim to be a new
-whole-firmware audit. The `rc17` suffix is a release-candidate branch/tag;
-the firmware protocol version remains `7.15.0`.
+This candidate applies focused hardening passes to security-sensitive parsing,
+confirmation, clear-signing, and signing-policy paths. It includes remediation
+for two follow-up reviews, including a full-tree static reachability pass. The
+`rc17` suffix is a release-candidate branch/tag; the firmware protocol version
+remains `7.15.0`.
+
+The release decision remains **NO-GO** until the pull-request CI matrix and the
+physical-device checklist below are both green. Automated evidence in this
+document qualifies the remediated head for hardware QA; it does not authorize
+merge, tagging, or release.
 
 ## Follow-up audit block
 
@@ -31,6 +37,27 @@ its complete CI matrix and physical-device checks pass.
 | Duplicate authenticator identities survived deletion | P2 | Reject new duplicates and remove every legacy matching slot in one confirmed mutation |
 | Brute-forceable short TOTP secrets were accepted | P2 | Require at least 16 decoded secret bytes |
 | Partial TOTP decode output survived a decode error | P3 | Route every post-decode exit through one `memzero()` cleanup path |
+
+## Second full-tree re-audit block
+
+The remediated first-pass head
+`9f4920ef144ed3a1e28a04a0621d2f21e48674b3` is also release-blocked. A
+full-tree static reachability review found ten additional P1 release blockers.
+They are separate from the ten findings above and cover signer memory safety,
+display/signature binding, and blind-signing policy enforcement.
+
+| Finding | Severity | Remediation |
+| --- | --- | --- |
+| Binance denomination stack overwrite | P1 | Validate the effective 31-character schema bound and grammar, use a correctly sized destination, check formatting, and fail closed on malformed transfer/session state |
+| Bitcoin-family `SignMessage` NUL/OOB display mismatch | P1 | Review the explicit protobuf byte length; render complete printable payloads and complete hex for binary payloads |
+| Ethereum `SignMessage` hidden suffix | P1 | Remove the 114-character/57-byte preview and page every signed byte |
+| TRON `SignMessage` hidden suffix | P1 | Remove the capped preview and page every signed byte |
+| Ethereum typed-hash AdvancedMode bypass | P1 | Reject precomputed typed-hash signing unless AdvancedMode is enabled |
+| EIP-712 display not bound to canonical values | P1 | Page every field/value and primary type; require canonical address, bytes, integer, boolean, and JSON node shapes before encoding |
+| EOS unknown-action AdvancedMode bypass | P1 | Abort opaque action signing when AdvancedMode is disabled and keep `eosio::newaccount` on its structured path |
+| Cosmos IBC receiver omitted from review | P1 | Require and page the exact receiver and sender, require the signed `uatom` denomination, and retain channel/port/timeout review |
+| Tendermint ACK could substitute asset/protocol fields | P1 | Bind every ACK to the initialized protocol, chain name, denomination, and message-type prefix and review the exact signed configuration |
+| Binance/Tendermint/Cosmos/Osmosis memo suffixes hidden | P1 | Route all four through one renderer-measured exact-length pager |
 
 ## Remediated findings
 
@@ -76,20 +103,69 @@ its complete CI matrix and physical-device checks pass.
   formatted uint256 within the OLED body budget.
 - Wipe the derived HD node after the recipient-address comparison.
 
+### Exact-byte message and memo review
+
+- Add one shared confirmation primitive that accepts an explicit byte length,
+  computes page boundaries with the OLED renderer's font, width, word wrapping,
+  and three-row body limit, and propagates rejection from every page.
+- Render printable ASCII completely as text. If any byte is a control or
+  non-ASCII value, render the complete payload as hexadecimal so embedded NULs
+  and binary suffixes cannot disappear.
+- Use the primitive for Bitcoin-family, Ethereum, and TRON message signing and
+  verification; Binance, Tendermint, Cosmos, and Osmosis memos; and existing
+  THORChain/MAYAChain/Ripple/TRON memo wrappers.
+- Apply the same rule to Solana/TON blind messages, Solana off-chain messages
+  and memos, identity signing challenges, and Bitcoin-family `OP_RETURN`
+  review. These adjacent paths had the same preview or C-string failure mode.
+
+### Signing policies and structured-data parsing
+
+- Require AdvancedMode for Ethereum precomputed typed-hash signing and EOS
+  unknown-action signing. A warning is not treated as policy enforcement.
+- Keep `EOS_NewAccount` in the supported-action allowlist so it cannot be
+  downgraded to an opaque fingerprint flow.
+- Require exact EIP-712 primitive type syntax and JSON node shapes; reject
+  short, overlong, non-hex, odd-nibble, or wrong-sized address/bytes values.
+- Require exact `EIP712Domain` primary-type matching, page the primary type,
+  field names, and every value, and fail closed on missing typed values rather
+  than dereferencing a null JSON node.
+- Bound type-string construction and integer parsing, reject invalid boolean
+  spellings and integer ranges, and remove partially parsed adjacent-memory
+  behavior from address/bytes encoding.
+
+### Binance, Cosmos, and generic Tendermint signing
+
+- Match Binance's effective denomination schema bound, reject unsafe
+  characters and non-positive/mismatched transfer amounts, and make signer
+  initialization/update/finalization state explicit and fail closed.
+- Require Cosmos IBC receiver, sender, amount, denomination, channel, port, and
+  both timeout-height components. Review the exact sender and receiver instead
+  of labeling the sender as the destination.
+- Separate Cosmos and generic Tendermint signing sessions so one protocol's ACK
+  cannot advance the other. Generic ACK metadata must exactly match the
+  initialized chain name, denomination, and message-type prefix.
+- Display generic Tendermint amounts in their exact signed atomic units and
+  denomination; do not relabel or rescale them with unrelated coin metadata.
+- Review the initialized chain ID, chain name, denomination, and message-type
+  prefix before final signature approval.
+
 ## Automated evidence
 
 All builds used the pinned `kktech/firmware:v15` toolchain image.
 
 | Configuration | Firmware tests | ARM build | SRAM reserve | Largest frame | Reserve after frame |
 | --- | ---: | --- | ---: | ---: | ---: |
-| Full, shipped (`KK_ZCASH_PRIVACY=OFF`) | 285/285 | Pass | 23,372 B | 7,664 B | 15,708 B |
+| Full, shipped (`KK_ZCASH_PRIVACY=OFF`) | 299/299 | Pass | 23,364 B | 7,664 B | 15,700 B |
 | Bitcoin-only | 28/28 | Pass | 32,908 B | 7,664 B | 25,244 B |
-| Zcash privacy | 344/344 | Pass | 19,072 B | 7,664 B | 11,408 B |
+| Zcash privacy | 358/358 | Pass | 19,064 B | 7,664 B | 11,400 B |
 
 Additional gates:
 
 - 43 focused Hive, authenticator, and Ethereum regression tests pass,
   including 14 directly covering the follow-up remediation cluster.
+- 19 new or updated regressions directly exercise the second-pass Binance,
+  exact-byte pager, EIP-712, EOS, Tendermint, and policy remediations. A broader
+  34-test security filter covering the affected suites also passes.
 - Cppcheck completes with zero findings.
 - Changed production files pass the pinned Clang Format 20 gate.
 - `git diff --check` passes.
@@ -114,8 +190,33 @@ Use a disposable test seed and verify on a physical KeepKey:
    Confirm Polygon/router reuse, dirty ABI address words, high deadline bits,
    and arbitrary approval targets never receive a Uniswap protocol label.
    Cancel each screen in a separate run and confirm no signature is returned.
-5. Run upgrade, reboot, PIN/passphrase, transaction-signing, and recovery smoke
-   tests for full, Bitcoin-only, and Zcash-privacy firmware artifacts.
+5. Sign Bitcoin-family, Ethereum, and TRON messages at the schema maximum. Test
+   embedded NUL, binary, and the exact 69-byte `%`/space word-wrap payload;
+   every byte or hex octet must be reviewable and cancellation on every page
+   must return no signature.
+6. Repeat exact-byte review checks for Binance, Tendermint, Cosmos, and Osmosis
+   256-byte memos. Smoke-test THORChain/MAYAChain/Ripple/TRON/Solana memo paths,
+   Solana/TON blind messages, identity challenges, and binary `OP_RETURN`.
+7. With AdvancedMode disabled, verify Ethereum typed-hash and EOS unknown-action
+   signing terminate with no signature. With it enabled, verify the expected
+   opaque flow remains available. Confirm `eosio::newaccount` always uses its
+   structured handler.
+8. Exercise EIP-712 long dynamic values, exact 20-byte addresses, dynamic and
+   fixed bytes, integer boundaries, booleans, missing fields, malformed JSON
+   node shapes, and primary-type prefixes such as `EIP`. Malformed values must
+   fail before a signature and every accepted value must be fully reviewable.
+9. Sign Cosmos IBC transfers with distinct sender and receiver values. Confirm
+   both exact addresses, amount, channel, port, and timeout; missing receiver or
+   a denomination other than `uatom` must fail.
+10. Attempt generic Tendermint ACKs with a changed chain name, denomination,
+    message-type prefix, and a Cosmos/Tendermint cross-protocol ACK. Each must
+    abort the session. Confirm accepted amounts and fees use the exact signed
+    atomic denomination.
+11. Exercise Binance denominations at 31 characters and reject 32-character,
+    lowercase, control-character, mismatched, zero, and negative cases without
+    a reset or signature.
+12. Run upgrade, reboot, PIN/passphrase, transaction-signing, and recovery smoke
+    tests for full, Bitcoin-only, and Zcash-privacy firmware artifacts.
 
 RC17 should be promoted only after the pull request CI matrix and this physical
 device checklist are both green.

--- a/docs/security/7.15.0-rc17-hardening.md
+++ b/docs/security/7.15.0-rc17-hardening.md
@@ -11,15 +11,15 @@ for three follow-up reviews, including two full-tree static reachability
 passes. The `rc17` suffix is a release-candidate branch/tag; the firmware
 protocol version remains `7.15.0`.
 
-The release decision remains **NO-GO** until the pull-request CI matrix and the
-physical-device checklist below are both green. Automated evidence in this
-document qualifies the remediated head for hardware QA; it does not authorize
-merge, tagging, or release.
+The release decision remains **NO-GO** until the pull-request CI matrix is green
+and an explicit release decision is made. The physical-device smoke gate below
+is complete. Automated evidence, including the generated Python report, is the
+authoritative exhaustive screen and boundary review; physical QA is intentionally
+limited to major device smoke tests.
 
 Qualified candidate head: `f746c52b2c0e5584fde9df04471eeb36ebbbf03b`.
 Its pull-request CI matrix completed successfully in GitHub Actions run
-`29980175333` on 2026-07-23. The physical-device checklist remains the release
-gate.
+`29980175333` on 2026-07-23.
 
 ## Follow-up audit block
 
@@ -218,6 +218,9 @@ Additional gates:
 - The full Python emulator suite passes 574 tests with 16 expected skips. Its
   settled OLED capture shows both 32-digit Swap values and both complete
   68-character IBC denominations before signing.
+- The generated Python report contains 303 scenarios: 297 passed, 6 intentionally
+  skipped, and 0 failed. It is the release evidence for exhaustive confirmation
+  screens, maximum-length paging, rejection paths, and signing-flow coverage.
 - Cppcheck completes with zero findings.
 - Changed production files pass the pinned Clang Format 20 gate.
 - `git diff --check` passes.
@@ -254,64 +257,38 @@ disclosures showed their complete 68-character denominations through the final
 `A`, and that the LP share disclosure showed the complete converted value
 through its final `...789012`. No OLED truncation or hidden suffix was observed.
 
-## Final hardware QA checklist
+## Physical release smoke gate
 
-Use a disposable test seed and verify on a physical KeepKey:
+The physical gate verifies that the automated result survives real hardware and
+real transport. It does not repeat the Python report screen by screen. The
+screen matrix, maximum boundaries, malformed inputs, policy combinations, and
+per-page cancellation cases belong in automated tests and the generated report.
 
-1. Cancel authenticator add, remove, and wipe at every confirmation screen;
-   reconnect and confirm that storage did not change.
-2. Add a valid TOTP account, compare generated codes with an independent
-   authenticator, verify duplicate and sub-128-bit secrets are rejected, remove
-   it, then wipe the authenticator store.
-3. Sign representative Hive transfer, comment, and multi-authorization
-   `custom_json` operations. Confirm every authorization, ID byte, and JSON
-   byte is reviewable, including the adversarial `%`/space payload across page
-   boundaries; malformed account names and overlong varints must fail.
-4. Exercise supported Uniswap V2 add/remove liquidity fixtures. Confirm token
-   amount, LP burn amount, minimums, native value, recipient, and deadline.
-   Confirm Polygon/router reuse, dirty ABI address words, high deadline bits,
-   and arbitrary approval targets never receive a Uniswap protocol label.
-   Cancel each screen in a separate run and confirm no signature is returned.
-5. Sign Bitcoin-family, Ethereum, and TRON messages at the schema maximum. Test
-   embedded NUL, binary, and the exact 69-byte `%`/space word-wrap payload;
-   every byte or hex octet must be reviewable and cancellation on every page
-   must return no signature.
-6. Repeat exact-byte review checks for Binance, Tendermint, Cosmos, and Osmosis
-   256-byte memos. Smoke-test THORChain/MAYAChain/Ripple/TRON/Solana memo paths,
-   Solana/TON blind messages, identity challenges, and binary `OP_RETURN`.
-7. With AdvancedMode disabled, verify Ethereum typed-hash and EOS unknown-action
-   signing terminate with no signature. With it enabled, verify the expected
-   opaque flow remains available. Confirm `eosio::newaccount` always uses its
-   structured handler.
-8. Exercise EIP-712 long dynamic values, exact 20-byte addresses, dynamic and
-   fixed bytes, integer boundaries, booleans, missing fields, malformed JSON
-   node shapes, and primary-type prefixes such as `EIP`. Malformed values must
-   fail before a signature and every accepted value must be fully reviewable.
-9. Sign Cosmos IBC transfers with distinct sender and receiver values. Confirm
-   both exact addresses, amount, channel, port, and timeout; missing receiver or
-   a denomination other than `uatom` must fail.
-10. Attempt generic Tendermint ACKs with a changed chain name, denomination,
-    message-type prefix, and a Cosmos/Tendermint cross-protocol ACK. Each must
-    abort the session. Confirm accepted amounts and fees use the exact signed
-    atomic denomination.
-11. Exercise Binance denominations at 31 characters and reject 32-character,
-    lowercase, control-character, mismatched, zero, and negative cases without
-    a reset or signature.
-12. Run upgrade, reboot, PIN/passphrase, transaction-signing, and recovery smoke
-    tests for full, Bitcoin-only, and Zcash-privacy firmware artifacts.
-13. Send otherwise-identical raw Osmosis `MsgSend` ACKs using `uosmo` and a
-    canonical non-native denomination such as `uatom`. Confirm the exact
-    denomination is reviewable, both transactions sign, and their signatures
-    differ. Repeat with leading-zero, signed, whitespace-prefixed, and
-    greater-than-`UINT64_MAX` amount strings and confirm each fails before a
-    signature.
-14. Review maximum-length accepted Osmosis Send and Swap fixtures. Confirm the
-    Send amount and destination and both Swap assets are on distinct screens,
-    every 68-character Swap denomination is visible through its final
-    character, and the signed minimum output is never below the OLED boundary.
-15. Exercise maximum 32-digit Osmosis LP add/remove share amounts. Confirm the
-    final decimal digit is present, cancellation returns no signature, and the
-    device neither resets nor reports a memory fault.
+The RC17 physical smoke gate is:
 
-RC17 should be promoted only after the pull request CI matrix and this physical
-device checklist are both green.
+1. Boot and reconnect the shipped full-firmware candidate; confirm the device
+   reports firmware `7.15.0`, variant `KeepKey`, and the expected candidate
+   revision.
+2. Complete a representative address and transaction-signing flow through
+   Vault and receive a valid 64-byte signature.
+3. Cancel a representative in-progress signing flow; confirm that no signature
+   is returned and the device remains initialized and connected.
+4. Run the highest-risk changed renderer/memory flow at its accepted maximum;
+   confirm the final values are visible and the device neither resets nor
+   reports a memory fault.
+5. Perform an operator visual sanity check that the physical screens match the
+   settled Python/emulator report.
+
+The evidence recorded above satisfies all five items: the exact candidate
+booted and reconnected through Vault; multiple Osmosis transactions signed; the
+LP cancellation returned no signature and preserved the session; maximum Swap
+and LP values completed without a reset or memory fault; and the operator
+confirmed the complete maximum-length disclosures.
+
+The former exhaustive 15-step physical checklist is retired as a release gate.
+Its screen-level and adversarial cases are covered by the automated suite and
+Python report. Any uncovered case should be added as a regression test rather
+than expanded into recurring manual release ceremony.
+
+RC17 may be considered for promotion after the current pull-request CI matrix
+is green and the release owner makes an explicit GO decision.

--- a/docs/security/7.15.0-rc17-hardening.md
+++ b/docs/security/7.15.0-rc17-hardening.md
@@ -1,0 +1,85 @@
+# Firmware 7.15.0 RC17 security hardening
+
+Date: 2026-07-21
+Integration baseline: `develop` at
+`d18571307a2f5bad3ec2949c7b27fd06e6914a8c` (RC16 firmware code plus
+test-client submodule updates)
+
+This candidate applies three focused hardening passes to security-sensitive
+parsing, confirmation, and clear-signing paths. It does not claim to be a new
+whole-firmware audit. The `rc17` suffix is a release-candidate branch/tag;
+the firmware protocol version remains `7.15.0`.
+
+## Remediated findings
+
+### Hive raw-operation review
+
+- Reject non-canonical LEB128 varints so the reviewed bytes cannot differ from
+  the chain's canonical reserialization.
+- Validate every account field as a Hive account name before rendering it,
+  rejecting embedded NULs, newlines, controls, and malformed names.
+- Bound `custom_json` authorization sets to four accounts, require canonical
+  ordering and uniqueness, retain every account in the parsed operation, and
+  confirm each account individually.
+- Page the complete custom JSON ID and JSON payload instead of showing only a
+  truncated authorization summary.
+
+### Authenticator mutations
+
+- Make add, remove, and wipe operations fail closed when the user cancels.
+- Stop authenticator processing when passphrase acquisition fails.
+- Reject overlong or control-character domain/account fields before lookup,
+  display, or mutation.
+- Put the TOTP secret on its own confirmation screen so it cannot overflow the
+  domain/account screen, and wipe the decoded secret from the stack after use.
+
+### Legacy Ethereum Uniswap V2 clear-signing
+
+- Propagate every confirmation result so cancellation cannot continue to a
+  signature.
+- Display the native-asset value for `addLiquidityETH` and reject a nonzero
+  native value for `removeLiquidityETH`.
+- Reject unknown token contracts rather than formatting a misleading amount.
+- Require the exact fixed ABI length and declared protobuf field shape before
+  any selector or fixed-offset read; trailing calldata is not clear-signed.
+- Display the deadline as an exact Unix integer and wipe the derived HD node
+  after the recipient-address comparison.
+
+## Automated evidence
+
+All builds used the pinned `kktech/firmware:v15` toolchain image.
+
+| Configuration | Firmware tests | ARM build | SRAM reserve | Largest frame | Reserve after frame |
+| --- | ---: | --- | ---: | ---: | ---: |
+| Full, shipped (`KK_ZCASH_PRIVACY=OFF`) | 277/277 | Pass | 23,372 B | 7,664 B | 15,708 B |
+| Bitcoin-only | 28/28 | Pass | 32,908 B | 7,664 B | 25,244 B |
+| Zcash privacy | 336/336 | Pass | 19,072 B | 7,664 B | 11,408 B |
+
+Additional gates:
+
+- 35 focused Hive, authenticator, and Ethereum regression tests pass.
+- Cppcheck completes with zero findings.
+- Changed production files pass the pinned Clang Format 20 gate.
+- `git diff --check` passes.
+- Every variant exceeds the 16,384-byte SRAM reserve floor and 4,096-byte
+  reserve-after-largest-frame margin.
+
+## Final hardware QA checklist
+
+Use a disposable test seed and verify on a physical KeepKey:
+
+1. Cancel authenticator add, remove, and wipe at every confirmation screen;
+   reconnect and confirm that storage did not change.
+2. Add a valid TOTP account, compare generated codes with an independent
+   authenticator, remove it, then wipe the authenticator store.
+3. Sign representative Hive transfer, comment, and multi-authorization
+   `custom_json` operations. Confirm every authorization, ID byte, and JSON
+   byte is reviewable; malformed account names and overlong varints must fail.
+4. Exercise supported Uniswap V2 add/remove liquidity fixtures. Confirm token
+   amount, minimums, native value, recipient, and deadline; cancel each screen
+   in a separate run and confirm that no signature is returned.
+5. Run upgrade, reboot, PIN/passphrase, transaction-signing, and recovery smoke
+   tests for full, Bitcoin-only, and Zcash-privacy firmware artifacts.
+
+RC17 should be promoted only after the pull request CI matrix and this physical
+device checklist are both green.

--- a/docs/security/7.15.0-rc18-release-shape.md
+++ b/docs/security/7.15.0-rc18-release-shape.md
@@ -1,0 +1,43 @@
+# Firmware 7.15.0 RC18 Release Shape
+
+Date: 2026-07-24
+
+RC18 collapses the former three-product build into two release products:
+
+| Product | Contents |
+| --- | --- |
+| Regular (`full`) | Every supported chain, including Zcash shielded/Orchard |
+| Bitcoin-only | Bitcoin only; all non-Bitcoin coins and Zcash privacy code removed |
+
+There is no separate `zcash-privacy` artifact. Zcash privacy is part of the
+regular firmware and cannot be disabled as a release choice. The internal
+`ZCASH_PRIVACY` compile value remains only so bitcoin-only can compile the
+privacy sources out.
+
+## Release and CI invariants
+
+- Device, emulator, unit-test, SRAM, and tagged-release matrices contain only
+  `full` and `bitcoin-only`.
+- An unflagged CMake build is the regular product and sets
+  `BITCOIN_ONLY=0`, `ZCASH_PRIVACY=1`, and `AES_SMALL_TABLES`.
+- `-DKK_BITCOIN_ONLY=ON` sets `BITCOIN_ONLY=1` and `ZCASH_PRIVACY=0`.
+- The published emulator is the regular/full image.
+- Release notes and reproducible-build instructions name only the regular and
+  bitcoin-only artifacts.
+
+## Automated evidence
+
+Both ARM builds used the pinned `kktech/firmware:v15` toolchain image.
+
+| Product | ARM build | Firmware tests | Board tests | Crypto tests | SRAM reserve | Largest frame | Reserve after frame |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Regular (`full`) | Pass | 363/363 | 2/2 | 4/4 | 19,064 B | 7,664 B | 11,400 B |
+| Bitcoin-only | Pass | 28/28 | 2/2 | 4/4 | 32,908 B | 7,664 B | 25,244 B |
+
+The regular ARM build produced `zcash.c.obj`; the bitcoin-only build did not.
+Both products pass the 16,384-byte minimum SRAM reserve and 4,096-byte
+reserve-after-largest-frame gates.
+
+Workflow YAML parsing, SRAM-budget JSON parsing, Python syntax compilation,
+`git diff --check`, and the release-shape search for stale `zcash-privacy`
+matrix entries also pass.

--- a/include/keepkey/board/font.h
+++ b/include/keepkey/board/font.h
@@ -20,6 +20,7 @@
 #ifndef FONT_H
 #define FONT_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 /* Data pertaining to the image of a character */
@@ -53,5 +54,9 @@ uint32_t font_width(const Font* font);
 
 uint32_t calc_str_width(const Font* font, const char* str);
 uint32_t calc_str_line(const Font* font, const char* str, uint16_t line_width);
+uint32_t calc_str_line_n(const Font* font, const char* str, size_t str_len,
+                         uint16_t line_width);
+size_t calc_str_page(const Font* font, const char* str, size_t str_len,
+                     uint16_t line_width, uint32_t max_lines);
 
 #endif

--- a/include/keepkey/board/util.h
+++ b/include/keepkey/board/util.h
@@ -54,8 +54,7 @@ void dec64_to_str(uint64_t dec64_val, char* str);
 
 bool is_valid_ascii(const uint8_t* data, uint32_t size);
 
-int base_to_precision(uint8_t* dest, const uint8_t* value,
-                      const uint8_t dest_len, const uint8_t value_len,
-                      const uint8_t precision);
+int base_to_precision(uint8_t* dest, const uint8_t* value, size_t dest_len,
+                      size_t value_len, uint8_t precision);
 
 #endif

--- a/include/keepkey/firmware/app_confirm.h
+++ b/include/keepkey/firmware/app_confirm.h
@@ -24,6 +24,7 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 #define CONFIRM_SIGN_IDENTITY_TITLE 32
 #define CONFIRM_SIGN_IDENTITY_BODY 416
@@ -46,6 +47,14 @@ bool confirm_load_device(bool is_node);
 bool confirm_address(const char* desc, const char* address);
 bool confirm_xpub(const char* node_str, const char* xpub);
 bool confirm_sign_identity(const IdentityType* identity, const char* challenge);
+/**
+ * Review every byte of a length-delimited payload. Printable ASCII is paged as
+ * text; any payload containing a control/non-ASCII byte is paged as complete
+ * hexadecimal. Page boundaries use the OLED renderer's actual font and
+ * word-wrap budget, so no accepted byte can be clipped below the third row.
+ */
+bool confirm_bytes(ButtonRequestType button_request, const char* title,
+                   const uint8_t* data, size_t size);
 bool confirm_cosmos_address(const char* desc, const char* address);
 bool confirm_osmosis_address(const char* desc, const char* address);
 bool confirm_ethereum_address(const char* desc, const char* address);

--- a/include/keepkey/firmware/authenticator.h
+++ b/include/keepkey/firmware/authenticator.h
@@ -26,6 +26,7 @@
 #define ACCOUNT_SIZE 12  // allow 11 chars for account string
 #define AUTHSECRET_SIZE_MAX \
   20  // 128-bit key len is the recommended minimum, this is room for 160-bit
+#define AUTHSECRET_SIZE_MIN 16  // reject brute-forceable TOTP secrets
 #define AUTHDATA_SIZE \
   10  // WARNING: This value must be coordinated with the size of uint8_t
       // encrypted_sec[] in in lib/firmware/storage.h and the storage version
@@ -41,6 +42,7 @@ enum AUTH_ERR_TYPE {
   LARGESEED,
   BADPASS,
   UNKERR,
+  DUPLICATE,
   AUTH_CANCELLED,
   NUM_AUTHERRS
 };

--- a/include/keepkey/firmware/authenticator.h
+++ b/include/keepkey/firmware/authenticator.h
@@ -41,6 +41,7 @@ enum AUTH_ERR_TYPE {
   LARGESEED,
   BADPASS,
   UNKERR,
+  AUTH_CANCELLED,
   NUM_AUTHERRS
 };
 
@@ -68,7 +69,7 @@ unsigned generateOTP(char* accountWithMsg, char otpStr[]);
 unsigned addAuthAccount(char* accountWithSeed);
 unsigned getAuthAccount(const char* slotStr, char acc[]);
 unsigned removeAuthAccount(char* domAcc);
-void wipeAuthData(void);
+unsigned wipeAuthData(void);
 #if DEBUG_LINK
 void getAuthSlot(char* authSlotData);
 #endif

--- a/include/keepkey/firmware/binance.h
+++ b/include/keepkey/firmware/binance.h
@@ -12,6 +12,10 @@ typedef struct _BinanceTransferMsg BinanceTransferMsg;
 typedef struct _BinanceTransferMsg_BinanceInputOutput BinanceInputOutput;
 typedef struct _BinanceTransferMsg_BinanceCoin BinanceCoin;
 
+#define BINANCE_MAX_DENOM_LEN 31
+
+bool binance_isValidDenom(const char* denom);
+bool binance_validateTransfer(const BinanceTransferMsg* transfer);
 bool binance_signTxInit(const HDNode* _node, const BinanceSignTx* _msg);
 bool binance_serializeCoin(const BinanceCoin* coin);
 bool binance_serializeInputOutput(const BinanceInputOutput* io);

--- a/include/keepkey/firmware/eip712.h
+++ b/include/keepkey/firmware/eip712.h
@@ -25,9 +25,9 @@
     Parser wants to see C strings, not javascript strings:
         requires all complete json message strings to be enclosed by braces,
    i.e., { ... } Cannot have entire json string quoted, i.e., "{ ... }" will not
-   work. Remove all quote escape chars, e.g., {"types":  not  {\"types\": int
-   values must be hex. Negative sign indicates negative value, e.g., -5, -8a67
-        Note: Do not prefix ints or uints with 0x
+   work. Remove all quote escape chars, e.g., {"types":  not  {\"types\":
+    Integer values must use canonical base-10 digits. Negative values use a
+   leading minus sign. Do not prefix ints or uints with 0x.
     All hex and byte strings must be big-endian
     Byte strings and address should be prefixed by 0x
 */
@@ -101,5 +101,10 @@ typedef enum { DOMAIN = 1, MESSAGE } dm;
 
 int encode(const json_t* jsonTypes, const json_t* jsonVals, const char* typeS,
            uint8_t* hashRet);
+
+/* Exposed for strict-value regression tests. */
+int encAddress(const char* string, uint8_t* encoded);
+int encodeBytes(const char* string, uint8_t* encoded);
+int encodeBytesN(const char* typeT, const char* string, uint8_t* encoded);
 
 #endif

--- a/include/keepkey/firmware/eos.h
+++ b/include/keepkey/firmware/eos.h
@@ -86,6 +86,9 @@ uint32_t eos_actionsRemaining(void);
 
 bool eos_hasActionUnknownDataRemaining(void);
 
+bool eos_isSupportedAction(const EosActionCommon* common);
+bool eos_unknownActionPolicyAllows(bool advanced_mode);
+
 /// \returns true iff successful.
 bool eos_compileActionUnknown(const EosActionCommon* common,
                               const EosActionUnknown* action);

--- a/include/keepkey/firmware/ethereum.h
+++ b/include/keepkey/firmware/ethereum.h
@@ -71,6 +71,8 @@ void bn_from_bytes(const uint8_t* value, size_t value_len, bignum256* val);
 void ethereum_typed_hash_sign(const EthereumSignTypedHash* msg,
                               const HDNode* node,
                               EthereumTypedDataSignature* resp);
+bool ethereum_typed_hash_policy_allows(bool advanced_mode);
+bool ethereum_eip712_is_domain_primary_type(const char* primary_type);
 bool ethereum_path_check(uint32_t address_n_count, const uint32_t* address_n,
                          bool pubkey_export, uint64_t chain);
 void e712_types_values(Ethereum712TypesValues* msg,

--- a/include/keepkey/firmware/ethereum_contracts/zxliquidtx.h
+++ b/include/keepkey/firmware/ethereum_contracts/zxliquidtx.h
@@ -22,6 +22,7 @@
 
 #include <inttypes.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 #define UNISWAP_ROUTER_ADDRESS                                               \
   "\x7a\x25\x0d\x56\x30\xB4\xcF\x53\x97\x39\xdF\x2C\x5d\xAc\xb4\xc6\x59\xF2" \
@@ -31,5 +32,7 @@ typedef struct _EthereumSignTx EthereumSignTx;
 
 bool zx_isZxLiquidTx(const EthereumSignTx* msg);
 bool zx_confirmZxLiquidTx(uint32_t data_total, const EthereumSignTx* msg);
+bool zx_formatZxLiquidityPrimaryAmount(const EthereumSignTx* msg, char* out,
+                                       size_t out_len);
 
 #endif

--- a/include/keepkey/firmware/hive.h
+++ b/include/keepkey/firmware/hive.h
@@ -83,6 +83,10 @@ bool hive_slip48_path_valid_for_role(const uint32_t* address_n, size_t count,
 // Matches the host serializer's cap; hived itself allows more, but eight is
 // all that can be reviewed on the OLED before approval fatigue sets in.
 #define HIVE_MAX_BENEFICIARIES 8
+// Maximum custom_json authorization accounts accepted per operation. Every
+// account is confirmed individually; bounding the set prevents an unreviewable
+// approval loop and keeps the parsed transaction's static RAM use predictable.
+#define HIVE_MAX_CUSTOM_JSON_AUTHS 4
 
 // Symbol whitelist bits for the asset parser. Every asset field in the op
 // table pins an explicit set — an op that accepts HIVE must never silently
@@ -149,6 +153,8 @@ typedef struct {
                       // set_withdraw_vesting_route percent)
   bool is_top_level;  // comment only: parent_author empty
   uint8_t n_auths;    // custom_json only: total auth account names
+  const uint8_t* auth_acct[HIVE_MAX_CUSTOM_JSON_AUTHS];
+  uint16_t auth_acct_len[HIVE_MAX_CUSTOM_JSON_AUTHS];
 
   // ── Phase-3 op fields ───────────────────────────────────────────────────
   // Borrowed HIVE_ASSET_LEN-byte asset slices in the op's own field order:

--- a/include/keepkey/firmware/hive.h
+++ b/include/keepkey/firmware/hive.h
@@ -44,9 +44,20 @@ bool hive_slip48_path_valid_for_role(const uint32_t* address_n, size_t count,
 #define HIVE_OP_VOTE 0
 #define HIVE_OP_COMMENT 1
 #define HIVE_OP_TRANSFER 2
+#define HIVE_OP_TRANSFER_TO_VESTING 3
+#define HIVE_OP_WITHDRAW_VESTING 4
+#define HIVE_OP_LIMIT_ORDER_CREATE 5
+#define HIVE_OP_LIMIT_ORDER_CANCEL 6
+#define HIVE_OP_CONVERT 8
 #define HIVE_OP_ACCOUNT_CREATE 9
 #define HIVE_OP_ACCOUNT_UPDATE 10
 #define HIVE_OP_CUSTOM_JSON 18
+#define HIVE_OP_COMMENT_OPTIONS 19
+#define HIVE_OP_TRANSFER_TO_SAVINGS 32
+#define HIVE_OP_TRANSFER_FROM_SAVINGS 33
+#define HIVE_OP_CLAIM_REWARD_BALANCE 39
+#define HIVE_OP_DELEGATE_VESTING_SHARES 40
+#define HIVE_OP_ACCOUNT_UPDATE2 43
 
 // ── Protocol limits ───────────────────────────────────────────────────────
 #define HIVE_DECIMALS 3  // HIVE and HBD both use 3 decimal places
@@ -62,6 +73,23 @@ bool hive_slip48_path_valid_for_role(const uint32_t* address_n, size_t count,
 #define HIVE_MAX_OPS_TX_LEN 2048
 // Maximum operations per HiveSignOperations transaction.
 #define HIVE_MAX_TX_OPS 4
+// Graphene asset: int64 LE amount + uint8 precision + 7-byte NUL-padded
+// symbol (append_asset layout).
+#define HIVE_ASSET_LEN 16
+// Most assets carried by a single op in the table (claim_reward_balance
+// carries three: HIVE, HBD, VESTS).
+#define HIVE_MAX_OP_ASSETS 3
+// Most comment_payout_beneficiaries entries accepted on a comment_options op.
+// Matches the host serializer's cap; hived itself allows more, but eight is
+// all that can be reviewed on the OLED before approval fatigue sets in.
+#define HIVE_MAX_BENEFICIARIES 8
+
+// Symbol whitelist bits for the asset parser. Every asset field in the op
+// table pins an explicit set — an op that accepts HIVE must never silently
+// accept VESTS, since the two differ by 1000x in displayed magnitude.
+#define HIVE_SYM_HIVE (1u << 0)
+#define HIVE_SYM_HBD (1u << 1)
+#define HIVE_SYM_VESTS (1u << 2)
 
 // ── Public API ────────────────────────────────────────────────────────────
 /**
@@ -116,9 +144,29 @@ typedef struct {
   uint16_t permlink_len;
   const uint8_t* json_metadata;  // comment only
   uint16_t json_metadata_len;
-  int16_t weight;     // vote only (-10000..10000)
+  int16_t weight;     // vote (-10000..10000), or a 0..10000 basis-point
+                      // percent (comment_options percent_hbd,
+                      // set_withdraw_vesting_route percent)
   bool is_top_level;  // comment only: parent_author empty
   uint8_t n_auths;    // custom_json only: total auth account names
+
+  // ── Phase-3 op fields ───────────────────────────────────────────────────
+  // Borrowed HIVE_ASSET_LEN-byte asset slices in the op's own field order:
+  //   transfer_to_vesting/convert/claim_account/savings: [0] = amount
+  //   withdraw_vesting/delegate_vesting_shares:          [0] = vesting_shares
+  //   limit_order_create:      [0] = amount_to_sell, [1] = min_to_receive
+  //   claim_reward_balance:    [0] = HIVE, [1] = HBD, [2] = VESTS
+  //   comment_options:         [0] = max_accepted_payout
+  const uint8_t* assets[HIVE_MAX_OP_ASSETS];
+  uint8_t n_assets;
+  uint32_t req_id;      // convert requestid / savings request_id / order id
+  uint32_t expiration;  // limit_order_create only
+  bool flag;            // fill_or_kill / approve / auto_vest / allow_votes
+  bool flag2;           // comment_options: allow_curation_rewards
+  uint8_t n_benef;      // comment_options: beneficiary count (0 = none)
+  const uint8_t* benef_acct[HIVE_MAX_BENEFICIARIES];
+  uint16_t benef_acct_len[HIVE_MAX_BENEFICIARIES];
+  uint16_t benef_weight[HIVE_MAX_BENEFICIARIES];  // basis points
 } HiveTxOp;
 
 typedef struct {
@@ -129,11 +177,25 @@ typedef struct {
 
 /**
  * Parse and validate a host-serialized Graphene transaction against the
- * phase-1 op table (vote, comment, custom_json). Returns NULL on success or
- * a static error message. Slices in `out` borrow from `tx` — keep it alive.
+ * device clear-sign op table. Returns NULL on success or a static error
+ * message. Slices in `out` borrow from `tx` — keep it alive.
+ *
+ * Ops 2 (transfer), 9 (account_create) and 10 (account_update) are
+ * permanently excluded; everything not in the table is refused outright —
+ * there is no blind-sign fallback.
  */
 const char* hive_parseOperations(const uint8_t* tx, size_t len,
                                  HiveParsedTx* out);
+
+/**
+ * Accessors for a HIVE_ASSET_LEN-byte asset slice stored in HiveTxOp.assets.
+ * The parser has already validated the symbol/precision pair, so the symbol
+ * is always a NUL-terminated "HIVE" / "HBD" / "VESTS" and the amount is
+ * non-negative.
+ */
+uint64_t hive_assetAmount(const uint8_t* asset);
+uint8_t hive_assetPrecision(const uint8_t* asset);
+const char* hive_assetSymbol(const uint8_t* asset);
 
 /**
  * Sign a parsed HiveSignOperations transaction: digest is

--- a/include/keepkey/firmware/osmosis.h
+++ b/include/keepkey/firmware/osmosis.h
@@ -5,6 +5,7 @@
 #include "trezor/crypto/bip32.h"
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 typedef struct _OsmosisSignTx OsmosisSignTx;
@@ -16,7 +17,8 @@ void debug_intermediate_hash(void);
 
 bool osmosis_signTxInit(const HDNode* _node, const OsmosisSignTx* _msg);
 
-bool osmosis_signTxUpdateMsgSend(const char* amount, const char* to_address);
+bool osmosis_signTxUpdateMsgSend(const char* amount, const char* to_address,
+                                 const char* denom);
 
 bool osmosis_signTxUpdateMsgDelegate(const char* amount,
                                      const char* delegator_address,
@@ -67,6 +69,8 @@ bool osmosis_signTxUpdateMsgSwap(const uint64_t pool_id,
                                  const char* token_out_min_amount);
 
 #define OSMOSIS_PRECISION 6
+#define OSMOSIS_MAX_AMOUNT_DIGITS 32
+#define OSMOSIS_MAX_DENOM_LEN 68
 
 // Longest amount a confirm screen renders: the digits, a point, a space and
 // the longest denom a message can carry.
@@ -77,9 +81,12 @@ bool osmosis_signTxUpdateMsgSwap(const uint64_t pool_id,
  * ("1500000", "uosmo") -> "1.500000 OSMO".
  *
  * Only uosmo is scaled — any other denom is shown exactly as the chain states
- * it, because the device does not know its precision.
+ * it, because the device does not know its precision. Returns false unless the
+ * amount is a canonical, schema-bounded unsigned decimal and the denomination
+ * is a schema-bounded Cosmos asset identifier. Native uosmo additionally must
+ * fit uint64, which is the range accepted by the native-asset display policy.
  */
-void osmosis_formatAmount(char* out, size_t out_len, const char* value,
+bool osmosis_formatAmount(char* out, size_t out_len, const char* value,
                           const char* denom);
 
 bool osmosis_signTxFinalize(uint8_t* public_key, uint8_t* signature);

--- a/include/keepkey/firmware/osmosis.h
+++ b/include/keepkey/firmware/osmosis.h
@@ -66,6 +66,22 @@ bool osmosis_signTxUpdateMsgSwap(const uint64_t pool_id,
                                  const char* token_in_denom,
                                  const char* token_out_min_amount);
 
+#define OSMOSIS_PRECISION 6
+
+// Longest amount a confirm screen renders: the digits, a point, a space and
+// the longest denom a message can carry.
+#define OSMOSIS_AMOUNT_STR_LEN 103
+
+/**
+ * Render an integer base-unit amount for a confirm screen:
+ * ("1500000", "uosmo") -> "1.500000 OSMO".
+ *
+ * Only uosmo is scaled — any other denom is shown exactly as the chain states
+ * it, because the device does not know its precision.
+ */
+void osmosis_formatAmount(char* out, size_t out_len, const char* value,
+                          const char* denom);
+
 bool osmosis_signTxFinalize(uint8_t* public_key, uint8_t* signature);
 bool osmosis_signingIsInited(void);
 bool osmosis_signingIsFinished(void);

--- a/include/keepkey/firmware/signtx_tendermint.h
+++ b/include/keepkey/firmware/signtx_tendermint.h
@@ -9,8 +9,15 @@
 
 typedef struct _TendermintSignTx TendermintSignTx;
 
+typedef enum {
+  TENDERMINT_SIGNING_NONE = 0,
+  TENDERMINT_SIGNING_COSMOS,
+  TENDERMINT_SIGNING_GENERIC,
+} TendermintSigningType;
+
 bool tendermint_signTxInit(const HDNode* _node, const void* _msg,
-                           const size_t msgsize, const char* denom);
+                           const size_t msgsize, const char* denom,
+                           TendermintSigningType type);
 bool tendermint_signTxUpdateMsgSend(const uint64_t amount,
                                     const char* to_address,
                                     const char* chainstr, const char* denom,
@@ -41,7 +48,9 @@ bool tendermint_signTxUpdateMsgIBCTransfer(
     const char* revision_number, const char* revision_height,
     const char* chainstr, const char* denom, const char* msgTypePrefix);
 bool tendermint_signTxFinalize(uint8_t* public_key, uint8_t* signature);
-bool tendermint_signingIsInited(void);
+bool tendermint_signingIsInited(TendermintSigningType type);
+bool tendermint_signingConfigMatches(const char* chain_name, const char* denom,
+                                     const char* message_type_prefix);
 bool tendermint_signingIsFinished(void);
 void tendermint_signAbort(void);
 const void* tendermint_getSignTx(void);

--- a/include/keepkey/firmware/tiny-json.h
+++ b/include/keepkey/firmware/tiny-json.h
@@ -35,6 +35,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define json_containerOf(ptr, type, member) \
   ((type*)((char*)ptr - offsetof(type, member)))
 
@@ -66,7 +70,6 @@ typedef struct json_s {
   jsonType_t type;
 } json_t;
 
-extern int errno;
 /** Parse a string to get a json.
  * @param str String pointer with a JSON object. It will be modified.
  * @param mem Array of json properties to allocate.

--- a/lib/board/font.c
+++ b/lib/board/font.c
@@ -21,6 +21,7 @@
 #include "keepkey/board/font.h"
 
 #include <stddef.h>
+#include <string.h>
 
 /* --- Image Font ------------------------------------------------------------
  */
@@ -2598,29 +2599,31 @@ uint32_t calc_str_width(const Font* font, const char* str) {
  * OUTPUT
  *     line count
  */
-uint32_t calc_str_line(const Font* font, const char* str, uint16_t line_width) {
+uint32_t calc_str_line_n(const Font* font, const char* str, size_t str_len,
+                         uint16_t line_width) {
   uint8_t line_count = 1;
   uint16_t x_offset = 0;
+  size_t offset = 0;
 
-  while (*str) {
-    uint8_t character_width = font_get_char(font, str[0])->width;
+  while (offset < str_len && str[offset]) {
+    uint8_t character_width = font_get_char(font, str[offset])->width;
     uint16_t word_width = character_width;
-    const char* next_character = str + 1;
+    size_t next_offset = offset + 1;
 
     /* Allow line breaks */
-    if (*str == '\n') {
+    if (str[offset] == '\n') {
       line_count++;
       x_offset = 0;
-      str++;
+      offset++;
       continue;
     }
 
     /* Calculate next work width */
-    if (*str == ' ') {
-      while (*next_character && *next_character != ' ' &&
-             *next_character != '\n') {
-        word_width += font_get_char(font, *next_character)->width;
-        next_character++;
+    if (str[offset] == ' ') {
+      while (next_offset < str_len && str[next_offset] &&
+             str[next_offset] != ' ' && str[next_offset] != '\n') {
+        word_width += font_get_char(font, str[next_offset])->width;
+        next_offset++;
       }
     }
 
@@ -2631,14 +2634,27 @@ uint32_t calc_str_line(const Font* font, const char* str, uint16_t line_width) {
     }
 
     /* Remove leading spaces */
-    if (x_offset == 0 && *str == ' ') {
-      str++;
+    if (x_offset == 0 && str[offset] == ' ') {
+      offset++;
       continue;
     }
 
     x_offset += character_width;
-    str++;
+    offset++;
   }
 
   return line_count;
+}
+
+uint32_t calc_str_line(const Font* font, const char* str, uint16_t line_width) {
+  return calc_str_line_n(font, str, strlen(str), line_width);
+}
+
+size_t calc_str_page(const Font* font, const char* str, size_t str_len,
+                     uint16_t line_width, uint32_t max_lines) {
+  size_t best = 0;
+  for (size_t take = 1; take <= str_len; take++) {
+    if (calc_str_line_n(font, str, take, line_width) <= max_lines) best = take;
+  }
+  return best;
 }

--- a/lib/board/util.c
+++ b/lib/board/util.c
@@ -103,33 +103,48 @@ bool is_valid_ascii(const uint8_t* data, uint32_t size) {
 }
 
 /* convert number in base units to specified decimal precision */
-int base_to_precision(uint8_t* dest, const uint8_t* value,
-                      const uint8_t dest_len, const uint8_t value_len,
-                      const uint8_t precision) {
-  if (!(dest && value)) {
-    // invalid pointer
-    return -1;
-  }
-  if (value_len + 1 > dest_len) {
-    // value too large for output buffer
-    return -1;
-  }
-  memset(dest, '0', dest_len);
-  uint8_t leading_digits =
-      ((value_len - precision) > 0) ? (value_len - precision) : 0;
+int base_to_precision(uint8_t* dest, const uint8_t* value, size_t dest_len,
+                      size_t value_len, uint8_t precision) {
+  if (!dest || !value || dest_len == 0 || value_len == 0) return -1;
 
-  if (!leading_digits) {
-    memcpy(dest, "0.", 2);
-    uint8_t offset =
-        2 + (((precision - value_len) > 0) ? (precision - value_len) : 0);
-    strlcpy((char*)&dest[offset], (char*)value, value_len);
-  } else {
-    uint8_t copy_len = MIN((value_len - leading_digits), precision);
-    memcpy(dest, value, leading_digits);
-    dest[leading_digits] = '.';
-    strlcpy((char*)&dest[leading_digits + 1], (char*)&value[leading_digits],
-            copy_len);
+  // Decimal inputs are signed as strings. Accept only their unique canonical
+  // representation so the value shown on the OLED is byte-for-byte bound to
+  // the value placed in the transaction.
+  if ((value_len > 1 && value[0] == '0')) return -1;
+  for (size_t i = 0; i < value_len; i++) {
+    if (value[i] < '0' || value[i] > '9') return -1;
   }
-  dest[dest_len] = '\0';
+
+  size_t rendered_len;
+  if (precision == 0) {
+    rendered_len = value_len;
+  } else if (value_len <= precision) {
+    rendered_len = (size_t)precision + 2;  // "0." + precision digits
+  } else {
+    rendered_len = value_len + 1;  // digits plus decimal point
+  }
+  if (rendered_len + 1 > dest_len) return -1;
+
+  size_t offset = 0;
+  if (precision == 0) {
+    memcpy(dest, value, value_len);
+    offset = value_len;
+  } else if (value_len <= precision) {
+    dest[offset++] = '0';
+    dest[offset++] = '.';
+    const size_t zeroes = (size_t)precision - value_len;
+    memset(dest + offset, '0', zeroes);
+    offset += zeroes;
+    memcpy(dest + offset, value, value_len);
+    offset += value_len;
+  } else {
+    const size_t leading_digits = value_len - precision;
+    memcpy(dest, value, leading_digits);
+    offset = leading_digits;
+    dest[offset++] = '.';
+    memcpy(dest + offset, value + leading_digits, precision);
+    offset += precision;
+  }
+  dest[offset] = '\0';
   return 0;
 }

--- a/lib/firmware/app_confirm.c
+++ b/lib/firmware/app_confirm.c
@@ -30,6 +30,7 @@
 #include "keepkey/board/layout.h"
 #include "keepkey/board/messages.h"
 #include "keepkey/board/confirm_sm.h"
+#include "keepkey/board/font.h"
 #include "keepkey/board/usb.h"
 #include "keepkey/board/util.h"
 
@@ -416,6 +417,81 @@ bool confirm_sign_identity(const IdentityType* identity,
                  body);
 }
 
+static bool confirm_bytes_is_ascii(const uint8_t* data, size_t size) {
+  for (size_t i = 0; i < size; i++) {
+    if (data[i] < 0x20 || data[i] > 0x7e) return false;
+  }
+  return true;
+}
+
+static size_t confirm_bytes_page_len(const uint8_t* data, size_t size,
+                                     bool ascii) {
+  if (size == 0) return 0;
+
+  if (ascii) {
+    size_t candidate = size;
+    if (candidate >= BODY_CHAR_MAX) candidate = BODY_CHAR_MAX - 1;
+    return calc_str_page(get_body_font(), (const char*)data, candidate,
+                         BODY_WIDTH, BODY_ROWS);
+  }
+
+  size_t candidate = size;
+  if (candidate > (BODY_CHAR_MAX - 1) / 2) candidate = (BODY_CHAR_MAX - 1) / 2;
+  char rendered[BODY_CHAR_MAX];
+  for (size_t i = 0; i < candidate; i++) {
+    snprintf(rendered + 2 * i, 3, "%02x", data[i]);
+  }
+  size_t chars = calc_str_page(get_body_font(), rendered, 2 * candidate,
+                               BODY_WIDTH, BODY_ROWS);
+  return (chars & ~(size_t)1) / 2;
+}
+
+bool confirm_bytes(ButtonRequestType button_request, const char* title,
+                   const uint8_t* data, size_t size) {
+  if (!title || (!data && size != 0)) return false;
+  if (size == 0) return confirm(button_request, title, "(empty)");
+
+  const bool ascii = confirm_bytes_is_ascii(data, size);
+  size_t pages = 0;
+  size_t offset = 0;
+  while (offset < size) {
+    const size_t take =
+        confirm_bytes_page_len(data + offset, size - offset, ascii);
+    if (take == 0) return false;
+    offset += take;
+    pages++;
+  }
+
+  offset = 0;
+  for (size_t page = 0; page < pages; page++) {
+    const size_t take =
+        confirm_bytes_page_len(data + offset, size - offset, ascii);
+    if (take == 0) return false;
+
+    char page_title[TITLE_CHAR_MAX];
+    if (pages > 1 || !ascii) {
+      snprintf(page_title, sizeof(page_title),
+               ascii ? "%s %u/%u" : "%s Hex %u/%u", title, (unsigned)(page + 1),
+               (unsigned)pages);
+    } else {
+      strlcpy(page_title, title, sizeof(page_title));
+    }
+
+    char rendered[BODY_CHAR_MAX];
+    if (ascii) {
+      memcpy(rendered, data + offset, take);
+      rendered[take] = '\0';
+    } else {
+      for (size_t i = 0; i < take; i++) {
+        snprintf(rendered + 2 * i, 3, "%02x", data[offset + i]);
+      }
+    }
+    if (!confirm(button_request, page_title, "%s", rendered)) return false;
+    offset += take;
+  }
+  return true;
+}
+
 bool confirm_omni(ButtonRequestType button_request, const char* title,
                   const uint8_t* data, uint32_t size) {
   uint32_t tx_type;
@@ -453,17 +529,5 @@ bool confirm_omni(ButtonRequestType button_request, const char* title,
 
 bool confirm_data(ButtonRequestType button_request, const char* title,
                   const uint8_t* data, uint32_t size) {
-  const char* str = (const char*)data;
-  char hex[50 * 2 + 1];
-  if (!is_valid_ascii(data, size)) {
-    if (size > 50) size = 50;
-    memset(hex, 0, sizeof(hex));
-    data2hex(data, size, hex);
-    if (size > 50) {
-      hex[50 * 2 - 1] = '.';
-      hex[50 * 2 - 2] = '.';
-    }
-    str = hex;
-  }
-  return confirm(button_request, title, "%s", str);
+  return confirm_bytes(button_request, title, data, size);
 }

--- a/lib/firmware/app_confirm.c
+++ b/lib/firmware/app_confirm.c
@@ -424,26 +424,78 @@ static bool confirm_bytes_is_ascii(const uint8_t* data, size_t size) {
   return true;
 }
 
-static size_t confirm_bytes_page_len(const uint8_t* data, size_t size,
-                                     bool ascii) {
+static size_t confirm_bytes_render_page(const uint8_t* data, size_t size,
+                                        bool ascii,
+                                        char rendered[BODY_CHAR_MAX]) {
   if (size == 0) return 0;
 
-  if (ascii) {
-    size_t candidate = size;
-    if (candidate >= BODY_CHAR_MAX) candidate = BODY_CHAR_MAX - 1;
-    return calc_str_page(get_body_font(), (const char*)data, candidate,
-                         BODY_WIDTH, BODY_ROWS);
+  const Font* font = get_body_font();
+  size_t consumed = 0;
+  size_t written = 0;
+  uint32_t row = 1;
+  uint16_t x = 0;
+
+  while (consumed < size) {
+    char chars[2];
+    size_t char_count;
+    if (ascii) {
+      chars[0] = (char)data[consumed];
+      char_count = 1;
+    } else {
+      static const char hex[] = "0123456789abcdef";
+      chars[0] = hex[data[consumed] >> 4];
+      chars[1] = hex[data[consumed] & 0x0f];
+      char_count = 2;
+    }
+
+    uint16_t width = 0;
+    for (size_t i = 0; i < char_count; i++) {
+      width += font_get_char(font, chars[i])->width;
+    }
+
+    // draw_string() wraps only at spaces and otherwise clips overlong words.
+    // Pre-insert hard line breaks so long addresses, hashes and IBC denoms are
+    // actually visible rather than merely counted as one renderer line.
+    if (ascii && chars[0] == ' ') {
+      uint32_t word_width = width;
+      for (size_t i = consumed + 1;
+           i < size && data[i] != ' ' && data[i] != '\n'; i++) {
+        word_width += font_get_char(font, (char)data[i])->width;
+      }
+      if (x == 0) {
+        // The renderer discards a leading separator. Consume it here only
+        // after the preceding word has been disclosed on this or the prior
+        // page; the visual line/page boundary remains the separator.
+        consumed++;
+        continue;
+      }
+      if ((uint32_t)x + word_width > BODY_WIDTH) {
+        if (row == BODY_ROWS) break;
+        if (written + 1 >= BODY_CHAR_MAX) break;
+        rendered[written++] = '\n';
+        row++;
+        x = 0;
+        consumed++;
+        continue;
+      }
+    }
+
+    if ((uint32_t)x + width > BODY_WIDTH) {
+      if (row == BODY_ROWS) break;
+      if (written + 1 >= BODY_CHAR_MAX) break;
+      rendered[written++] = '\n';
+      row++;
+      x = 0;
+    }
+    if (written + char_count >= BODY_CHAR_MAX) break;
+    memcpy(rendered + written, chars, char_count);
+    written += char_count;
+    x += width;
+    consumed++;
   }
 
-  size_t candidate = size;
-  if (candidate > (BODY_CHAR_MAX - 1) / 2) candidate = (BODY_CHAR_MAX - 1) / 2;
-  char rendered[BODY_CHAR_MAX];
-  for (size_t i = 0; i < candidate; i++) {
-    snprintf(rendered + 2 * i, 3, "%02x", data[i]);
-  }
-  size_t chars = calc_str_page(get_body_font(), rendered, 2 * candidate,
-                               BODY_WIDTH, BODY_ROWS);
-  return (chars & ~(size_t)1) / 2;
+  rendered[written] = '\0';
+  return consumed;
 }
 
 bool confirm_bytes(ButtonRequestType button_request, const char* title,
@@ -455,8 +507,9 @@ bool confirm_bytes(ButtonRequestType button_request, const char* title,
   size_t pages = 0;
   size_t offset = 0;
   while (offset < size) {
-    const size_t take =
-        confirm_bytes_page_len(data + offset, size - offset, ascii);
+    char rendered[BODY_CHAR_MAX];
+    const size_t take = confirm_bytes_render_page(data + offset, size - offset,
+                                                  ascii, rendered);
     if (take == 0) return false;
     offset += take;
     pages++;
@@ -464,8 +517,9 @@ bool confirm_bytes(ButtonRequestType button_request, const char* title,
 
   offset = 0;
   for (size_t page = 0; page < pages; page++) {
-    const size_t take =
-        confirm_bytes_page_len(data + offset, size - offset, ascii);
+    char rendered[BODY_CHAR_MAX];
+    const size_t take = confirm_bytes_render_page(data + offset, size - offset,
+                                                  ascii, rendered);
     if (take == 0) return false;
 
     char page_title[TITLE_CHAR_MAX];
@@ -477,15 +531,6 @@ bool confirm_bytes(ButtonRequestType button_request, const char* title,
       strlcpy(page_title, title, sizeof(page_title));
     }
 
-    char rendered[BODY_CHAR_MAX];
-    if (ascii) {
-      memcpy(rendered, data + offset, take);
-      rendered[take] = '\0';
-    } else {
-      for (size_t i = 0; i < take; i++) {
-        snprintf(rendered + 2 * i, 3, "%02x", data[offset + i]);
-      }
-    }
     if (!confirm(button_request, page_title, "%s", rendered)) return false;
     offset += take;
   }

--- a/lib/firmware/authenticator.c
+++ b/lib/firmware/authenticator.c
@@ -57,6 +57,16 @@ static bool getAuthData(void) {
 
 static void setAuthData(void) { storage_setAuthData(authData); }
 
+static bool authDisplayFieldValid(const char* value, size_t max_len) {
+  size_t len = strnlen(value, max_len + 1);
+  if (len == 0 || len > max_len) return false;
+  for (size_t i = 0; i < len; i++) {
+    uint8_t ch = (uint8_t)value[i];
+    if (ch < 0x20 || ch > 0x7e) return false;
+  }
+  return true;
+}
+
 #if DEBUG_LINK
 static unsigned _otpSlot = 0;
 void getAuthSlot(char* authSlotData) {
@@ -77,29 +87,30 @@ void getAuthSlot(char* authSlotData) {
 }
 #endif
 
-void wipeAuthData(void) {
-  confirm(ButtonRequestType_ButtonRequest_Other, "Confirm Wipe Authdata",
-          "Do you want to PERMANENTLY delete all authenticator accounts?\n If "
-          "not, unplug Keepkey now.");
+unsigned wipeAuthData(void) {
+  if (!confirm(ButtonRequestType_ButtonRequest_Other, "Confirm Wipe Authdata",
+               "Do you want to PERMANENTLY delete all authenticator accounts?"))
+    return AUTH_CANCELLED;
 
   // wipe storage and reset authdata encryption flag
   storage_wipeAuthData();
   // wipe local copy
   memzero(authData, sizeof(authData));
   localAuthdataUpdate = true;
-  return;
+  return NOERR;
 }
 
 unsigned addAuthAccount(char* accountWithSeed) {
   char *domain, *account, *seedStr;
   unsigned slot;
-  char authSecret[AUTHSECRET_SIZE_MAX];  // 128-bit key len is the recommended
-                                         // minimum, this is room for 160-bit
+  char authSecret[AUTHSECRET_SIZE_MAX] = {
+      0};  // 128-bit key len is the recommended minimum, this is room for
+           // 160-bit
   size_t authSecretLen;
 
   // accountWithSeed should be of the form "domain:account:seedStr"
   domain = strtok(accountWithSeed, ":");  // get the domain string token
-  if (NULL == domain) {
+  if (NULL == domain || !authDisplayFieldValid(domain, DOMAIN_SIZE - 1)) {
     return TOKERR;
   }
 
@@ -107,7 +118,7 @@ unsigned addAuthAccount(char* accountWithSeed) {
   if (NULL == account) {
     return TOKERR;
   }
-  if (0 == strlen(account)) {
+  if (!authDisplayFieldValid(account, ACCOUNT_SIZE - 1)) {
     return TOKERR;
   }
 
@@ -144,12 +155,21 @@ unsigned addAuthAccount(char* accountWithSeed) {
     return BADSECRET;  // bad decode
   }
 
-  confirm(ButtonRequestType_ButtonRequest_Other, "Confirm add account",
-          "Domain: %.*s\nAccount: %.*s\nSecret: %s", DOMAIN_SIZE, domain,
-          ACCOUNT_SIZE, account, seedStr);
+  // Keep the secret on its own screen. A 32-character base32 secret appended
+  // after domain/account can wrap past the OLED's three body rows, leaving the
+  // tail signed into storage but invisible to the user.
+  if (!confirm(ButtonRequestType_ButtonRequest_Other, "Add Auth Account",
+               "Domain: %.*s\nAccount: %.*s", DOMAIN_SIZE, domain, ACCOUNT_SIZE,
+               account) ||
+      !confirm(ButtonRequestType_ButtonRequest_Other, "TOTP Secret", "%s",
+               seedStr)) {
+    memzero(authSecret, sizeof(authSecret));
+    return AUTH_CANCELLED;
+  }
 
   authData[slot].secretSize = authSecretLen;
   memcpy(authData[slot].authSecret, authSecret, authData[slot].secretSize);
+  memzero(authSecret, sizeof(authSecret));
   strlcpy(authData[slot].domain, domain, DOMAIN_SIZE);
   strlcpy(authData[slot].account, account, ACCOUNT_SIZE);
 
@@ -301,14 +321,14 @@ unsigned removeAuthAccount(char* domAcc) {
 
   // accountWithSeed should be of the form "domain:account"
   domain = strtok(domAcc, ":");  // get the domain string token
-  if (NULL == domain) {
+  if (NULL == domain || !authDisplayFieldValid(domain, DOMAIN_SIZE - 1)) {
     return TOKERR;
   }
   account = strtok(NULL, "");  // get the account string token
   if (NULL == account) {
     return TOKERR;
   }
-  if (0 == strlen(account)) {
+  if (!authDisplayFieldValid(account, ACCOUNT_SIZE - 1)) {
     return TOKERR;
   }
 
@@ -328,9 +348,10 @@ unsigned removeAuthAccount(char* domAcc) {
     return NOACC;  // account not found
   }
 
-  confirm(ButtonRequestType_ButtonRequest_Other, "Confirm Delete Account",
-          "Do you want to PERMANENTLY delete account %.*s:%.*s?",
-          DOMAIN_SIZE - 1, domain, ACCOUNT_SIZE - 1, account);
+  if (!confirm(ButtonRequestType_ButtonRequest_Other, "Confirm Delete Account",
+               "Do you want to PERMANENTLY delete account %.*s:%.*s?",
+               DOMAIN_SIZE - 1, domain, ACCOUNT_SIZE - 1, account))
+    return AUTH_CANCELLED;
 
   memzero((void*)&authData[slot], sizeof(authType));
   setAuthData();

--- a/lib/firmware/authenticator.c
+++ b/lib/firmware/authenticator.c
@@ -102,11 +102,12 @@ unsigned wipeAuthData(void) {
 
 unsigned addAuthAccount(char* accountWithSeed) {
   char *domain, *account, *seedStr;
-  unsigned slot;
+  unsigned slot = AUTHDATA_SIZE;
   char authSecret[AUTHSECRET_SIZE_MAX] = {
       0};  // 128-bit key len is the recommended minimum, this is room for
            // 160-bit
   size_t authSecretLen;
+  unsigned result = UNKERR;
 
   // accountWithSeed should be of the form "domain:account:seedStr"
   domain = strtok(accountWithSeed, ":");  // get the domain string token
@@ -131,6 +132,9 @@ unsigned addAuthAccount(char* accountWithSeed) {
   }
 
   authSecretLen = base32_decoded_length(strlen(seedStr));
+  if (authSecretLen < AUTHSECRET_SIZE_MIN) {
+    return BADSECRET;
+  }
   if (AUTHSECRET_SIZE_MAX < authSecretLen) {
     return LARGESEED;
   }
@@ -139,11 +143,14 @@ unsigned addAuthAccount(char* accountWithSeed) {
     return BADPASS;  // fingerprint did not match, passphrase incorrect
   }
 
-  // look for first empty slot
-  for (slot = 0; slot < AUTHDATA_SIZE; slot++) {
-    if (authData[slot].secretSize == 0) {
-      break;
-    }
+  // Reject duplicate identities and remember the first empty slot. Legacy
+  // duplicates are removed together by removeAuthAccount().
+  for (unsigned i = 0; i < AUTHDATA_SIZE; i++) {
+    if (authData[i].secretSize != 0 &&
+        strncmp(authData[i].domain, domain, DOMAIN_SIZE) == 0 &&
+        strncmp(authData[i].account, account, ACCOUNT_SIZE) == 0)
+      return DUPLICATE;
+    if (slot == AUTHDATA_SIZE && authData[i].secretSize == 0) slot = i;
   }
   if (slot == AUTHDATA_SIZE) {
     return NOSLOT;  // no empty slots
@@ -152,7 +159,8 @@ unsigned addAuthAccount(char* accountWithSeed) {
   if (NULL == base32_decode((const char*)seedStr, strlen(seedStr),
                             (uint8_t*)authSecret, sizeof(authSecret),
                             BASE32_ALPHABET_RFC4648)) {
-    return BADSECRET;  // bad decode
+    result = BADSECRET;
+    goto cleanup;
   }
 
   // Keep the secret on its own screen. A 32-character base32 secret appended
@@ -163,19 +171,21 @@ unsigned addAuthAccount(char* accountWithSeed) {
                account) ||
       !confirm(ButtonRequestType_ButtonRequest_Other, "TOTP Secret", "%s",
                seedStr)) {
-    memzero(authSecret, sizeof(authSecret));
-    return AUTH_CANCELLED;
+    result = AUTH_CANCELLED;
+    goto cleanup;
   }
 
   authData[slot].secretSize = authSecretLen;
   memcpy(authData[slot].authSecret, authSecret, authData[slot].secretSize);
-  memzero(authSecret, sizeof(authSecret));
   strlcpy(authData[slot].domain, domain, DOMAIN_SIZE);
   strlcpy(authData[slot].account, account, ACCOUNT_SIZE);
 
   setAuthData();
+  result = NOERR;
 
-  return NOERR;  // success
+cleanup:
+  memzero(authSecret, sizeof(authSecret));
+  return result;
 }
 
 unsigned generateOTP(char* accountWithMsg, char otpStr[]) {
@@ -317,7 +327,7 @@ unsigned getAuthAccount(const char* slotStr, char acc[]) {
 
 unsigned removeAuthAccount(char* domAcc) {
   char *domain, *account;
-  unsigned slot;
+  bool found = false;
 
   // accountWithSeed should be of the form "domain:account"
   domain = strtok(domAcc, ":");  // get the domain string token
@@ -336,15 +346,16 @@ unsigned removeAuthAccount(char* domAcc) {
     return BADPASS;  // fingerprint did not match, passphrase incorrect
   }
 
-  // find slot for account
-  for (slot = 0; slot < AUTHDATA_SIZE; slot++) {
-    if ((0 == strncmp(authData[slot].domain, domain, DOMAIN_SIZE - 1)) &&
-        (0 == strncmp(authData[slot].account, account, ACCOUNT_SIZE - 1))) {
-      break;
-    }
+  // Find every matching slot. Older firmware allowed duplicate identities, so
+  // a confirmed deletion must remove all copies atomically.
+  for (unsigned slot = 0; slot < AUTHDATA_SIZE; slot++) {
+    if (authData[slot].secretSize != 0 &&
+        strncmp(authData[slot].domain, domain, DOMAIN_SIZE) == 0 &&
+        strncmp(authData[slot].account, account, ACCOUNT_SIZE) == 0)
+      found = true;
   }
 
-  if (slot == AUTHDATA_SIZE) {
+  if (!found) {
     return NOACC;  // account not found
   }
 
@@ -353,7 +364,12 @@ unsigned removeAuthAccount(char* domAcc) {
                DOMAIN_SIZE - 1, domain, ACCOUNT_SIZE - 1, account))
     return AUTH_CANCELLED;
 
-  memzero((void*)&authData[slot], sizeof(authType));
+  for (unsigned slot = 0; slot < AUTHDATA_SIZE; slot++) {
+    if (authData[slot].secretSize != 0 &&
+        strncmp(authData[slot].domain, domain, DOMAIN_SIZE) == 0 &&
+        strncmp(authData[slot].account, account, ACCOUNT_SIZE) == 0)
+      memzero((void*)&authData[slot], sizeof(authType));
+  }
   setAuthData();
   return NOERR;  // success
 }

--- a/lib/firmware/binance.c
+++ b/lib/firmware/binance.c
@@ -16,12 +16,49 @@ static BinanceSignTx msg;
 
 const BinanceSignTx* binance_getBinanceSignTx(void) { return &msg; }
 
-bool binance_signTxInit(const HDNode* _node, const BinanceSignTx* _msg) {
-  initialized = true;
-  msgs_remaining = _msg->msg_count;
-  has_message = false;
+bool binance_isValidDenom(const char* denom) {
+  if (!denom) return false;
+  const size_t len = strnlen(denom, BINANCE_MAX_DENOM_LEN + 1);
+  if (len == 0 || len > BINANCE_MAX_DENOM_LEN) return false;
+  for (size_t i = 0; i < len; i++) {
+    const char c = denom[i];
+    if (!((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-'))
+      return false;
+  }
+  return true;
+}
 
-  memzero(&node, sizeof(node));
+bool binance_validateTransfer(const BinanceTransferMsg* transfer) {
+  if (!transfer || transfer->inputs_count != 1 ||
+      transfer->inputs[0].coins_count != 1 || transfer->outputs_count != 1 ||
+      transfer->outputs[0].coins_count != 1)
+    return false;
+
+  const BinanceInputOutput* input = &transfer->inputs[0];
+  const BinanceInputOutput* output = &transfer->outputs[0];
+  const BinanceCoin* input_coin = &input->coins[0];
+  const BinanceCoin* output_coin = &output->coins[0];
+  if (!input->has_address || !output->has_address || !input_coin->has_amount ||
+      !output_coin->has_amount || !input_coin->has_denom ||
+      !output_coin->has_denom || input_coin->amount <= 0 ||
+      output_coin->amount <= 0 || input_coin->amount != output_coin->amount ||
+      strcmp(input_coin->denom, output_coin->denom) != 0 ||
+      !binance_isValidDenom(input_coin->denom))
+    return false;
+
+  return true;
+}
+
+bool binance_signTxInit(const HDNode* _node, const BinanceSignTx* _msg) {
+  binance_signAbort();
+  if (!_node || !_msg || !_msg->has_msg_count || _msg->msg_count == 0 ||
+      !_msg->has_account_number || _msg->account_number < 0 ||
+      !_msg->has_chain_id || _msg->chain_id[0] == '\0' || !_msg->has_sequence ||
+      _msg->sequence < 0 || !_msg->has_source || _msg->source < 0)
+    return false;
+
+  msgs_remaining = _msg->msg_count;
+
   memcpy(&node, _node, sizeof(node));
   memcpy(&msg, _msg, sizeof(msg));
 
@@ -32,7 +69,7 @@ bool binance_signTxInit(const HDNode* _node, const BinanceSignTx* _msg) {
 
   success &= tendermint_snprintf(&ctx, buffer, sizeof(buffer),
                                  "{\"account_number\":\"%" PRIu64 "\"",
-                                 msg.account_number);
+                                 (uint64_t)msg.account_number);
 
   const char* const chainid_prefix = ",\"chain_id\":\"";
   sha256_Update(&ctx, (uint8_t*)chainid_prefix, strlen(chainid_prefix));
@@ -45,16 +82,25 @@ bool binance_signTxInit(const HDNode* _node, const BinanceSignTx* _msg) {
   }
 
   sha256_Update(&ctx, (const uint8_t*)"\",\"msgs\":[", 10);
-  return success;
+  if (!success) {
+    binance_signAbort();
+    return false;
+  }
+  initialized = true;
+  return true;
 }
 
 bool binance_serializeCoin(const BinanceCoin* coin) {
+  if (!coin || !coin->has_amount || coin->amount <= 0 || !coin->has_denom ||
+      !binance_isValidDenom(coin->denom))
+    return false;
+
   bool success = true;
   char buffer[64 + 1];
 
   success &= tendermint_snprintf(&ctx, buffer, sizeof(buffer),
                                  "{\"amount\":%" PRIu64 ",\"denom\":\"%s\"}",
-                                 coin->amount, coin->denom);
+                                 (uint64_t)coin->amount, coin->denom);
 
   return success;
 }
@@ -83,6 +129,9 @@ bool binance_serializeInputOutput(const BinanceInputOutput* io) {
 }
 
 bool binance_signTxUpdateTransfer(const BinanceTransferMsg* _msg) {
+  if (!initialized || msgs_remaining == 0 || !binance_validateTransfer(_msg))
+    return false;
+
   bool success = true;
 
   sha256_Update(&ctx, (const uint8_t*)"{\"inputs\":[", 11);
@@ -103,18 +152,23 @@ bool binance_signTxUpdateTransfer(const BinanceTransferMsg* _msg) {
 
   sha256_Update(&ctx, (const uint8_t*)"]}", 2);
 
-  has_message = true;
-  msgs_remaining--;
+  if (success) {
+    has_message = true;
+    msgs_remaining--;
+  }
   return success;
 }
 
 bool binance_signTxFinalize(uint8_t* public_key, uint8_t* signature) {
+  if (!initialized || msgs_remaining != 0 || !has_message || !public_key ||
+      !signature)
+    return false;
   char buffer[64 + 1];
 
   if (!tendermint_snprintf(&ctx, buffer, sizeof(buffer),
                            "],\"sequence\":\"%" PRIu64
                            "\",\"source\":\"%" PRIu64 "\"}",
-                           msg.sequence, msg.source))
+                           (uint64_t)msg.sequence, (uint64_t)msg.source))
     return false;
 
   hdnode_fill_public_key(&node);
@@ -128,7 +182,9 @@ bool binance_signTxFinalize(uint8_t* public_key, uint8_t* signature) {
 
 bool binance_signingIsInited(void) { return initialized; }
 
-bool binance_signingIsFinished(void) { return msgs_remaining == 0; }
+bool binance_signingIsFinished(void) {
+  return initialized && msgs_remaining == 0 && has_message;
+}
 
 void binance_signAbort(void) {
   initialized = false;

--- a/lib/firmware/eip712.c
+++ b/lib/firmware/eip712.c
@@ -31,11 +31,13 @@
    strings and address should be prefixed by 0x
 */
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include "keepkey/board/confirm_sm.h"
 #include "keepkey/board/memory.h"
+#include "keepkey/firmware/app_confirm.h"
 #include "keepkey/firmware/eip712.h"
 #include "keepkey/firmware/ethereum_tokens.h"
 #include "keepkey/firmware/tiny-json.h"
@@ -47,38 +49,117 @@ static dm confirmProp;
 
 static const char* nameForValue;
 
+static bool append_type_string(char* dest, const char* value) {
+  if (!dest || !value) return false;
+  const size_t used = strnlen(dest, STRBUFSIZE + 1);
+  const size_t added = strlen(value);
+  if (used > STRBUFSIZE || added > STRBUFSIZE - used) return false;
+  memcpy(dest + used, value, added + 1);
+  return true;
+}
+
+static bool type_array_suffix_is_valid(const char* suffix) {
+  if (*suffix == '\0') return true;
+  if (*suffix++ != '[') return false;
+  while (*suffix >= '0' && *suffix <= '9') suffix++;
+  return suffix[0] == ']' && suffix[1] == '\0';
+}
+
+static bool type_matches(const char* type, const char* base) {
+  const size_t len = strlen(base);
+  return strncmp(type, base, len) == 0 &&
+         type_array_suffix_is_valid(type + len);
+}
+
+static bool type_is_integer(const char* type, const char* prefix) {
+  const size_t prefix_len = strlen(prefix);
+  if (strncmp(type, prefix, prefix_len) != 0) return false;
+  const char* p = type + prefix_len;
+  unsigned bits = 0;
+  bool has_bits = false;
+  while (*p >= '0' && *p <= '9') {
+    has_bits = true;
+    bits = bits * 10 + (unsigned)(*p++ - '0');
+  }
+  if (has_bits && (bits < 8 || bits > 256 || (bits % 8) != 0)) return false;
+  return type_array_suffix_is_valid(p);
+}
+
+static unsigned integer_type_width(const char* type, const char* prefix) {
+  const char* p = type + strlen(prefix);
+  if (*p < '0' || *p > '9') return 256;
+  unsigned bits = 0;
+  while (*p >= '0' && *p <= '9') {
+    bits = bits * 10 + (unsigned)(*p++ - '0');
+  }
+  return bits;
+}
+
+static bool type_is_bytes(const char* type, unsigned* byte_size,
+                          bool* dynamic) {
+  if (strncmp(type, "bytes", 5) != 0) return false;
+  const char* p = type + 5;
+  if (*p == '\0' || *p == '[') {
+    if (!type_array_suffix_is_valid(p)) return false;
+    *byte_size = 0;
+    *dynamic = true;
+    return true;
+  }
+  unsigned size = 0;
+  bool has_size = false;
+  while (*p >= '0' && *p <= '9') {
+    has_size = true;
+    size = size * 10 + (unsigned)(*p++ - '0');
+  }
+  if (!has_size || size == 0 || size > 32 || !type_array_suffix_is_valid(p))
+    return false;
+  *byte_size = size;
+  *dynamic = false;
+  return true;
+}
+
+static int hex_nibble(char c) {
+  if (c >= '0' && c <= '9') return c - '0';
+  if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+  if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+  return -1;
+}
+
+static bool hex_string_is_valid(const char* string, size_t expected_bytes,
+                                bool exact_size) {
+  if (!string || string[0] != '0' || string[1] != 'x') return false;
+  const size_t chars = strlen(string + 2);
+  if ((chars & 1) != 0 || (exact_size && chars != 2 * expected_bytes))
+    return false;
+  for (size_t i = 0; i < chars; i++) {
+    if (hex_nibble(string[i + 2]) < 0) return false;
+  }
+  return true;
+}
+
 int encodableType(const char* typeStr) {
   int ctr;
 
-  if (0 == strncmp(typeStr, "address", sizeof("address") - 1)) {
+  if (!typeStr || typeStr[0] == '\0') return NOT_ENCODABLE;
+
+  if (type_matches(typeStr, "address")) {
     return ADDRESS;
   }
-  if (0 == strncmp(typeStr, "string", sizeof("string") - 1)) {
+  if (type_matches(typeStr, "string")) {
     return STRING;
   }
-  if (0 == strncmp(typeStr, "int", sizeof("int") - 1)) {
-    // This could be 'int8', 'int16', ..., 'int256'
+  if (type_is_integer(typeStr, "int")) {
     return INT;
   }
-  if (0 == strncmp(typeStr, "uint", sizeof("uint") - 1)) {
-    // This could be 'uint8', 'uint16', ..., 'uint256'
+  if (type_is_integer(typeStr, "uint")) {
     return UINT;
   }
-  if (0 == strncmp(typeStr, "bytes", sizeof("bytes") - 1)) {
-    // This could be 'bytes', 'bytes1', ..., 'bytes32'
-    if (0 == strcmp(typeStr, "bytes")) {
-      return BYTES;
-    } else {
-      // parse out the length val
-      uint8_t byteTypeSize = (uint8_t)(strtol((typeStr + 5), NULL, 10));
-      if (byteTypeSize > 32) {
-        return NOT_ENCODABLE;
-      } else {
-        return BYTES_N;
-      }
-    }
+  unsigned byte_size = 0;
+  bool dynamic = false;
+  if (type_is_bytes(typeStr, &byte_size, &dynamic)) {
+    return dynamic ? BYTES : BYTES_N;
   }
-  if (0 == strcmp(typeStr, "bool")) {
+  if (type_matches(typeStr, "bool")) {
     return BOOL;
   }
 
@@ -90,10 +171,11 @@ int encodableType(const char* typeStr) {
     strtok(typeNoArrTok, "[");  // eliminate the array tokens if there
 
     if (udefList[ctr] != 0) {
-      if (0 == strncmp(udefList[ctr], typeNoArrTok,
-                       strlen(udefList[ctr]) - strlen(typeNoArrTok))) {
+      const size_t previous_len = strcspn(udefList[ctr], "[");
+      const size_t candidate_len = strlen(typeNoArrTok);
+      if (previous_len == candidate_len &&
+          strncmp(udefList[ctr], typeNoArrTok, candidate_len) == 0) {
         return PREV_USERDEF;
-      } else {
       }
 
     } else {
@@ -134,8 +216,10 @@ int parseType(const json_t* eip712Types, const char* typeS, char* typeStr) {
     return JSON_TYPE_S_NAMEERR;
   }
 
-  strncat(typeStr, nameTest, STRBUFSIZE - strlen((const char*)typeStr));
-  strncat(typeStr, "(", STRBUFSIZE - strlen((const char*)typeStr));
+  if (!append_type_string(typeStr, nameTest) ||
+      !append_type_string(typeStr, "(")) {
+    return UDEF_NAME_ERROR;
+  }
 
   tarray = json_getChild(jType);
   while (tarray != 0) {
@@ -189,10 +273,12 @@ int parseType(const json_t* eip712Types, const char* typeS, char* typeStr) {
       if (NULL == pVal) {
         return JSON_NOPAIRVAL;
       }
-      strncat(typeStr, typeType, STRBUFSIZE - strlen((const char*)typeStr));
-      strncat(typeStr, " ", STRBUFSIZE - strlen((const char*)typeStr));
-      strncat(typeStr, pVal, STRBUFSIZE - strlen((const char*)typeStr));
-      strncat(typeStr, ",", STRBUFSIZE - strlen((const char*)typeStr));
+      if (!append_type_string(typeStr, typeType) ||
+          !append_type_string(typeStr, " ") ||
+          !append_type_string(typeStr, pVal) ||
+          !append_type_string(typeStr, ",")) {
+        return UDEF_NAME_ERROR;
+      }
     }
     tarray = json_getSibling(tarray);
   }
@@ -202,32 +288,28 @@ int parseType(const json_t* eip712Types, const char* typeS, char* typeStr) {
     typeStr[strlen(typeStr) - 1] = ')';
   } else {
     // append paren, there are no parameters
-    strncat(typeStr, ")", STRBUFSIZE - 1);
+    if (!append_type_string(typeStr, ")")) return UDEF_NAME_ERROR;
   }
   if (strlen(append) > 0) {
-    strncat(typeStr, append, STRBUFSIZE - strlen((const char*)append));
+    if (!append_type_string(typeStr, append)) return UDEF_NAME_ERROR;
   }
 
   return SUCCESS;
 }
 
 int encAddress(const char* string, uint8_t* encoded) {
-  unsigned ctr;
-  char byteStrBuf[3] = {0};
-
-  if (string == NULL) {
+  if (!string) {
     return ADDR_STRING_NULL;
   }
-  if (ADDRESS_SIZE < strlen(string)) {
+  if (strlen(string) != ADDRESS_SIZE ||
+      !hex_string_is_valid(string, 20, true)) {
     return ADDR_STRING_VFLOW;
   }
 
-  for (ctr = 0; ctr < 12; ctr++) {
-    encoded[ctr] = '\0';
-  }
-  for (ctr = 12; ctr < 32; ctr++) {
-    strncpy(byteStrBuf, &string[2 * ((ctr - 12)) + 2], 2);
-    encoded[ctr] = (uint8_t)(strtol(byteStrBuf, NULL, 16));
+  memset(encoded, 0, 12);
+  for (size_t i = 0; i < 20; i++) {
+    encoded[12 + i] = (uint8_t)((hex_nibble(string[2 + 2 * i]) << 4) |
+                                hex_nibble(string[3 + 2 * i]));
   }
   return SUCCESS;
 }
@@ -242,17 +324,15 @@ int encString(const char* string, uint8_t* encoded) {
 }
 
 int encodeBytes(const char* string, uint8_t* encoded) {
+  if (!hex_string_is_valid(string, 0, false)) return GENERAL_ERROR;
   struct SHA3_CTX byteCtx;
   const char* valStrPtr = string + 2;
-  uint8_t valByte[1];
-  char byteStrBuf[3] = {0};
 
   sha3_256_Init(&byteCtx);
   while (*valStrPtr != '\0') {
-    strncpy(byteStrBuf, valStrPtr, 2);
-    valByte[0] = (uint8_t)(strtol(byteStrBuf, NULL, 16));
-    sha3_Update(&byteCtx, (const unsigned char*)valByte,
-                (size_t)sizeof(uint8_t));
+    const uint8_t valByte =
+        (uint8_t)((hex_nibble(valStrPtr[0]) << 4) | hex_nibble(valStrPtr[1]));
+    sha3_Update(&byteCtx, &valByte, sizeof(valByte));
     valStrPtr += 2;
   }
   keccak_Final(&byteCtx, encoded);
@@ -260,46 +340,37 @@ int encodeBytes(const char* string, uint8_t* encoded) {
 }
 
 int encodeBytesN(const char* typeT, const char* string, uint8_t* encoded) {
-  char byteStrBuf[3] = {0};
-  unsigned ctr;
-
-  if (MAX_ENCBYTEN_SIZE < strlen(string)) {
-    return BYTESN_STRING_ERROR;
-  }
-
-  // parse out the length val
-  uint8_t byteTypeSize = (uint8_t)(strtol((typeT + 5), NULL, 10));
-  if (32 < byteTypeSize) {
+  unsigned byteTypeSize = 0;
+  bool dynamic = false;
+  if (!type_is_bytes(typeT, &byteTypeSize, &dynamic) || dynamic) {
     return BYTESN_SIZE_ERROR;
   }
-  for (ctr = 0; ctr < 32; ctr++) {
-    // zero padding
-    encoded[ctr] = 0;
+  if (!hex_string_is_valid(string, byteTypeSize, true)) {
+    return BYTESN_STRING_ERROR;
   }
-  unsigned zeroFillLen = 32 - ((strlen(string) - 2 /* skip '0x' */) / 2);
-  // bytesN are zero padded on the right
-  for (ctr = zeroFillLen; ctr < 32; ctr++) {
-    strncpy(byteStrBuf, &string[2 + 2 * (ctr - zeroFillLen)], 2);
-    encoded[ctr - zeroFillLen] = (uint8_t)(strtol(byteStrBuf, NULL, 16));
+  memset(encoded, 0, 32);
+  for (size_t i = 0; i < byteTypeSize; i++) {
+    encoded[i] = (uint8_t)((hex_nibble(string[2 + 2 * i]) << 4) |
+                           hex_nibble(string[3 + 2 * i]));
   }
   return SUCCESS;
 }
 
 int confirmName(const char* name, bool valAvailable) {
-  if (valAvailable) {
-    nameForValue = name;
-    return SUCCESS;
-  }
-  if (!review(ButtonRequestType_ButtonRequest_Other, "MESSAGE DATA",
-              "Press button to continue for\n\"%s\" values", name)) {
+  (void)valAvailable;
+  if (!name) return GENERAL_ERROR;
+  nameForValue = name;
+  if (!confirm_bytes(ButtonRequestType_ButtonRequest_Other, "EIP-712 Field",
+                     (const uint8_t*)name, strlen(name))) {
     return USER_CANCELLED;
   }
   return SUCCESS;
 }
 
 int confirmValue(const char* value) {
-  if (!review(ButtonRequestType_ButtonRequest_Other, "MESSAGE DATA", "%s %s",
-              nameForValue, value)) {
+  if (!value || !confirm_bytes(ButtonRequestType_ButtonRequest_Other,
+                               nameForValue ? "EIP-712 Value" : "MESSAGE DATA",
+                               (const uint8_t*)value, strlen(value))) {
     return USER_CANCELLED;
   }
   return SUCCESS;
@@ -322,6 +393,11 @@ void marshallDsVals(const char* value) {
     dsverifyingContract = value;
   }
   return;
+}
+
+static int confirmTypedValue(bool ds_vals, const char* value) {
+  if (ds_vals) marshallDsVals(value);
+  return confirmValue(value);
 }
 
 int dsConfirm(void) {
@@ -446,7 +522,6 @@ int parseVals(const json_t* eip712Types, const json_t* jType,
       walkVals = nextVal;
       while (0 != walkVals) {
         if (0 == strcmp(json_getName(walkVals), typeName)) {
-          valStr = json_getValue(walkVals);
           break;
         } else {
           // keep looking for val
@@ -454,31 +529,35 @@ int parseVals(const json_t* eip712Types, const json_t* jType,
         }
       }
 
-      bool hasValue = (JSON_TEXT == json_getType(walkVals) ||
-                       JSON_INTEGER == json_getType(walkVals));
+      if (walkVals == 0) {
+        return JSON_TYPE_WNOVAL;
+      }
+      const jsonType_t value_type = json_getType(walkVals);
+      const bool hasValue = value_type == JSON_TEXT ||
+                            value_type == JSON_INTEGER ||
+                            value_type == JSON_BOOLEAN;
+      valStr = hasValue ? json_getValue(walkVals) : NULL;
       if (SUCCESS != (errRet = confirmName(typeName, hasValue))) {
         return errRet;
       }
 
-      if (walkVals == 0) {
-        return JSON_TYPE_WNOVAL;
-      } else {
-        if (0 == strncmp("address", typeType, strlen("address") - 1)) {
+      {
+        if (type_matches(typeType, "address")) {
           if (']' == typeType[strlen(typeType) - 1]) {
             // array of addresses
+            if (value_type != JSON_ARRAY) return GENERAL_ERROR;
             json_t const* addrVals = json_getChild(walkVals);
             sha3_256_Init(&valCtx);  // hash of concatenated encoded strings
             while (0 != addrVals) {
+              if (json_getType(addrVals) != JSON_TEXT) return GENERAL_ERROR;
+              const char* address = json_getValue(addrVals);
               // just walk the string values assuming, for fixed sizes, all
               // values are there.
-              if (ds_vals) {
-                marshallDsVals(json_getValue(addrVals));
-              } else if (SUCCESS !=
-                         (errRet = confirmValue(json_getValue(addrVals)))) {
+              if (SUCCESS != (errRet = confirmTypedValue(ds_vals, address))) {
                 return errRet;
               }
 
-              errRet = encAddress(json_getValue(addrVals), encBytes);
+              errRet = encAddress(address, encBytes);
               if (SUCCESS != errRet) {
                 return errRet;
               }
@@ -487,9 +566,8 @@ int parseVals(const json_t* eip712Types, const json_t* jType,
             }
             keccak_Final(&valCtx, encBytes);
           } else {
-            if (ds_vals) {
-              marshallDsVals(valStr);
-            } else if (SUCCESS != (errRet = confirmValue(valStr))) {
+            if (value_type != JSON_TEXT) return GENERAL_ERROR;
+            if (SUCCESS != (errRet = confirmTypedValue(ds_vals, valStr))) {
               return errRet;
             }
             errRet = encAddress(valStr, encBytes);
@@ -498,22 +576,23 @@ int parseVals(const json_t* eip712Types, const json_t* jType,
             }
           }
 
-        } else if (0 == strncmp("string", typeType, strlen("string") - 1)) {
+        } else if (type_matches(typeType, "string")) {
           if (']' == typeType[strlen(typeType) - 1]) {
             // array of strings
+            if (value_type != JSON_ARRAY) return GENERAL_ERROR;
             json_t const* stringVals = json_getChild(walkVals);
             uint8_t strEncBytes[32];
             sha3_256_Init(&valCtx);  // hash of concatenated encoded strings
             while (0 != stringVals) {
+              if (json_getType(stringVals) != JSON_TEXT) return GENERAL_ERROR;
+              const char* string_value = json_getValue(stringVals);
               // just walk the string values assuming, for fixed sizes, all
               // values are there.
-              if (ds_vals) {
-                marshallDsVals(json_getValue(stringVals));
-              } else if (SUCCESS !=
-                         (errRet = confirmValue(json_getValue(stringVals)))) {
+              if (SUCCESS !=
+                  (errRet = confirmTypedValue(ds_vals, string_value))) {
                 return errRet;
               }
-              errRet = encString(json_getValue(stringVals), strEncBytes);
+              errRet = encString(string_value, strEncBytes);
               if (SUCCESS != errRet) {
                 return errRet;
               }
@@ -522,9 +601,8 @@ int parseVals(const json_t* eip712Types, const json_t* jType,
             }
             keccak_Final(&valCtx, encBytes);
           } else {
-            if (ds_vals) {
-              marshallDsVals(valStr);
-            } else if (SUCCESS != (errRet = confirmValue(valStr))) {
+            if (value_type != JSON_TEXT) return GENERAL_ERROR;
+            if (SUCCESS != (errRet = confirmTypedValue(ds_vals, valStr))) {
               return errRet;
             }
             errRet = encString(valStr, encBytes);
@@ -533,18 +611,19 @@ int parseVals(const json_t* eip712Types, const json_t* jType,
             }
           }
 
-        } else if ((0 == strncmp("uint", typeType, strlen("uint") - 1)) ||
-                   (0 == strncmp("int", typeType, strlen("int") - 1))) {
+        } else if (type_is_integer(typeType, "uint") ||
+                   type_is_integer(typeType, "int")) {
           if (']' == typeType[strlen(typeType) - 1]) {
             return INT_ARRAY_ERROR;
           } else {
-            if (ds_vals) {
-              marshallDsVals(valStr);
-            } else if (SUCCESS != (errRet = confirmValue(valStr))) {
+            if (value_type != JSON_TEXT && value_type != JSON_INTEGER)
+              return GENERAL_ERROR;
+            if (SUCCESS != (errRet = confirmTypedValue(ds_vals, valStr))) {
               return errRet;
             }
+            const bool is_uint = type_is_integer(typeType, "uint");
             uint8_t negInt = 0;  // 0 is positive, 1 is negative
-            if (0 == strncmp("int", typeType, strlen("int") - 1)) {
+            if (!is_uint) {
               if (*valStr == '-') {
                 negInt = 1;
               }
@@ -560,154 +639,184 @@ int parseVals(const json_t* eip712Types, const json_t* jType,
               }
             }
             // all int strings are assumed to be base 10 and fit into 64 bits
+            const char* digits = valStr + (negInt ? 1 : 0);
+            if (*digits == '\0') return GENERAL_ERROR;
+            for (const char* p = digits; *p; p++) {
+              if (*p < '0' || *p > '9') return GENERAL_ERROR;
+            }
+            errno = 0;
             char* endptr = NULL;
             long long intVal = strtoll(valStr, &endptr, 10);
-            if (endptr == valStr || *endptr != '\0') {
+            if (errno == ERANGE || endptr == valStr || *endptr != '\0') {
               return GENERAL_ERROR;
             }
-            if (0 == strncmp("uint", typeType, 4) && intVal < 0) {
+            if (is_uint && intVal < 0) {
               return GENERAL_ERROR;
+            }
+            const unsigned declared_bits =
+                integer_type_width(typeType, is_uint ? "uint" : "int");
+            if (declared_bits < 64) {
+              if (is_uint) {
+                const uint64_t max_value = (UINT64_C(1) << declared_bits) - 1;
+                if ((uint64_t)intVal > max_value) return GENERAL_ERROR;
+              } else {
+                const int64_t min_value = -(INT64_C(1) << (declared_bits - 1));
+                const int64_t max_value =
+                    (INT64_C(1) << (declared_bits - 1)) - 1;
+                if (intVal < min_value || intVal > max_value)
+                  return GENERAL_ERROR;
+              }
             }
             // Needs to be big endian, so add to encBytes appropriately
-            encBytes[24] = (intVal >> 56) & 0xff;
-            encBytes[25] = (intVal >> 48) & 0xff;
-            encBytes[26] = (intVal >> 40) & 0xff;
-            encBytes[27] = (intVal >> 32) & 0xff;
-            encBytes[28] = (intVal >> 24) & 0xff;
-            encBytes[29] = (intVal >> 16) & 0xff;
-            encBytes[30] = (intVal >> 8) & 0xff;
-            encBytes[31] = (intVal) & 0xff;
-          }
-
-        } else if (0 == strncmp("bytes", typeType, strlen("bytes"))) {
-          if (']' == typeType[strlen(typeType) - 1]) {
-            return BYTESN_ARRAY_ERROR;
-          } else {
-            // This could be 'bytes', 'bytes1', ..., 'bytes32'
-            if (ds_vals) {
-              marshallDsVals(valStr);
-            } else if (SUCCESS != (errRet = confirmValue(valStr))) {
-              return errRet;
-            }
-            if (0 == strcmp(typeType, "bytes")) {
-              errRet = encodeBytes(valStr, encBytes);
-              if (SUCCESS != errRet) {
-                return errRet;
-              }
-
-            } else {
-              errRet = encodeBytesN(typeType, valStr, encBytes);
-              if (SUCCESS != errRet) {
-                return errRet;
-              }
-            }
-          }
-
-        } else if (0 == strncmp("bool", typeType, strlen(typeType))) {
-          if (']' == typeType[strlen(typeType) - 1]) {
-            return BOOL_ARRAY_ERROR;
-          } else {
-            if (ds_vals) {
-              marshallDsVals(valStr);
-            } else if (SUCCESS != (errRet = confirmValue(valStr))) {
-              return errRet;
-            }
-            for (ctr = 0; ctr < 32; ctr++) {
-              // leading zeros in bool
-              encBytes[ctr] = 0;
-            }
-            if (0 == strncmp(valStr, "true", sizeof("true"))) {
-              encBytes[31] = 0x01;
-            }
+            const uint64_t intBits = (uint64_t)intVal;
+            encBytes[24] = (intBits >> 56) & 0xff;
+            encBytes[25] = (intBits >> 48) & 0xff;
+            encBytes[26] = (intBits >> 40) & 0xff;
+            encBytes[27] = (intBits >> 32) & 0xff;
+            encBytes[28] = (intBits >> 24) & 0xff;
+            encBytes[29] = (intBits >> 16) & 0xff;
+            encBytes[30] = (intBits >> 8) & 0xff;
+            encBytes[31] = intBits & 0xff;
           }
 
         } else {
-          // encode user defined type
-          char encSubTypeStr[STRBUFSIZE + 1] = {0};
-          // clear out the user-defined types list
-          for (ctr = 0; ctr < MAX_USERDEF_TYPES; ctr++) {
-            udefList[ctr] = NULL;
-          }
+          unsigned byte_size = 0;
+          bool dynamic_bytes = false;
+          if (type_is_bytes(typeType, &byte_size, &dynamic_bytes)) {
+            if (']' == typeType[strlen(typeType) - 1]) {
+              return BYTESN_ARRAY_ERROR;
+            } else {
+              if (value_type != JSON_TEXT) return GENERAL_ERROR;
+              // This could be 'bytes', 'bytes1', ..., 'bytes32'
+              if (SUCCESS != (errRet = confirmTypedValue(ds_vals, valStr))) {
+                return errRet;
+              }
+              if (dynamic_bytes) {
+                errRet = encodeBytes(valStr, encBytes);
+                if (SUCCESS != errRet) {
+                  return errRet;
+                }
 
-          char typeNoArrTok[MAX_TYPESTRING] = {0};
-          // need to get typehash of type first
-          if (']' == typeType[strlen(typeType) - 1]) {
-            // array of structs. To parse name, remove array tokens.
-            strncpy(typeNoArrTok, typeType, sizeof(typeNoArrTok) - 1);
-            if (strlen(typeNoArrTok) < strlen(typeType)) {
-              return UDEF_ARRAY_NAME_ERR;
+              } else {
+                errRet = encodeBytesN(typeType, valStr, encBytes);
+                if (SUCCESS != errRet) {
+                  return errRet;
+                }
+              }
             }
-            strtok(typeNoArrTok, "[");
-            if (STACK_GOOD != (errRet = memcheck(STACK_SIZE_GUARD))) {
-              return errRet;
+
+          } else if (type_matches(typeType, "bool")) {
+            if (']' == typeType[strlen(typeType) - 1]) {
+              return BOOL_ARRAY_ERROR;
+            } else {
+              if (value_type != JSON_BOOLEAN && value_type != JSON_TEXT)
+                return GENERAL_ERROR;
+              if (SUCCESS != (errRet = confirmTypedValue(ds_vals, valStr))) {
+                return errRet;
+              }
+              if (strcmp(valStr, "true") != 0 && strcmp(valStr, "false") != 0)
+                return GENERAL_ERROR;
+              for (ctr = 0; ctr < 32; ctr++) {
+                // leading zeros in bool
+                encBytes[ctr] = 0;
+              }
+              if (strcmp(valStr, "true") == 0) {
+                encBytes[31] = 0x01;
+              }
             }
-            if (SUCCESS != (errRet = parseType(eip712Types, typeNoArrTok,
-                                               encSubTypeStr))) {
-              return errRet;
-            }
+
           } else {
-            if (STACK_GOOD != (errRet = memcheck(STACK_SIZE_GUARD))) {
-              return errRet;
+            // encode user defined type
+            char encSubTypeStr[STRBUFSIZE + 1] = {0};
+            // clear out the user-defined types list
+            for (ctr = 0; ctr < MAX_USERDEF_TYPES; ctr++) {
+              udefList[ctr] = NULL;
             }
-            if (SUCCESS !=
-                (errRet = parseType(eip712Types, typeType, encSubTypeStr))) {
-              return errRet;
+
+            char typeNoArrTok[MAX_TYPESTRING] = {0};
+            // need to get typehash of type first
+            if (']' == typeType[strlen(typeType) - 1]) {
+              // array of structs. To parse name, remove array tokens.
+              if (value_type != JSON_ARRAY) return GENERAL_ERROR;
+              strncpy(typeNoArrTok, typeType, sizeof(typeNoArrTok) - 1);
+              if (strlen(typeNoArrTok) < strlen(typeType)) {
+                return UDEF_ARRAY_NAME_ERR;
+              }
+              strtok(typeNoArrTok, "[");
+              if (STACK_GOOD != (errRet = memcheck(STACK_SIZE_GUARD))) {
+                return errRet;
+              }
+              if (SUCCESS != (errRet = parseType(eip712Types, typeNoArrTok,
+                                                 encSubTypeStr))) {
+                return errRet;
+              }
+            } else {
+              if (STACK_GOOD != (errRet = memcheck(STACK_SIZE_GUARD))) {
+                return errRet;
+              }
+              if (SUCCESS !=
+                  (errRet = parseType(eip712Types, typeType, encSubTypeStr))) {
+                return errRet;
+              }
             }
-          }
-          sha3_256_Init(&valCtx);
-          sha3_Update(&valCtx, (const unsigned char*)encSubTypeStr,
-                      (size_t)strlen(encSubTypeStr));
-          keccak_Final(&valCtx, encBytes);
+            sha3_256_Init(&valCtx);
+            sha3_Update(&valCtx, (const unsigned char*)encSubTypeStr,
+                        (size_t)strlen(encSubTypeStr));
+            keccak_Final(&valCtx, encBytes);
 
-          if (']' == typeType[strlen(typeType) - 1]) {
-            // array of udefs
-            struct SHA3_CTX eleCtx = {0};  // local hash context
-            struct SHA3_CTX arrCtx = {0};  // array elements hash context
-            uint8_t eleHashBytes[32];
+            if (']' == typeType[strlen(typeType) - 1]) {
+              // array of udefs
+              struct SHA3_CTX eleCtx = {0};  // local hash context
+              struct SHA3_CTX arrCtx = {0};  // array elements hash context
+              uint8_t eleHashBytes[32];
 
-            sha3_256_Init(&arrCtx);
+              sha3_256_Init(&arrCtx);
 
-            json_t const* udefVals = json_getChild(walkVals);
-            while (0 != udefVals) {
-              sha3_256_Init(&eleCtx);
-              sha3_Update(&eleCtx, (const unsigned char*)encBytes, 32);
+              json_t const* udefVals = json_getChild(walkVals);
+              while (0 != udefVals) {
+                if (json_getType(udefVals) != JSON_OBJ) return GENERAL_ERROR;
+                sha3_256_Init(&eleCtx);
+                sha3_Update(&eleCtx, (const unsigned char*)encBytes, 32);
+                if (STACK_GOOD != (errRet = memcheck(STACK_SIZE_GUARD))) {
+                  return errRet;
+                }
+                if (SUCCESS !=
+                    (errRet = parseVals(
+                         eip712Types,
+                         json_getProperty(eip712Types,
+                                          strtok(typeNoArrTok, "]")),
+                         json_getChild(udefVals),  // where to get the values
+                         &eleCtx  // encode hash happens in parse, this is the
+                                  // return
+                         ))) {
+                  return errRet;
+                }
+                keccak_Final(&eleCtx, eleHashBytes);
+                sha3_Update(&arrCtx, (const unsigned char*)eleHashBytes, 32);
+                // just walk the udef values assuming, for fixed sizes, all
+                // values are there.
+                udefVals = json_getSibling(udefVals);
+              }
+              keccak_Final(&arrCtx, encBytes);
+
+            } else {
+              if (value_type != JSON_OBJ) return GENERAL_ERROR;
+              sha3_256_Init(&valCtx);
+              sha3_Update(&valCtx, (const unsigned char*)encBytes,
+                          (size_t)sizeof(encBytes));
               if (STACK_GOOD != (errRet = memcheck(STACK_SIZE_GUARD))) {
                 return errRet;
               }
               if (SUCCESS !=
                   (errRet = parseVals(
-                       eip712Types,
-                       json_getProperty(eip712Types, strtok(typeNoArrTok, "]")),
-                       json_getChild(udefVals),  // where to get the values
-                       &eleCtx  // encode hash happens in parse, this is the
-                                // return
+                       eip712Types, json_getProperty(eip712Types, typeType),
+                       json_getChild(walkVals),  // where to get the values
+                       &valCtx  // val hash happens in parse, this is the return
                        ))) {
                 return errRet;
               }
-              keccak_Final(&eleCtx, eleHashBytes);
-              sha3_Update(&arrCtx, (const unsigned char*)eleHashBytes, 32);
-              // just walk the udef values assuming, for fixed sizes, all values
-              // are there.
-              udefVals = json_getSibling(udefVals);
+              keccak_Final(&valCtx, encBytes);
             }
-            keccak_Final(&arrCtx, encBytes);
-
-          } else {
-            sha3_256_Init(&valCtx);
-            sha3_Update(&valCtx, (const unsigned char*)encBytes,
-                        (size_t)sizeof(encBytes));
-            if (STACK_GOOD != (errRet = memcheck(STACK_SIZE_GUARD))) {
-              return errRet;
-            }
-            if (SUCCESS !=
-                (errRet = parseVals(
-                     eip712Types, json_getProperty(eip712Types, typeType),
-                     json_getChild(walkVals),  // where to get the values
-                     &valCtx  // val hash happens in parse, this is the return
-                     ))) {
-              return errRet;
-            }
-            keccak_Final(&valCtx, encBytes);
           }
         }
       }

--- a/lib/firmware/eip712.c
+++ b/lib/firmware/eip712.c
@@ -326,13 +326,11 @@ void marshallDsVals(const char* value) {
 
 int dsConfirm(void) {
   // First check if we recognize the contract
-  const TokenType* assetToken;
   uint8_t addrHexStr[20] = {0};
   char name[41] = {0};
   char version[11] = {0};
   uint32_t chainInt;
   bool noChain = true;
-  int ctr;
   IconType iconNum = NO_ICON;
   char title[64] = {0};
   char* fillerStr = "";
@@ -351,7 +349,7 @@ int dsConfirm(void) {
     // this before, and it was the firmware's only caller of newlib's scanf
     // engine — ~6KB of ROM on a part with none to spare.
     char byteStrBuf[3] = {0};
-    for (ctr = 2; ctr < 42; ctr += 2) {
+    for (int ctr = 2; ctr < 42; ctr += 2) {
       strncpy(byteStrBuf, (char*)&dsverifyingContract[ctr], 2);
       addrHexStr[(ctr - 2) / 2] = (uint8_t)strtol(byteStrBuf, NULL, 16);
     }
@@ -370,7 +368,8 @@ int dsConfirm(void) {
     // }
   }
   if (noChain == false && dsverifyingContract != NULL) {
-    assetToken = tokenByChainAddress(chainInt, (uint8_t*)addrHexStr);
+    const TokenType* assetToken =
+        tokenByChainAddress(chainInt, (uint8_t*)addrHexStr);
     (void)assetToken;
     fillerStr = "";
   }

--- a/lib/firmware/eip712.c
+++ b/lib/firmware/eip712.c
@@ -347,9 +347,13 @@ int dsConfirm(void) {
   }
 
   if (dsverifyingContract != NULL) {
+    // Same two-chars-then-strtol idiom as encAddress(). sscanf("%2hhx") did
+    // this before, and it was the firmware's only caller of newlib's scanf
+    // engine — ~6KB of ROM on a part with none to spare.
+    char byteStrBuf[3] = {0};
     for (ctr = 2; ctr < 42; ctr += 2) {
-      sscanf((char*)&dsverifyingContract[ctr], "%2hhx",
-             &addrHexStr[(ctr - 2) / 2]);
+      strncpy(byteStrBuf, (char*)&dsverifyingContract[ctr], 2);
+      addrHexStr[(ctr - 2) / 2] = (uint8_t)strtol(byteStrBuf, NULL, 16);
     }
     strcat(verifyingContract, "Verifying Contract: ");
     strncat(verifyingContract, dsverifyingContract,
@@ -358,11 +362,7 @@ int dsConfirm(void) {
 
   if (NULL != dschainId) {
     noChain = false;
-#ifdef EMULATOR
-    sscanf((char*)dschainId, "%u", &chainInt);
-#else
-    sscanf((char*)dschainId, "%ld", &chainInt);
-#endif
+    chainInt = (uint32_t)strtoul((const char*)dschainId, NULL, 10);
     // As more chains are supported, add icon choice below
     // TBD: not implemented for first release
     // if (chainInt == 1) {

--- a/lib/firmware/eos.c
+++ b/lib/firmware/eos.c
@@ -385,7 +385,7 @@ bool eos_compilePermissionLevel(const EosPermissionLevel* auth) {
 
 bool eos_hasActionUnknownDataRemaining(void) { return 0 < unknown_remaining; }
 
-static bool isSupportedAction(const EosActionCommon* common) {
+bool eos_isSupportedAction(const EosActionCommon* common) {
   if (common->account == EOS_eosio || common->account == EOS_eosio_token) {
     switch (common->name) {
       case EOS_Transfer:
@@ -402,15 +402,18 @@ static bool isSupportedAction(const EosActionCommon* common) {
       case EOS_DeleteAuth:
       case EOS_LinkAuth:
       case EOS_UnlinkAuth:
+      case EOS_NewAccount:
         return true;
     }
   }
   return false;
 }
 
+bool eos_unknownActionPolicyAllows(bool advanced_mode) { return advanced_mode; }
+
 bool eos_compileActionUnknown(const EosActionCommon* common,
                               const EosActionUnknown* action) {
-  if (isSupportedAction(common)) {
+  if (eos_isSupportedAction(common)) {
     fsm_sendFailure(
         FailureType_Failure_SyntaxError,
         "EosActionUnknown cannot be used with supported contract actions");
@@ -418,10 +421,15 @@ bool eos_compileActionUnknown(const EosActionCommon* common,
     return false;
   }
 
-  if (!storage_isPolicyEnabled("AdvancedMode")) {
-    (void)review(ButtonRequestType_ButtonRequest_Other, "Warning",
-                 "Signing of arbitrary EOS actions is recommended only for "
-                 "experienced users. Enable 'AdvancedMode' policy to dismiss.");
+  if (!eos_unknownActionPolicyAllows(storage_isPolicyEnabled("AdvancedMode"))) {
+    (void)review(ButtonRequestType_ButtonRequest_Other, "Blocked",
+                 "Arbitrary EOS actions require AdvancedMode. "
+                 "Enable in device settings.");
+    fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                    "Arbitrary EOS action signing disabled by policy");
+    eos_signingAbort();
+    layoutHome();
+    return false;
   }
 
   if (unknown_remaining == 0) {

--- a/lib/firmware/ethereum.c
+++ b/lib/firmware/ethereum.c
@@ -49,6 +49,14 @@
 
 #define _(X) (X)
 
+bool ethereum_typed_hash_policy_allows(bool advanced_mode) {
+  return advanced_mode;
+}
+
+bool ethereum_eip712_is_domain_primary_type(const char* primary_type) {
+  return primary_type && strcmp(primary_type, "EIP712Domain") == 0;
+}
+
 #define MAX_CHAIN_ID 2147483630
 
 #define ETHEREUM_TX_TYPE_LEGACY 0UL
@@ -1308,14 +1316,23 @@ void e712_types_values(Ethereum712TypesValues* msg,
       failMessage(JSON_PTYPENAMEERR);
       return;
     }
-    const char* primeType;
-    if (0 == (primeType = json_getValue(obTest))) {
+    if (json_getType(obTest) != JSON_TEXT) {
       failMessage(JSON_PTYPEVALERR);
       return;
     }
-    if (0 != strncmp(primeType, "EIP712Domain",
-                     strlen(primeType))) {  // if primaryType is "EIP712Domain",
-                                            // message hash is NULL
+    const char* primeType;
+    if (0 == (primeType = json_getValue(obTest)) || primeType[0] == '\0') {
+      failMessage(JSON_PTYPEVALERR);
+      return;
+    }
+    if (!confirm_bytes(ButtonRequestType_ButtonRequest_Other,
+                       "EIP-712 Primary Type", (const uint8_t*)primeType,
+                       strlen(primeType))) {
+      failMessage(USER_CANCELLED);
+      return;
+    }
+    if (!ethereum_eip712_is_domain_primary_type(
+            primeType)) {  // domain-only signatures have no message hash
       errRet = encode(jsonT, jsonV, primeType, resp->message_hash.bytes);
       if (!(SUCCESS == errRet || NULL_MSG_HASH == errRet)) {
         failMessage(errRet);

--- a/lib/firmware/ethereum_contracts/zxappliquid.c
+++ b/lib/firmware/ethereum_contracts/zxappliquid.c
@@ -7,114 +7,138 @@
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "keepkey/firmware/ethereum_contracts/zxappliquid.h"
 #include "keepkey/firmware/ethereum_contracts/zxliquidtx.h"
 
 #include "keepkey/board/confirm_sm.h"
+#include "keepkey/board/font.h"
+#include "keepkey/board/layout.h"
 #include "keepkey/board/util.h"
-#include "keepkey/firmware/app_confirm.h"
-#include "keepkey/firmware/coins.h"
 #include "keepkey/firmware/ethereum.h"
 #include "keepkey/firmware/ethereum_tokens.h"
-#include "keepkey/firmware/fsm.h"
-#include "keepkey/firmware/storage.h"
-#include "trezor/crypto/address.h"
-#include "trezor/crypto/bip32.h"
-#include "trezor/crypto/curves.h"
-#include "trezor/crypto/memzero.h"
+#include "trezor/crypto/bignum.h"
 #include "trezor/crypto/sha3.h"
 
-bool zx_confirmApproveLiquidity(uint32_t data_total,
-                                const EthereumSignTx *msg) {
-  /* reads selector + 2 32-byte words (spender, allowance) */
-  if (data_total != 4 + 2 * 32 || !msg->has_data_initial_chunk ||
-      msg->data_initial_chunk.size != 4 + 2 * 32 || !msg->has_to ||
-      msg->to.size != 20)
-    return false;
-  const char *to, *tikstr, *poolstr, *allowance, *amt;
-  unsigned char data[40];
-  uint8_t digest[SHA3_256_DIGEST_LENGTH] = {0};
-  uint8_t tokdigest[SHA3_256_DIGEST_LENGTH] = {0};
-  char digestStr[2 * SHA3_256_DIGEST_LENGTH + 1], amtStr[2 * 32 + 1] = {0};
-  int32_t ctr, tokctr;
-  uint32_t wethord;
-  const TokenType *WETH, *ttoken;
+#include <stdio.h>
+#include <string.h>
 
-  if (!tokenByTicker(msg->chain_id, "WETH", &WETH)) return false;
-  wethord = read_be((const uint8_t *)WETH->address);
-  to = (const char *)msg->to.bytes;
-  tokctr = 0;
-  while (tokctr != -1) {
-    ttoken = tokenIter(&tokctr);
+#define UNISWAP_APPROVE_CALL_SIZE (4 + 2 * 32)
+#define UNISWAP_AMOUNT_TEXT_SIZE 96
 
-    // https://uniswap.org/docs/v2/smart-contract-integration/getting-pair-addresses/
-    uint32_t ttokenord = read_be((const uint8_t *)ttoken->address);
-    if (ttokenord < wethord) {
-      memcpy(data, ttoken->address, 20);
-      memcpy(&data[20], WETH->address, 20);
-    } else {
-      memcpy(data, WETH->address, 20);
-      memcpy(&data[20], ttoken->address, 20);
-    }
-    keccak_256(data, sizeof(data), tokdigest);
-    SHA3_CTX ctx = {0};
-    keccak_256_Init(&ctx);
-    keccak_Update(&ctx, (unsigned char *)"\xff", 1);
-    keccak_Update(&ctx, (unsigned char *)"\x5C\x69\xbE\xe7\x01\xef\x81\x4a\x2B\x6a\x3E\xDD\x4B\x16\x52\xCB\x9c\xc5\xaA\x6f", 20);
-    keccak_Update(&ctx, tokdigest, sizeof(tokdigest));
-    keccak_Update(&ctx, (unsigned char *)"\x96\xe8\xac\x42\x77\x19\x8f\xf8\xb6\xf7\x85\x47\x8a\xa9\xa3\x9f\x40\x3c\xb7\x68\xdd\x02\xcb\xee\x32\x6c\x3e\x7d\xa3\x48\x84\x5f", 32);
-    keccak_Final(&ctx, digest);
-    if (memcmp(to, &digest[12], 20) == 0) break;
+static const uint8_t UNISWAP_FACTORY_ADDRESS[20] = {
+    0x5c, 0x69, 0xbe, 0xe7, 0x01, 0xef, 0x81, 0x4a, 0x2b, 0x6a,
+    0x3e, 0xdd, 0x4b, 0x16, 0x52, 0xcb, 0x9c, 0xc5, 0xaa, 0x6f};
+static const uint8_t UNISWAP_PAIR_INIT_CODE_HASH[32] = {
+    0x96, 0xe8, 0xac, 0x42, 0x77, 0x19, 0x8f, 0xf8, 0xb6, 0xf7, 0x85,
+    0x47, 0x8a, 0xa9, 0xa3, 0x9f, 0x40, 0x3c, 0xb7, 0x68, 0xdd, 0x02,
+    0xcb, 0xee, 0x32, 0x6c, 0x3e, 0x7d, 0xa3, 0x48, 0x84, 0x5f};
+static const uint8_t WETH_MAINNET_ADDRESS[20] = {
+    0xc0, 0x2a, 0xaa, 0x39, 0xb2, 0x23, 0xfe, 0x8d, 0x0a, 0x0e,
+    0x5c, 0x4f, 0x27, 0xea, 0xd9, 0x08, 0x3c, 0x75, 0x6c, 0xc2};
+
+static bool tx_value_is_zero(const EthereumSignTx* msg) {
+  if (!msg->has_value && msg->value.size != 0) return false;
+  for (size_t i = 0; i < msg->value.size; i++) {
+    if (msg->value.bytes[i] != 0) return false;
   }
-
-  if (tokctr != -1) {
-    for (ctr = 0; ctr < SHA3_256_DIGEST_LENGTH; ctr++) {
-      snprintf(&digestStr[ctr * 2], 3, "%02x", digest[ctr]);
-    }
-    tikstr = ttoken->ticker;
-    poolstr = &digestStr[12 * 2];
-  } else {
-    for (ctr = 0; ctr < 20; ctr++) {
-      snprintf(&digestStr[ctr * 2], 3, "%02x", to[ctr]);
-    }
-    tikstr = "";
-    poolstr = digestStr;
-  }
-
-  allowance = (char *)(msg->data_initial_chunk.bytes + 4 + 32);
-  if (memcmp(allowance, (uint8_t *)&MAX_ALLOWANCE, 32) == 0) {
-    amt = "full balance";
-  } else {
-    for (ctr = 0; ctr < 32; ctr++) {
-      snprintf(&amtStr[ctr * 2], 3, "%02x", allowance[ctr]);
-    }
-    amt = amtStr;
-  }
-
-  const char *appStr = "uniswap approve liquidity";
-  return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, appStr,
-                 "Amount: %s", amt) &&
-         confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, appStr,
-                 "approve for pool %s %s", tikstr, poolstr);
+  return true;
 }
 
-bool zx_isZxApproveLiquid(const EthereumSignTx *msg) {
-  if (!msg->has_to || msg->to.size != 20 || !msg->has_data_initial_chunk ||
-      msg->data_initial_chunk.size != 4 + 2 * 32)
+static bool spender_word_is_router(const EthereumSignTx* msg) {
+  const uint8_t* word = msg->data_initial_chunk.bytes + 4;
+  for (size_t i = 0; i < 12; i++) {
+    if (word[i] != 0) return false;
+  }
+  return memcmp(word + 12, UNISWAP_ROUTER_ADDRESS, 20) == 0;
+}
+
+static void derive_pair_address(const uint8_t* token_a, const uint8_t* token_b,
+                                uint8_t pair[20]) {
+  uint8_t ordered[40];
+  if (memcmp(token_a, token_b, 20) < 0) {
+    memcpy(ordered, token_a, 20);
+    memcpy(ordered + 20, token_b, 20);
+  } else {
+    memcpy(ordered, token_b, 20);
+    memcpy(ordered + 20, token_a, 20);
+  }
+
+  uint8_t salt[SHA3_256_DIGEST_LENGTH];
+  uint8_t digest[SHA3_256_DIGEST_LENGTH];
+  keccak_256(ordered, sizeof(ordered), salt);
+  SHA3_CTX ctx = {0};
+  keccak_256_Init(&ctx);
+  const uint8_t prefix = 0xff;
+  keccak_Update(&ctx, &prefix, 1);
+  keccak_Update(&ctx, UNISWAP_FACTORY_ADDRESS, sizeof(UNISWAP_FACTORY_ADDRESS));
+  keccak_Update(&ctx, salt, sizeof(salt));
+  keccak_Update(&ctx, UNISWAP_PAIR_INIT_CODE_HASH,
+                sizeof(UNISWAP_PAIR_INIT_CODE_HASH));
+  keccak_Final(&ctx, digest);
+  memcpy(pair, digest + 12, 20);
+}
+
+static const TokenType* pool_underlying_token(const EthereumSignTx* msg) {
+  int32_t token_index = 0;
+  while (token_index >= 0) {
+    const TokenType* token = tokenIter(&token_index);
+    if (token == UnknownToken) break;
+    if (token->chain_id != 1 ||
+        memcmp(token->address, WETH_MAINNET_ADDRESS, 20) == 0)
+      continue;
+    uint8_t pair[20];
+    derive_pair_address((const uint8_t*)token->address, WETH_MAINNET_ADDRESS,
+                        pair);
+    if (memcmp(msg->to.bytes, pair, 20) == 0) return token;
+  }
+  return NULL;
+}
+
+static bool approve_shape_is_clear_signable(const EthereumSignTx* msg) {
+  if (!msg->has_chain_id || msg->chain_id != 1 || !msg->has_to ||
+      msg->to.size != 20 || !msg->has_data_initial_chunk ||
+      msg->data_initial_chunk.size != UNISWAP_APPROVE_CALL_SIZE ||
+      memcmp(msg->data_initial_chunk.bytes, "\x09\x5e\xa7\xb3", 4) != 0 ||
+      msg->value.size > 32 || !tx_value_is_zero(msg) ||
+      !spender_word_is_router(msg))
     return false;
-  if (memcmp(msg->data_initial_chunk.bytes, "\x09\x5e\xa7\xb3", 4) == 0)
-    if (memcmp((uint8_t *)(msg->data_initial_chunk.bytes + 4 + 32 - 20),
-               UNISWAP_ROUTER_ADDRESS, 20) == 0)
-      return true;
-  return false;
+  return pool_underlying_token(msg) != NULL;
+}
+
+bool zx_confirmApproveLiquidity(uint32_t data_total,
+                                const EthereumSignTx* msg) {
+  if (data_total != UNISWAP_APPROVE_CALL_SIZE ||
+      !approve_shape_is_clear_signable(msg))
+    return false;
+
+  const TokenType* token = pool_underlying_token(msg);
+  const uint8_t* allowance = msg->data_initial_chunk.bytes + 4 + 32;
+  char amount_text[UNISWAP_AMOUNT_TEXT_SIZE];
+  if (memcmp(allowance, (const uint8_t*)MAX_ALLOWANCE, 32) == 0) {
+    strlcpy(amount_text, "full LP balance", sizeof(amount_text));
+  } else {
+    bignum256 amount;
+    bn_from_bytes(allowance, 32, &amount);
+    if (bn_format(&amount, NULL, " LP", 18, 0, false, amount_text,
+                  sizeof(amount_text)) == 0 ||
+        calc_str_line(get_body_font(), amount_text, BODY_WIDTH) > BODY_ROWS)
+      return false;
+  }
+
+  if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+               "Uniswap LP Approval", "%s", amount_text))
+    return false;
+
+  char pair_text[43] = {'0', 'x', '\0'};
+  for (size_t i = 0; i < 20; i++) {
+    snprintf(pair_text + 2 + i * 2, 3, "%02x", msg->to.bytes[i]);
+  }
+  return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                 "Uniswap LP Pool", "%s\n%s", token->ticker, pair_text);
+}
+
+bool zx_isZxApproveLiquid(const EthereumSignTx* msg) {
+  return approve_shape_is_clear_signable(msg);
 }

--- a/lib/firmware/ethereum_contracts/zxappliquid.c
+++ b/lib/firmware/ethereum_contracts/zxappliquid.c
@@ -37,7 +37,10 @@
 bool zx_confirmApproveLiquidity(uint32_t data_total,
                                 const EthereumSignTx *msg) {
   /* reads selector + 2 32-byte words (spender, allowance) */
-  if (data_total < 4 + 2 * 32) return false;
+  if (data_total != 4 + 2 * 32 || !msg->has_data_initial_chunk ||
+      msg->data_initial_chunk.size != 4 + 2 * 32 || !msg->has_to ||
+      msg->to.size != 20)
+    return false;
   const char *to, *tikstr, *poolstr, *allowance, *amt;
   unsigned char data[40];
   uint8_t digest[SHA3_256_DIGEST_LENGTH] = {0};
@@ -99,14 +102,16 @@ bool zx_confirmApproveLiquidity(uint32_t data_total,
   }
 
   const char *appStr = "uniswap approve liquidity";
-  confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, appStr, "Amount: %s",
-          amt);
-  confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, appStr,
-          "approve for pool %s %s", tikstr, poolstr);
-  return true;
+  return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, appStr,
+                 "Amount: %s", amt) &&
+         confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, appStr,
+                 "approve for pool %s %s", tikstr, poolstr);
 }
 
 bool zx_isZxApproveLiquid(const EthereumSignTx *msg) {
+  if (!msg->has_to || msg->to.size != 20 || !msg->has_data_initial_chunk ||
+      msg->data_initial_chunk.size != 4 + 2 * 32)
+    return false;
   if (memcmp(msg->data_initial_chunk.bytes, "\x09\x5e\xa7\xb3", 4) == 0)
     if (memcmp((uint8_t *)(msg->data_initial_chunk.bytes + 4 + 32 - 20),
                UNISWAP_ROUTER_ADDRESS, 20) == 0)

--- a/lib/firmware/ethereum_contracts/zxliquidtx.c
+++ b/lib/firmware/ethereum_contracts/zxliquidtx.c
@@ -64,6 +64,7 @@ static HDNode* zx_getDerivedNode(const char* curve, const uint32_t* address_n,
 }
 
 static bool isAddLiquidityEthCall(const EthereumSignTx* msg) {
+  if (msg->data_initial_chunk.size < 4) return false;
   if (memcmp(msg->data_initial_chunk.bytes, "\xf3\x05\xd7\x19", 4) == 0)
     return true;
 
@@ -71,6 +72,7 @@ static bool isAddLiquidityEthCall(const EthereumSignTx* msg) {
 }
 
 static bool isRemoveLiquidityEthCall(const EthereumSignTx* msg) {
+  if (msg->data_initial_chunk.size < 4) return false;
   if (memcmp(msg->data_initial_chunk.bytes, "\x02\x75\x1c\xec", 4) == 0)
     return true;
 
@@ -93,6 +95,7 @@ static bool confirmFromAccountMatch(const EthereumSignTx* msg,
     memzero(node, sizeof(*node));
     return false;
   }
+  memzero(node, sizeof(*node));
 
   fromAddress =
       (const uint8_t*)(msg->data_initial_chunk.bytes + 4 + 5 * 32 - 20);
@@ -120,6 +123,9 @@ static bool confirmFromAccountMatch(const EthereumSignTx* msg,
 }
 
 bool zx_isZxLiquidTx(const EthereumSignTx* msg) {
+  if (!msg->has_to || msg->to.size != 20 || !msg->has_data_initial_chunk ||
+      msg->data_initial_chunk.size != 4 + 6 * 32)
+    return false;
   if (memcmp(msg->to.bytes, UNISWAP_ROUTER_ADDRESS, 20) ==
       0) {  // correct contract address?
 
@@ -132,7 +138,10 @@ bool zx_isZxLiquidTx(const EthereumSignTx* msg) {
 
 bool zx_confirmZxLiquidTx(uint32_t data_total, const EthereumSignTx* msg) {
   /* reads through the deadline word at offset 4 + 6*32 - 8 .. 4 + 6*32 */
-  if (data_total < 4 + 6 * 32) return false;
+  if (data_total != 4 + 6 * 32 || !msg->has_data_initial_chunk ||
+      msg->data_initial_chunk.size != 4 + 6 * 32 || !msg->has_to ||
+      msg->to.size != 20 || msg->value.size > 32)
+    return false;
   const TokenType* token;
   char constr1[40], constr2[40], tokbuf[32];
   const char* arStr = "";
@@ -150,6 +159,7 @@ bool zx_confirmZxLiquidTx(uint32_t data_total, const EthereumSignTx* msg) {
 
   tokenAddress = (const uint8_t*)(msg->data_initial_chunk.bytes + 4 + 32 - 20);
   token = tokenByChainAddress(msg->chain_id, tokenAddress);
+  if (token == UnknownToken) return false;
   deadlineBytes =
       (const uint8_t*)(msg->data_initial_chunk.bytes + 4 + 6 * 32 - 8);
   deadline = ((uint64_t)deadlineBytes[0] << 8 * 7) |
@@ -169,10 +179,23 @@ bool zx_confirmZxLiquidTx(uint32_t data_total, const EthereumSignTx* msg) {
                 &Amount);  // token min amount
   ethereumFormatAmount(&Amount, token, msg->chain_id, tokbuf, sizeof(tokbuf));
   snprintf(constr2, 32, "%s", tokbuf);
-  confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, arStr,
-          "%s\nMinimum %s", constr1, constr2);
+  if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, arStr,
+               "%s\nMinimum %s", constr1, constr2))
+    return false;
   if (!confirmFromAccountMatch(msg, arStr)) {
     return false;
+  }
+
+  if (isAddLiquidityEthCall(msg)) {
+    bn_from_bytes(msg->value.bytes, msg->value.size, &Amount);
+    ethereumFormatAmount(&Amount, NULL, msg->chain_id, tokbuf, sizeof(tokbuf));
+    if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, arStr,
+                 "Native amount\n%s", tokbuf))
+      return false;
+  } else {
+    for (size_t i = 0; i < msg->value.size; i++) {
+      if (msg->value.bytes[i] != 0) return false;
+    }
   }
 
   bn_from_bytes(msg->data_initial_chunk.bytes + 4 + 3 * 32, 32,
@@ -180,11 +203,15 @@ bool zx_confirmZxLiquidTx(uint32_t data_total, const EthereumSignTx* msg) {
   ethereumFormatAmount(&Amount, NULL, msg->chain_id, tokbuf, sizeof(tokbuf));
 
   snprintf(constr1, 32, "%s", tokbuf);
-  confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, arStr, "Minimum %s",
-          constr1);
+  if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, arStr,
+               "Minimum %s", constr1))
+    return false;
 
-  confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, arStr, "Deadline %s",
-          ctime((const time_t*)&deadline));
+  char deadline_str[24];
+  snprintf(deadline_str, sizeof(deadline_str), "%" PRIu64, deadline);
+  if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, arStr,
+               "Deadline (Unix)\n%s", deadline_str))
+    return false;
 
   return true;
 }

--- a/lib/firmware/ethereum_contracts/zxliquidtx.c
+++ b/lib/firmware/ethereum_contracts/zxliquidtx.c
@@ -20,198 +20,200 @@
 #include "keepkey/firmware/ethereum_contracts/zxliquidtx.h"
 
 #include "keepkey/board/confirm_sm.h"
-#include "keepkey/board/util.h"
-#include "keepkey/firmware/app_confirm.h"
-#include "keepkey/firmware/coins.h"
+#include "keepkey/board/font.h"
+#include "keepkey/board/layout.h"
 #include "keepkey/firmware/ethereum.h"
 #include "keepkey/firmware/ethereum_tokens.h"
-#include "keepkey/firmware/fsm.h"
 #include "keepkey/firmware/storage.h"
 #include "trezor/crypto/address.h"
+#include "trezor/crypto/bignum.h"
 #include "trezor/crypto/bip32.h"
 #include "trezor/crypto/curves.h"
 #include "trezor/crypto/memzero.h"
-#include "trezor/crypto/sha3.h"
 
-#include <time.h>
+#include <stdio.h>
+#include <string.h>
+
+#define UNISWAP_LIQUIDITY_CALL_SIZE (4 + 6 * 32)
+#define UNISWAP_TOKEN_WORD 0
+#define UNISWAP_PRIMARY_AMOUNT_WORD 1
+#define UNISWAP_TOKEN_MIN_WORD 2
+#define UNISWAP_NATIVE_MIN_WORD 3
+#define UNISWAP_RECIPIENT_WORD 4
+#define UNISWAP_DEADLINE_WORD 5
+#define UNISWAP_AMOUNT_TEXT_SIZE 96
+
+static const uint8_t* abi_word(const EthereumSignTx* msg, size_t word) {
+  return msg->data_initial_chunk.bytes + 4 + word * 32;
+}
+
+static bool abi_address_is_canonical(const uint8_t* word) {
+  for (size_t i = 0; i < 12; i++) {
+    if (word[i] != 0) return false;
+  }
+  return true;
+}
+
+static bool uint256_fits_u64(const uint8_t* word) {
+  for (size_t i = 0; i < 24; i++) {
+    if (word[i] != 0) return false;
+  }
+  return true;
+}
+
+static bool tx_value_is_zero(const EthereumSignTx* msg) {
+  if (!msg->has_value && msg->value.size != 0) return false;
+  for (size_t i = 0; i < msg->value.size; i++) {
+    if (msg->value.bytes[i] != 0) return false;
+  }
+  return true;
+}
+
+static bool isAddLiquidityEthCall(const EthereumSignTx* msg) {
+  return memcmp(msg->data_initial_chunk.bytes, "\xf3\x05\xd7\x19", 4) == 0;
+}
+
+static bool isRemoveLiquidityEthCall(const EthereumSignTx* msg) {
+  return memcmp(msg->data_initial_chunk.bytes, "\x02\x75\x1c\xec", 4) == 0;
+}
+
+static const TokenType* liquidity_token(const EthereumSignTx* msg) {
+  const uint8_t* token_address = abi_word(msg, UNISWAP_TOKEN_WORD) + 12;
+  const TokenType* token = tokenByChainAddress(1, token_address);
+  return token == UnknownToken ? NULL : token;
+}
+
+static bool liquidity_shape_is_clear_signable(const EthereumSignTx* msg) {
+  if (!msg->has_chain_id || msg->chain_id != 1 || !msg->has_to ||
+      msg->to.size != 20 ||
+      memcmp(msg->to.bytes, UNISWAP_ROUTER_ADDRESS, 20) != 0 ||
+      !msg->has_data_initial_chunk ||
+      msg->data_initial_chunk.size != UNISWAP_LIQUIDITY_CALL_SIZE ||
+      msg->value.size > 32 || (!msg->has_value && msg->value.size != 0))
+    return false;
+
+  if (!isAddLiquidityEthCall(msg) && !isRemoveLiquidityEthCall(msg))
+    return false;
+  if (!abi_address_is_canonical(abi_word(msg, UNISWAP_TOKEN_WORD)) ||
+      !abi_address_is_canonical(abi_word(msg, UNISWAP_RECIPIENT_WORD)) ||
+      !uint256_fits_u64(abi_word(msg, UNISWAP_DEADLINE_WORD)))
+    return false;
+  if (liquidity_token(msg) == NULL) return false;
+  if (isRemoveLiquidityEthCall(msg) && !tx_value_is_zero(msg)) return false;
+  return true;
+}
+
+static bool format_amount(const bignum256* amount, const char* suffix,
+                          unsigned int decimals, char* out, size_t out_len) {
+  if (bn_format(amount, NULL, suffix, decimals, 0, false, out, out_len) == 0)
+    return false;
+  return calc_str_line(get_body_font(), out, BODY_WIDTH) <= BODY_ROWS;
+}
+
+bool zx_formatZxLiquidityPrimaryAmount(const EthereumSignTx* msg, char* out,
+                                       size_t out_len) {
+  if (!out || out_len == 0 || !liquidity_shape_is_clear_signable(msg))
+    return false;
+
+  bignum256 amount;
+  bn_from_bytes(abi_word(msg, UNISWAP_PRIMARY_AMOUNT_WORD), 32, &amount);
+  if (isAddLiquidityEthCall(msg)) {
+    const TokenType* token = liquidity_token(msg);
+    return format_amount(&amount, token->ticker, token->decimals, out, out_len);
+  }
+  return format_amount(&amount, " LP", 18, out, out_len);
+}
 
 static HDNode* zx_getDerivedNode(const char* curve, const uint32_t* address_n,
                                  size_t address_n_count,
                                  uint32_t* fingerprint) {
   static HDNode CONFIDENTIAL node;
-  if (fingerprint) {
-    *fingerprint = 0;
-  }
-
-  if (!get_curve_by_name(curve)) {
-    return 0;
-  }
-
-  if (!storage_getRootNode(curve, true, &node)) {
-    return 0;
-  }
-
-  if (!address_n || address_n_count == 0) {
-    return &node;
-  }
-
+  if (fingerprint) *fingerprint = 0;
+  if (!get_curve_by_name(curve)) return NULL;
+  if (!storage_getRootNode(curve, true, &node)) return NULL;
+  if (!address_n || address_n_count == 0) return &node;
   if (hdnode_private_ckd_cached(&node, address_n, address_n_count,
-                                fingerprint) == 0) {
-    return 0;
-  }
-
+                                fingerprint) == 0)
+    return NULL;
   return &node;
 }
 
-static bool isAddLiquidityEthCall(const EthereumSignTx* msg) {
-  if (msg->data_initial_chunk.size < 4) return false;
-  if (memcmp(msg->data_initial_chunk.bytes, "\xf3\x05\xd7\x19", 4) == 0)
-    return true;
-
-  return false;
-}
-
-static bool isRemoveLiquidityEthCall(const EthereumSignTx* msg) {
-  if (msg->data_initial_chunk.size < 4) return false;
-  if (memcmp(msg->data_initial_chunk.bytes, "\x02\x75\x1c\xec", 4) == 0)
-    return true;
-
-  return false;
-}
-
-static bool confirmFromAccountMatch(const EthereumSignTx* msg,
-                                    const char* addremStr) {
-  // Determine withdrawal address
-  char addressStr[43] = {'0', 'x', '\0'};
-  const char* fromSrc;
-  const uint8_t* fromAddress;
-  uint8_t addressBytes[20];
+static bool confirmFromAccountMatch(const EthereumSignTx* msg) {
+  char address_str[43] = {'0', 'x', '\0'};
+  uint8_t address_bytes[20];
 
   HDNode* node = zx_getDerivedNode(SECP256K1_NAME, msg->address_n,
                                    msg->address_n_count, NULL);
   if (!node) return false;
-
-  if (!hdnode_get_ethereum_pubkeyhash(node, addressBytes)) {
+  if (!hdnode_get_ethereum_pubkeyhash(node, address_bytes)) {
     memzero(node, sizeof(*node));
     return false;
   }
   memzero(node, sizeof(*node));
 
-  fromAddress =
-      (const uint8_t*)(msg->data_initial_chunk.bytes + 4 + 5 * 32 - 20);
-
-  bool isSelf = (memcmp(fromAddress, addressBytes, 20) == 0);
-  fromSrc = isSelf ? "this wallet" : "NOT this wallet";
-
-  for (uint32_t ctr = 0; ctr < 20; ctr++) {
-    snprintf(&addressStr[2 + ctr * 2], 3, "%02x", fromAddress[ctr]);
+  const uint8_t* recipient = abi_word(msg, UNISWAP_RECIPIENT_WORD) + 12;
+  bool is_self = memcmp(recipient, address_bytes, 20) == 0;
+  for (uint32_t i = 0; i < 20; i++) {
+    snprintf(&address_str[2 + i * 2], 3, "%02x", recipient[i]);
   }
 
-  if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, addremStr,
-               "Liquidity recipient is %s: %s", fromSrc, addressStr)) {
+  if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+               "Uniswap Recipient", "%s\n%s",
+               is_self ? "this wallet" : "NOT this wallet", address_str))
     return false;
-  }
-
-  /* Fail closed: the liquidity/LP recipient (the `to` parameter) must be the
-   * signer's own address. Previously a non-self recipient only produced a soft
-   * "NOT this wallet" warning that the user could click through, letting LP
-   * tokens / withdrawn ETH be routed to an attacker. */
-  if (!isSelf) {
-    return false;
-  }
-  return true;
+  return is_self;
 }
 
 bool zx_isZxLiquidTx(const EthereumSignTx* msg) {
-  if (!msg->has_to || msg->to.size != 20 || !msg->has_data_initial_chunk ||
-      msg->data_initial_chunk.size != 4 + 6 * 32)
-    return false;
-  if (memcmp(msg->to.bytes, UNISWAP_ROUTER_ADDRESS, 20) ==
-      0) {  // correct contract address?
-
-    if (isAddLiquidityEthCall(msg)) return true;
-
-    if (isRemoveLiquidityEthCall(msg)) return true;
-  }
-  return false;
+  return liquidity_shape_is_clear_signable(msg);
 }
 
 bool zx_confirmZxLiquidTx(uint32_t data_total, const EthereumSignTx* msg) {
-  /* reads through the deadline word at offset 4 + 6*32 - 8 .. 4 + 6*32 */
-  if (data_total != 4 + 6 * 32 || !msg->has_data_initial_chunk ||
-      msg->data_initial_chunk.size != 4 + 6 * 32 || !msg->has_to ||
-      msg->to.size != 20 || msg->value.size > 32)
+  if (data_total != UNISWAP_LIQUIDITY_CALL_SIZE ||
+      !liquidity_shape_is_clear_signable(msg))
     return false;
-  const TokenType* token;
-  char constr1[40], constr2[40], tokbuf[32];
-  const char* arStr = "";
-  const uint8_t *tokenAddress, *deadlineBytes;
-  bignum256 Amount;
-  uint64_t deadline;
+
+  const TokenType* token = liquidity_token(msg);
+  bignum256 amount;
+  char amount_text[UNISWAP_AMOUNT_TEXT_SIZE];
+
+  if (!zx_formatZxLiquidityPrimaryAmount(msg, amount_text,
+                                         sizeof(amount_text)) ||
+      !confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+               isAddLiquidityEthCall(msg) ? "Uniswap Token" : "Uniswap LP Burn",
+               "%s", amount_text))
+    return false;
+
+  bn_from_bytes(abi_word(msg, UNISWAP_TOKEN_MIN_WORD), 32, &amount);
+  if (!format_amount(&amount, token->ticker, token->decimals, amount_text,
+                     sizeof(amount_text)) ||
+      !confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+               "Uniswap Token Min", "%s", amount_text))
+    return false;
+
+  if (!confirmFromAccountMatch(msg)) return false;
 
   if (isAddLiquidityEthCall(msg)) {
-    arStr = "uniswap add liquidity";
-  } else if (isRemoveLiquidityEthCall(msg)) {
-    arStr = "uniswap remove liquidity";
-  } else {
-    return false;
-  }
-
-  tokenAddress = (const uint8_t*)(msg->data_initial_chunk.bytes + 4 + 32 - 20);
-  token = tokenByChainAddress(msg->chain_id, tokenAddress);
-  if (token == UnknownToken) return false;
-  deadlineBytes =
-      (const uint8_t*)(msg->data_initial_chunk.bytes + 4 + 6 * 32 - 8);
-  deadline = ((uint64_t)deadlineBytes[0] << 8 * 7) |
-             ((uint64_t)deadlineBytes[1] << 8 * 6) |
-             ((uint64_t)deadlineBytes[2] << 8 * 5) |
-             ((uint64_t)deadlineBytes[3] << 8 * 4) |
-             ((uint64_t)deadlineBytes[4] << 8 * 3) |
-             ((uint64_t)deadlineBytes[5] << 8 * 2) |
-             ((uint64_t)deadlineBytes[6] << 8 * 1) |
-             ((uint64_t)deadlineBytes[7]);
-
-  bn_from_bytes(msg->data_initial_chunk.bytes + 4 + 32, 32,
-                &Amount);  // token amount
-  ethereumFormatAmount(&Amount, token, msg->chain_id, tokbuf, sizeof(tokbuf));
-  snprintf(constr1, 32, "%s", tokbuf);
-  bn_from_bytes(msg->data_initial_chunk.bytes + 4 + 2 * 32, 32,
-                &Amount);  // token min amount
-  ethereumFormatAmount(&Amount, token, msg->chain_id, tokbuf, sizeof(tokbuf));
-  snprintf(constr2, 32, "%s", tokbuf);
-  if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, arStr,
-               "%s\nMinimum %s", constr1, constr2))
-    return false;
-  if (!confirmFromAccountMatch(msg, arStr)) {
-    return false;
-  }
-
-  if (isAddLiquidityEthCall(msg)) {
-    bn_from_bytes(msg->value.bytes, msg->value.size, &Amount);
-    ethereumFormatAmount(&Amount, NULL, msg->chain_id, tokbuf, sizeof(tokbuf));
-    if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, arStr,
-                 "Native amount\n%s", tokbuf))
+    bn_from_bytes(msg->value.bytes, msg->value.size, &amount);
+    if (!format_amount(&amount, " ETH", 18, amount_text, sizeof(amount_text)) ||
+        !confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, "Uniswap ETH",
+                 "%s", amount_text))
       return false;
-  } else {
-    for (size_t i = 0; i < msg->value.size; i++) {
-      if (msg->value.bytes[i] != 0) return false;
-    }
   }
 
-  bn_from_bytes(msg->data_initial_chunk.bytes + 4 + 3 * 32, 32,
-                &Amount);  // eth min amount
-  ethereumFormatAmount(&Amount, NULL, msg->chain_id, tokbuf, sizeof(tokbuf));
-
-  snprintf(constr1, 32, "%s", tokbuf);
-  if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, arStr,
-               "Minimum %s", constr1))
+  bn_from_bytes(abi_word(msg, UNISWAP_NATIVE_MIN_WORD), 32, &amount);
+  if (!format_amount(&amount, " ETH", 18, amount_text, sizeof(amount_text)) ||
+      !confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, "Uniswap ETH Min",
+               "%s", amount_text))
     return false;
 
-  char deadline_str[24];
-  snprintf(deadline_str, sizeof(deadline_str), "%" PRIu64, deadline);
-  if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, arStr,
-               "Deadline (Unix)\n%s", deadline_str))
-    return false;
-
-  return true;
+  const uint8_t* deadline_word = abi_word(msg, UNISWAP_DEADLINE_WORD);
+  uint64_t deadline = 0;
+  for (size_t i = 24; i < 32; i++) {
+    deadline = (deadline << 8) | deadline_word[i];
+  }
+  char deadline_text[21];
+  snprintf(deadline_text, sizeof(deadline_text), "%" PRIu64, deadline);
+  return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                 "Uniswap Deadline", "%s", deadline_text);
 }

--- a/lib/firmware/fsm_msg_binance.h
+++ b/lib/firmware/fsm_msg_binance.h
@@ -95,30 +95,38 @@ static void binance_response(void);
 
 void fsm_msgBinanceTransferMsg(const BinanceTransferMsg* msg) {
   CHECK_PARAM(binance_signingIsInited(), "Signing not in progress?");
-  CHECK_PARAM(msg->inputs_count == 1, "Malformed BinanceTransferMsg")
-  CHECK_PARAM(msg->inputs[0].coins_count == 1, "Malformed BinanceTransferMsg")
-  CHECK_PARAM(msg->outputs_count == 1, "Malformed BinanceTransferMsg")
-  CHECK_PARAM(msg->outputs[0].coins_count == 1, "Malformed BinanceTransferMsg")
-  CHECK_PARAM(msg->inputs[0].coins[0].amount == msg->outputs[0].coins[0].amount,
-              "Malformed BinanceTransferMsg")
-  CHECK_PARAM(strcmp(msg->inputs[0].coins[0].denom,
-                     msg->outputs[0].coins[0].denom) == 0,
-              "Malformed BinanceTransferMsg")
+  if (!binance_validateTransfer(msg)) {
+    binance_signAbort();
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    "Malformed BinanceTransferMsg");
+    layoutHome();
+    return;
+  }
 
   const CoinType* coin = fsm_getCoin(true, "Binance");
   if (!coin) {
+    binance_signAbort();
+    layoutHome();
     return;
   }
 
   switch (msg->outputs[0].address_type) {
     case OutputAddressType_TRANSFER:
     default: {
-      char amount_str[42];
-      char denom_str[14];
-      snprintf(denom_str, strlen(msg->outputs[0].coins[0].denom) + 2, " %s",
-               msg->outputs[0].coins[0].denom);
-      bn_format_uint64(msg->outputs[0].coins[0].amount, NULL, denom_str, 8, 0,
-                       false, amount_str, sizeof(amount_str));
+      char amount_str[64];
+      char denom_str[BINANCE_MAX_DENOM_LEN + 2];
+      const int denom_len = snprintf(denom_str, sizeof(denom_str), " %s",
+                                     msg->outputs[0].coins[0].denom);
+      if (denom_len <= 0 || (size_t)denom_len >= sizeof(denom_str) ||
+          !bn_format_uint64((uint64_t)msg->outputs[0].coins[0].amount, NULL,
+                            denom_str, 8, 0, false, amount_str,
+                            sizeof(amount_str))) {
+        binance_signAbort();
+        fsm_sendFailure(FailureType_Failure_SyntaxError,
+                        "Invalid Binance transfer amount");
+        layoutHome();
+        return;
+      }
       if (!confirm_transaction_output(
               ButtonRequestType_ButtonRequest_ConfirmOutput, amount_str,
               msg->outputs[0].address)) {
@@ -151,13 +159,16 @@ static void binance_response(void) {
 
   const CoinType* coin = fsm_getCoin(true, "Binance");
   if (!coin) {
+    binance_signAbort();
+    layoutHome();
     return;
   }
 
   const BinanceSignTx* sign_tx = binance_getBinanceSignTx();
 
-  if (sign_tx->has_memo && !confirm(ButtonRequestType_ButtonRequest_ConfirmMemo,
-                                    _("Memo"), "%s", sign_tx->memo)) {
+  if (sign_tx->has_memo &&
+      !confirm_bytes(ButtonRequestType_ButtonRequest_ConfirmMemo, _("Memo"),
+                     (const uint8_t*)sign_tx->memo, strlen(sign_tx->memo))) {
     binance_signAbort();
     fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
     layoutHome();

--- a/lib/firmware/fsm_msg_coin.h
+++ b/lib/firmware/fsm_msg_coin.h
@@ -270,8 +270,8 @@ void fsm_msgSignMessage(SignMessage* msg) {
 
   CHECK_INITIALIZED
 
-  if (!confirm(ButtonRequestType_ButtonRequest_SignMessage, "Sign Message",
-               "%s", (char*)msg->message.bytes)) {
+  if (!confirm_bytes(ButtonRequestType_ButtonRequest_SignMessage,
+                     "Sign Message", msg->message.bytes, msg->message.size)) {
     fsm_sendFailure(FailureType_Failure_ActionCancelled,
                     "Sign message cancelled");
     layoutHome();
@@ -325,8 +325,9 @@ void fsm_msgVerifyMessage(VerifyMessage* msg) {
       layoutHome();
       return;
     }
-    if (!review(ButtonRequestType_ButtonRequest_Other, "Message Verified", "%s",
-                (char*)msg->message.bytes)) {
+    if (!confirm_bytes(ButtonRequestType_ButtonRequest_Other,
+                       "Message Verified", msg->message.bytes,
+                       msg->message.size)) {
       fsm_sendFailure(FailureType_Failure_ActionCancelled,
                       _("Action cancelled by user"));
       layoutHome();

--- a/lib/firmware/fsm_msg_common.h
+++ b/lib/firmware/fsm_msg_common.h
@@ -247,6 +247,7 @@ void fsm_msgPing(Ping* msg) {
       "Authenticator secret seed too large",
       "passphrase incorrect for authdata",
       "Auth secret unknown error",
+      "Authenticator account already exists",
       "Authenticator action cancelled",
   };
 

--- a/lib/firmware/fsm_msg_common.h
+++ b/lib/firmware/fsm_msg_common.h
@@ -214,13 +214,14 @@ static bool isValidModelNumber(const char* model) {
   return false;
 }
 
-void checkPassphrase(void) {
+static bool checkPassphrase(void) {
   if (!passphrase_protect()) {
     fsm_sendFailure(FailureType_Failure_ActionCancelled,
                     "authenticator needs passphrase");
     layoutHome();
-    return;
+    return false;
   }
+  return true;
 }
 
 void fsm_msgPing(Ping* msg) {
@@ -246,6 +247,7 @@ void fsm_msgPing(Ping* msg) {
       "Authenticator secret seed too large",
       "passphrase incorrect for authdata",
       "Auth secret unknown error",
+      "Authenticator action cancelled",
   };
 
   typedef enum _AUTH_MSG_TYPE {
@@ -286,7 +288,7 @@ void fsm_msgPing(Ping* msg) {
         0};  // allow room for domain + ":" + account
 
     CHECK_PIN
-    checkPassphrase();
+    if (!checkPassphrase()) return;
 
     switch (authMsg) {
       case INITAUTH:
@@ -325,8 +327,7 @@ void fsm_msgPing(Ping* msg) {
         break;
 
       case WIPEADATA:
-        wipeAuthData();
-        errcode = NOERR;
+        errcode = wipeAuthData();
         resp->has_message = false;
         break;
 

--- a/lib/firmware/fsm_msg_cosmos.h
+++ b/lib/firmware/fsm_msg_cosmos.h
@@ -92,7 +92,8 @@ void fsm_msgCosmosSignTx(const CosmosSignTx* msg) {
 
   RESP_INIT(CosmosMsgRequest);
 
-  if (!tendermint_signTxInit(node, (void*)msg, sizeof(CosmosSignTx), "uatom")) {
+  if (!tendermint_signTxInit(node, (void*)msg, sizeof(CosmosSignTx), "uatom",
+                             TENDERMINT_SIGNING_COSMOS)) {
     tendermint_signAbort();
     memzero(node, sizeof(*node));
     fsm_sendFailure(FailureType_Failure_FirmwareError,
@@ -108,7 +109,8 @@ void fsm_msgCosmosSignTx(const CosmosSignTx* msg) {
 
 void fsm_msgCosmosMsgAck(const CosmosMsgAck* msg) {
   // Confirm transaction basics
-  CHECK_PARAM(tendermint_signingIsInited(), "Signing not in progress");
+  CHECK_PARAM(tendermint_signingIsInited(TENDERMINT_SIGNING_COSMOS),
+              "Cosmos signing not in progress");
 
   const CoinType* coin = fsm_getCoin(true, "Cosmos");
   if (!coin) {
@@ -375,12 +377,13 @@ void fsm_msgCosmosMsgAck(const CosmosMsgAck* msg) {
     }
   } else if (msg->has_ibc_transfer) {
     /** Confirm required transaction parameters exist */
-    if (!msg->ibc_transfer.has_sender ||
+    if (!msg->ibc_transfer.has_receiver || !msg->ibc_transfer.has_sender ||
         !msg->ibc_transfer.has_source_channel ||
         !msg->ibc_transfer.has_source_port ||
         !msg->ibc_transfer.has_revision_height ||
         !msg->ibc_transfer.has_revision_number ||
-        !msg->ibc_transfer.has_denom) {
+        !msg->ibc_transfer.has_denom || !msg->ibc_transfer.has_amount ||
+        strcmp(msg->ibc_transfer.denom, "uatom") != 0) {
       tendermint_signAbort();
       fsm_sendFailure(FailureType_Failure_FirmwareError,
                       _("Message is missing required parameters"));
@@ -393,7 +396,19 @@ void fsm_msgCosmosMsgAck(const CosmosMsgAck* msg) {
                      amount_str, sizeof(amount_str));
 
     if (!confirm(ButtonRequestType_ButtonRequest_Other, "IBC Transfer",
-                 "Transfer %s to %s?", amount_str, msg->ibc_transfer.sender)) {
+                 "Transfer %s via IBC?", amount_str)) {
+      tendermint_signAbort();
+      fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+      layoutHome();
+      return;
+    }
+
+    if (!confirm_bytes(ButtonRequestType_ButtonRequest_Other, "IBC Sender",
+                       (const uint8_t*)msg->ibc_transfer.sender,
+                       strlen(msg->ibc_transfer.sender)) ||
+        !confirm_bytes(ButtonRequestType_ButtonRequest_Other, "IBC Receiver",
+                       (const uint8_t*)msg->ibc_transfer.receiver,
+                       strlen(msg->ibc_transfer.receiver))) {
       tendermint_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
@@ -462,8 +477,8 @@ void fsm_msgCosmosMsgAck(const CosmosMsgAck* msg) {
   }
 
   if (sign_tx->has_memo && (strlen(sign_tx->memo) > 0)) {
-    if (!confirm(ButtonRequestType_ButtonRequest_ConfirmMemo, _("Memo"), "%s",
-                 sign_tx->memo)) {
+    if (!confirm_bytes(ButtonRequestType_ButtonRequest_ConfirmMemo, _("Memo"),
+                       (const uint8_t*)sign_tx->memo, strlen(sign_tx->memo))) {
       tendermint_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();

--- a/lib/firmware/fsm_msg_crypto.h
+++ b/lib/firmware/fsm_msg_crypto.h
@@ -63,9 +63,31 @@ void fsm_msgSignIdentity(SignIdentity* msg) {
 
   CHECK_INITIALIZED
 
-  if (!confirm_sign_identity(&(msg->identity), msg->has_challenge_visual
-                                                   ? msg->challenge_visual
-                                                   : 0)) {
+  CHECK_PARAM(msg->has_identity, "Invalid identity");
+
+  const bool sign_ssh =
+      msg->identity.has_proto && strcmp(msg->identity.proto, "ssh") == 0;
+  const bool sign_gpg =
+      msg->identity.has_proto && strcmp(msg->identity.proto, "gpg") == 0;
+
+  /* SSH/GPG sign only challenge_hidden. The legacy confirmation displayed
+   * challenge_visual instead, allowing a host to show benign text while the
+   * device signed unrelated bytes. Generic identity signatures bind both
+   * challenges, so review both there; SSH/GPG review only the actual signed
+   * payload and never present the unsigned visual field as authoritative. */
+  if (!confirm_sign_identity(&msg->identity, NULL) ||
+      ((!sign_ssh && !sign_gpg) &&
+       !confirm_bytes(
+           ButtonRequestType_ButtonRequest_SignIdentity, "Visual Challenge",
+           (const uint8_t*)msg->challenge_visual,
+           msg->has_challenge_visual ? strlen(msg->challenge_visual) : 0)) ||
+      !confirm_bytes(
+          ButtonRequestType_ButtonRequest_SignIdentity,
+          sign_ssh   ? "Signed SSH Challenge"
+          : sign_gpg ? "Signed GPG Digest"
+                     : "Hidden Challenge",
+          msg->challenge_hidden.bytes,
+          msg->has_challenge_hidden ? msg->challenge_hidden.size : 0)) {
     fsm_sendFailure(FailureType_Failure_ActionCancelled,
                     "Sign identity cancelled");
     layoutHome();
@@ -75,8 +97,7 @@ void fsm_msgSignIdentity(SignIdentity* msg) {
   CHECK_PIN
 
   uint8_t hash[32];
-  if (!msg->has_identity ||
-      cryptoIdentityFingerprint(&(msg->identity), hash) == 0) {
+  if (cryptoIdentityFingerprint(&(msg->identity), hash) == 0) {
     fsm_sendFailure(FailureType_Failure_Other, "Invalid identity");
     layoutHome();
     return;
@@ -101,11 +122,6 @@ void fsm_msgSignIdentity(SignIdentity* msg) {
   if (!node) {
     return;
   }
-
-  bool sign_ssh =
-      msg->identity.has_proto && (strcmp(msg->identity.proto, "ssh") == 0);
-  bool sign_gpg =
-      msg->identity.has_proto && (strcmp(msg->identity.proto, "gpg") == 0);
 
   int result = 0;
   layout_simple_message("Signing Identity...");

--- a/lib/firmware/fsm_msg_ethereum.h
+++ b/lib/firmware/fsm_msg_ethereum.h
@@ -319,44 +319,16 @@ void fsm_msgEthereumGetAddress(EthereumGetAddress* msg) {
   layoutHome();
 }
 
-#define MSG_MAX (38 * 3)  // 38 chars per line, three lines max
 void fsm_msgEthereumSignMessage(EthereumSignMessage* msg) {
-  char msgBuf[MSG_MAX + 1] = {0};
-  const char* typeIndicator;
-  unsigned ctr;
-  unsigned msgLen = 0;
-  bool canPrint = true;
-
   RESP_INIT(EthereumMessageSignature);
 
   CHECK_INITIALIZED
 
   CHECK_PIN
 
-  // truncate to display size if too long
-  msgLen = msg->message.size * 2;
-  if (msgLen > MSG_MAX) {
-    msgLen = MSG_MAX;
-  }
-  for (ctr = 0; ctr < msg->message.size; ctr++) {
-    if (isprint(msg->message.bytes[ctr]) == false) {
-      canPrint = false;
-      break;
-    }
-  }
-  if (canPrint) {
-    typeIndicator = "Sign Message";
-    strncpy(msgBuf, (char*)msg->message.bytes, MSG_MAX + 1);
-    msgBuf[MSG_MAX] = '\0';
-  } else {
-    typeIndicator = "Sign Bytes";
-    for (ctr = 0; ctr < msgLen / 2; ctr++) {
-      snprintf(&msgBuf[2 * ctr], 3, "%02x", msg->message.bytes[ctr]);
-    }
-  }
-
-  if (!confirm(ButtonRequestType_ButtonRequest_ProtectCall, _(typeIndicator),
-               "%s", msgBuf)) {
+  if (!confirm_bytes(ButtonRequestType_ButtonRequest_ProtectCall,
+                     "Sign Ethereum Message", msg->message.bytes,
+                     msg->message.size)) {
     fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
     layoutHome();
     return;
@@ -372,12 +344,6 @@ void fsm_msgEthereumSignMessage(EthereumSignMessage* msg) {
 }
 
 void fsm_msgEthereumVerifyMessage(const EthereumVerifyMessage* msg) {
-  char msgBuf[MSG_MAX + 1] = {0};
-  const char* typeIndicator;
-  unsigned ctr;
-  unsigned msgLen = 0;
-  bool canPrint = true;
-
   CHECK_PARAM(msg->has_address, _("No address provided"));
   CHECK_PARAM(msg->has_message, _("No message provided"));
 
@@ -394,29 +360,9 @@ void fsm_msgEthereumVerifyMessage(const EthereumVerifyMessage* msg) {
     return;
   }
 
-  // truncate to display size if too long
-  msgLen = msg->message.size;
-  if (msgLen > MSG_MAX) {
-    msgLen = MSG_MAX;
-  }
-  for (ctr = 0; ctr < msgLen; ctr++) {
-    if (isprint(msg->message.bytes[ctr]) == false) {
-      canPrint = false;
-      break;
-    }
-  }
-  if (canPrint) {
-    typeIndicator = "Message Verified";
-    strncpy(msgBuf, (char*)msg->message.bytes, MSG_MAX + 1);
-    msgBuf[MSG_MAX] = '\0';
-  } else {
-    typeIndicator = "Bytes Verified";
-    for (ctr = 0; ctr < msgLen / 2; ctr++) {
-      snprintf(&msgBuf[2 * ctr], 3, "%02x", msg->message.bytes[ctr]);
-    }
-  }
-  if (!confirm(ButtonRequestType_ButtonRequest_Other, _(typeIndicator), "%s",
-               msgBuf)) {
+  if (!confirm_bytes(ButtonRequestType_ButtonRequest_Other,
+                     "Ethereum Message Verified", msg->message.bytes,
+                     msg->message.size)) {
     fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
     layoutHome();
     return;
@@ -432,6 +378,20 @@ void fsm_msgEthereumSignTypedHash(const EthereumSignTypedHash* msg) {
   CHECK_INITIALIZED
 
   CHECK_PIN
+
+  /* This endpoint receives only precomputed hashes, so the device cannot bind
+   * them to the typed data the host claims they represent. Treat it exactly
+   * like every other blind-signing path. */
+  if (!ethereum_typed_hash_policy_allows(
+          storage_isPolicyEnabled("AdvancedMode"))) {
+    (void)review(ButtonRequestType_ButtonRequest_Other, "Blocked",
+                 "Typed-hash signing requires AdvancedMode. "
+                 "Enable in device settings.");
+    fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                    _("Typed-hash signing disabled by policy"));
+    layoutHome();
+    return;
+  }
 
   if (msg->domain_separator_hash.size != 32 ||
       (msg->has_message_hash && msg->message_hash.size != 32)) {

--- a/lib/firmware/fsm_msg_hive.h
+++ b/lib/firmware/fsm_msg_hive.h
@@ -781,15 +781,21 @@ void fsm_msgHiveSignOperations(const HiveSignOperations* msg) {
         break;
       }
       case HIVE_OP_CUSTOM_JSON: {
-        char target[33];
-        hive_copy_slice(target, sizeof(target), op->target, op->target_len);
-        char extra[12] = "";
-        if (op->n_auths > 1) {
-          snprintf(extra, sizeof(extra), " +%u", (unsigned)(op->n_auths - 1));
+        approved = true;
+        for (uint8_t a = 0; approved && a < op->n_auths; a++) {
+          char auth_name[17];
+          hive_copy_slice(auth_name, sizeof(auth_name), op->auth_acct[a],
+                          op->auth_acct_len[a]);
+          approved = confirm(
+              ButtonRequestType_ButtonRequest_ConfirmOutput, "Custom JSON Auth",
+              "%u/%u: @%s\n%s key", (unsigned)(a + 1), (unsigned)op->n_auths,
+              auth_name, op->needs_active ? "Active" : "Posting");
         }
-        approved =
-            confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
-                    "Custom JSON", "id: %s\nby @%s%s", target, name, extra);
+        if (approved) {
+          approved =
+              hive_confirm_slice(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                                 "Custom JSON ID", op->target, op->target_len);
+        }
         if (approved) {
           approved =
               hive_confirm_slice(ButtonRequestType_ButtonRequest_ConfirmOutput,

--- a/lib/firmware/fsm_msg_hive.h
+++ b/lib/firmware/fsm_msg_hive.h
@@ -604,10 +604,9 @@ static bool hive_slip48_ops_path_ok(const uint32_t* address_n, uint32_t count,
 
 // User-controlled string fields are paged in full. Printable fields are shown
 // as text; fields containing non-ASCII bytes are shown as complete hex rather
-// than a short preview. At the body font's maximum 8-pixel glyph width, each
-// page fits within the three 225-pixel OLED body rows.
-#define HIVE_DISPLAY_ASCII_CHUNK 72
-#define HIVE_DISPLAY_HEX_CHUNK 40
+// than a short preview. Page boundaries are selected with the same font and
+// word-wrapping calculation used by draw_string(), so no signed suffix can be
+// pushed below the OLED's three visible body rows.
 
 static bool hive_slice_is_ascii(const uint8_t* s, uint16_t len) {
   bool ascii = true;
@@ -620,19 +619,46 @@ static bool hive_slice_is_ascii(const uint8_t* s, uint16_t len) {
   return ascii;
 }
 
+static uint16_t hive_rendered_page_len(const uint8_t* s, uint16_t len,
+                                       bool ascii) {
+  if (len == 0) return 0;
+
+  if (ascii) {
+    size_t candidate = len;
+    if (candidate >= BODY_CHAR_MAX) candidate = BODY_CHAR_MAX - 1;
+    return (uint16_t)calc_str_page(get_body_font(), (const char*)s, candidate,
+                                   BODY_WIDTH, BODY_ROWS);
+  }
+
+  uint16_t candidate = len;
+  if (candidate > (BODY_CHAR_MAX - 1) / 2) candidate = (BODY_CHAR_MAX - 1) / 2;
+  char rendered[BODY_CHAR_MAX];
+  for (uint16_t i = 0; i < candidate; i++) {
+    snprintf(rendered + 2 * i, 3, "%02x", s[i]);
+  }
+  size_t chars = calc_str_page(get_body_font(), rendered, 2 * candidate,
+                               BODY_WIDTH, BODY_ROWS);
+  return (uint16_t)(chars / 2);
+}
+
 static bool hive_confirm_slice(ButtonRequestType type, const char* title,
                                const uint8_t* s, uint16_t len) {
   if (len == 0) return confirm(type, title, "(empty)");
 
   bool ascii = hive_slice_is_ascii(s, len);
-  uint16_t chunk_size =
-      ascii ? HIVE_DISPLAY_ASCII_CHUNK : HIVE_DISPLAY_HEX_CHUNK;
-  uint16_t pages = (uint16_t)((len + chunk_size - 1) / chunk_size);
+  uint16_t pages = 0;
+  uint16_t offset = 0;
+  while (offset < len) {
+    uint16_t take = hive_rendered_page_len(s + offset, len - offset, ascii);
+    if (take == 0) return false;
+    offset = (uint16_t)(offset + take);
+    pages++;
+  }
 
+  offset = 0;
   for (uint16_t page = 0; page < pages; page++) {
-    uint16_t offset = (uint16_t)(page * chunk_size);
-    uint16_t take = (uint16_t)(len - offset);
-    if (take > chunk_size) take = chunk_size;
+    uint16_t take = hive_rendered_page_len(s + offset, len - offset, ascii);
+    if (take == 0) return false;
 
     char page_title[TITLE_CHAR_MAX];
     if (pages > 1 || !ascii) {
@@ -644,17 +670,18 @@ static bool hive_confirm_slice(ButtonRequestType type, const char* title,
     }
 
     if (ascii) {
-      char rendered[HIVE_DISPLAY_ASCII_CHUNK + 1];
+      char rendered[BODY_CHAR_MAX];
       memcpy(rendered, s + offset, take);
       rendered[take] = '\0';
       if (!confirm(type, page_title, "%s", rendered)) return false;
     } else {
-      char rendered[HIVE_DISPLAY_HEX_CHUNK * 2 + 1];
+      char rendered[BODY_CHAR_MAX];
       for (uint16_t i = 0; i < take; i++) {
         snprintf(rendered + 2 * i, 3, "%02x", s[offset + i]);
       }
       if (!confirm(type, page_title, "%s", rendered)) return false;
     }
+    offset = (uint16_t)(offset + take);
   }
   return true;
 }

--- a/lib/firmware/fsm_msg_hive.h
+++ b/lib/firmware/fsm_msg_hive.h
@@ -659,6 +659,20 @@ static bool hive_confirm_slice(ButtonRequestType type, const char* title,
   return true;
 }
 
+// "1.234 HIVE" — precision comes from the asset bytes being signed, which
+// the parser has already pinned to the symbol's protocol-fixed value.
+static void hive_format_asset(const uint8_t* a, char* out, size_t out_len) {
+  char suffix[9];  // space + longest symbol ("VESTS") + NUL
+  snprintf(suffix, sizeof(suffix), " %s", hive_assetSymbol(a));
+  bn_format_uint64(hive_assetAmount(a), NULL, suffix, hive_assetPrecision(a), 0,
+                   false, out, out_len);
+}
+
+// Basis points (0..10000) as "12.34%".
+static void hive_format_percent(int16_t bp, char* out, size_t out_len) {
+  snprintf(out, out_len, "%d.%02d%%", bp / 100, bp % 100);
+}
+
 static void hive_copy_slice(char* out, size_t out_len, const uint8_t* s,
                             uint16_t len) {
   if (out_len == 0) return;
@@ -783,6 +797,164 @@ void fsm_msgHiveSignOperations(const HiveSignOperations* msg) {
         }
         break;
       }
+      case HIVE_OP_TRANSFER_TO_VESTING: {
+        char amount[40], target[17];
+        hive_format_asset(op->assets[0], amount, sizeof(amount));
+        hive_copy_slice(target, sizeof(target), op->target, op->target_len);
+        approved =
+            op->target_len == 0
+                ? confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                          "Power Up", "Power up\n%s\nto @%s", amount, name)
+                : confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                          "Power Up", "%s\nfrom @%s\nto @%s", amount, name,
+                          target);
+        break;
+      }
+      case HIVE_OP_WITHDRAW_VESTING: {
+        char amount[40];
+        hive_format_asset(op->assets[0], amount, sizeof(amount));
+        approved =
+            hive_assetAmount(op->assets[0]) == 0
+                ? confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                          "Stop Power Down", "Cancel power down\nfor @%s", name)
+                : confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                          "Power Down", "Power down\n%s\nfrom @%s", amount,
+                          name);
+        break;
+      }
+      case HIVE_OP_LIMIT_ORDER_CREATE: {
+        char sell[40], receive[40];
+        hive_format_asset(op->assets[0], sell, sizeof(sell));
+        hive_format_asset(op->assets[1], receive, sizeof(receive));
+        approved = confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                           "Market Order", "@%s sells\n%s\nfor >= %s", name,
+                           sell, receive);
+        if (approved) {
+          // Order id and fill_or_kill decide whether an unfilled order rests
+          // on the book or is discarded, so they get their own screen rather
+          // than being crowded off the first one.
+          approved = confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                             "Order Terms", "Order #%u\n%s\nExpires %u",
+                             (unsigned)op->req_id,
+                             op->flag ? "Fill or kill" : "Rests on book",
+                             (unsigned)op->expiration);
+        }
+        break;
+      }
+      case HIVE_OP_LIMIT_ORDER_CANCEL:
+        approved = confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                           "Cancel Order", "Cancel order #%u\nfor @%s?",
+                           (unsigned)op->req_id, name);
+        break;
+      case HIVE_OP_CONVERT: {
+        char amount[40];
+        hive_format_asset(op->assets[0], amount, sizeof(amount));
+        approved = confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                           "Convert", "Convert %s\nto HIVE for @%s\n(#%u)",
+                           amount, name, (unsigned)op->req_id);
+        break;
+      } break;
+      case HIVE_OP_COMMENT_OPTIONS: {
+        char max_payout[40], percent[16];
+        hive_format_asset(op->assets[0], max_payout, sizeof(max_payout));
+        hive_format_percent(op->weight, percent, sizeof(percent));
+        approved = confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                           "Payout Options", "@%s\nMax %s\nHBD split %s", name,
+                           max_payout, percent);
+        if (approved) {
+          approved = confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                             "Payout Options", "Votes: %s\nCuration: %s",
+                             op->flag ? "allowed" : "disabled",
+                             op->flag2 ? "allowed" : "disabled");
+        }
+        // Beneficiaries divert payout to other accounts — each one is
+        // confirmed individually rather than summarized as a count.
+        for (uint8_t b = 0; approved && b < op->n_benef; b++) {
+          char benef[17], benef_pct[16];
+          hive_copy_slice(benef, sizeof(benef), op->benef_acct[b],
+                          op->benef_acct_len[b]);
+          hive_format_percent((int16_t)op->benef_weight[b], benef_pct,
+                              sizeof(benef_pct));
+          approved = confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                             "Payout Beneficiary", "%u/%u: @%s\ngets %s",
+                             (unsigned)(b + 1), (unsigned)op->n_benef, benef,
+                             benef_pct);
+        }
+        if (approved) {
+          approved = hive_confirm_slice(
+              ButtonRequestType_ButtonRequest_ConfirmOutput, "Payout Permlink",
+              op->permlink, op->permlink_len);
+        }
+        break;
+      }
+      case HIVE_OP_TRANSFER_TO_SAVINGS:
+      case HIVE_OP_TRANSFER_FROM_SAVINGS: {
+        char amount[40], target[17];
+        bool deposit = (op->op_type == HIVE_OP_TRANSFER_TO_SAVINGS);
+        hive_format_asset(op->assets[0], amount, sizeof(amount));
+        hive_copy_slice(target, sizeof(target), op->target, op->target_len);
+        // One variable per row. A 16-character account name sharing a row
+        // with a label can wrap into a fourth row, which the display drops
+        // silently — and here that row carries the destination account.
+        // req_id is deliberately not shown: it is a cancellation handle, not
+        // a fund-routing field, and crowding it in costs the destination row.
+        approved = confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                           deposit ? "Savings Deposit" : "Savings Withdraw",
+                           "%s\nfrom @%s\nto @%s", amount, name, target);
+        if (approved && op->detail_len > 0) {
+          approved =
+              hive_confirm_slice(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                                 "Savings Memo", op->detail, op->detail_len);
+        }
+        break;
+      }
+      case HIVE_OP_CLAIM_REWARD_BALANCE: {
+        char hive_amt[40], hbd_amt[40], vests_amt[40];
+        hive_format_asset(op->assets[0], hive_amt, sizeof(hive_amt));
+        hive_format_asset(op->assets[1], hbd_amt, sizeof(hbd_amt));
+        hive_format_asset(op->assets[2], vests_amt, sizeof(vests_amt));
+        // Three assets plus the account name cannot share one screen: the
+        // OLED body fits exactly three rows (layout.c places rows at y =
+        // 24/38/52 and draw_char_with_shift silently drops any glyph past
+        // y+height > 64), so a fourth row would be signed but never shown.
+        approved = confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                           "Claim Rewards", "@%s claims\n%s\n%s", name,
+                           hive_amt, hbd_amt);
+        if (approved) {
+          approved =
+              confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                      "Claim Rewards", "@%s claims\n%s", name, vests_amt);
+        }
+        break;
+      }
+      case HIVE_OP_DELEGATE_VESTING_SHARES: {
+        char amount[40], target[17];
+        hive_format_asset(op->assets[0], amount, sizeof(amount));
+        hive_copy_slice(target, sizeof(target), op->target, op->target_len);
+        approved =
+            hive_assetAmount(op->assets[0]) == 0
+                ? confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                          "Remove Delegation",
+                          "@%s removes its\ndelegation to @%s?", name, target)
+                : confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                          "Delegate", "@%s delegates\n%s\nto @%s", name, amount,
+                          target);
+        break;
+      }
+      case HIVE_OP_ACCOUNT_UPDATE2:
+        approved = confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                           "Profile Update", "Update profile\nof @%s?", name);
+        if (approved && op->detail_len > 0) {
+          approved = hive_confirm_slice(
+              ButtonRequestType_ButtonRequest_ConfirmOutput, "Account Metadata",
+              op->detail, op->detail_len);
+        }
+        if (approved && op->json_metadata_len > 0) {
+          approved = hive_confirm_slice(
+              ButtonRequestType_ButtonRequest_ConfirmOutput, "Profile Metadata",
+              op->json_metadata, op->json_metadata_len);
+        }
+        break;
       default:
         break;  // unreachable — parser rejected unknown ops
     }

--- a/lib/firmware/fsm_msg_hive.h
+++ b/lib/firmware/fsm_msg_hive.h
@@ -853,7 +853,7 @@ void fsm_msgHiveSignOperations(const HiveSignOperations* msg) {
                            "Convert", "Convert %s\nto HIVE for @%s\n(#%u)",
                            amount, name, (unsigned)op->req_id);
         break;
-      } break;
+      }
       case HIVE_OP_COMMENT_OPTIONS: {
         char max_payout[40], percent[16];
         hive_format_asset(op->assets[0], max_payout, sizeof(max_payout));

--- a/lib/firmware/fsm_msg_osmosis.h
+++ b/lib/firmware/fsm_msg_osmosis.h
@@ -150,17 +150,6 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
       return;
     }
 
-    // MsgSend's legacy Amino serializer is intentionally uosmo-only. Enforce
-    // that invariant in firmware because callers can bypass host libraries and
-    // send OsmosisMsgAck directly over the wire.
-    if (strcmp(msg->send.denom, "uosmo") != 0) {
-      osmosis_signAbort();
-      fsm_sendFailure(FailureType_Failure_SyntaxError,
-                      "Only uosmo is supported for Osmosis MsgSend");
-      layoutHome();
-      return;
-    }
-
     char amount_str[OSMOSIS_AMOUNT_STR_LEN];
     if (!osmosis_formatAmountOrFail(amount_str, sizeof(amount_str),
                                     msg->send.amount, msg->send.denom)) {

--- a/lib/firmware/fsm_msg_osmosis.h
+++ b/lib/firmware/fsm_msg_osmosis.h
@@ -1,5 +1,3 @@
-#include <math.h>
-#define OSMOSIS_PRECISION 6
 #define OSMOSIS_LP_ASSET_PRECISION 18
 
 void fsm_msgOsmosisGetAddress(const OsmosisGetAddress* msg) {
@@ -140,15 +138,9 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
       return;
     }
 
-    float amount = atof(msg->send.amount);
-    const char* denom = msg->send.denom;
-    if (!strcmp(msg->send.denom, "uosmo")) {
-      amount /= pow(10, OSMOSIS_PRECISION);
-      denom = "OSMO";
-    }
-
-    char amount_str[103];
-    snprintf(amount_str, sizeof(amount_str) - 1, "%.6f %s", amount, denom);
+    char amount_str[OSMOSIS_AMOUNT_STR_LEN];
+    osmosis_formatAmount(amount_str, sizeof(amount_str), msg->send.amount,
+                         msg->send.denom);
 
     /** Confirm transaction parameters on screen */
     if (!confirm_transaction_output(
@@ -179,12 +171,9 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
       return;
     }
 
-    float amount = atof(msg->delegate.amount);
-    const char* denom = msg->delegate.denom;
-    if (!strcmp(msg->delegate.denom, "uosmo")) {
-      amount /= pow(10, OSMOSIS_PRECISION);
-      denom = "OSMO";
-    }
+    char amount_str[OSMOSIS_AMOUNT_STR_LEN];
+    osmosis_formatAmount(amount_str, sizeof(amount_str), msg->delegate.amount,
+                         msg->delegate.denom);
 
     /** Confirm transaction parameters on-screen */
     if (!confirm_osmosis_address("Confirm Delegator Address",
@@ -203,8 +192,8 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
       return;
     }
 
-    if (!confirm(ButtonRequestType_ButtonRequest_Other, "Confirm Amount",
-                 "%.6f %s", amount, denom)) {
+    if (!confirm(ButtonRequestType_ButtonRequest_Other, "Confirm Amount", "%s",
+                 amount_str)) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
@@ -231,12 +220,9 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
       return;
     }
 
-    float amount = atof(msg->undelegate.amount);
-    const char* denom = msg->undelegate.denom;
-    if (!strcmp(msg->undelegate.denom, "uosmo")) {
-      amount /= pow(10, OSMOSIS_PRECISION);
-      denom = "OSMO";
-    }
+    char amount_str[OSMOSIS_AMOUNT_STR_LEN];
+    osmosis_formatAmount(amount_str, sizeof(amount_str), msg->undelegate.amount,
+                         msg->undelegate.denom);
 
     /** Confirm transaction parameters on-screen */
     if (!confirm_osmosis_address("Confirm Delegator Address",
@@ -255,8 +241,8 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
       return;
     }
 
-    if (!confirm(ButtonRequestType_ButtonRequest_Other, "Confirm Amount",
-                 "%.6f %s", amount, denom)) {
+    if (!confirm(ButtonRequestType_ButtonRequest_Other, "Confirm Amount", "%s",
+                 amount_str)) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
@@ -298,23 +284,19 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
       return;
     }
 
-    float amount_in_max_b = atof(msg->lp_add.amount_in_max_b);
-    const char* denom_in_max_b = msg->lp_add.denom_in_max_b;
-    if (!strcmp(msg->lp_add.denom_in_max_b, "uosmo")) {
-      amount_in_max_b /= pow(10, OSMOSIS_PRECISION);
-      denom_in_max_b = "OSMO";
-    }
+    char amount_in_max_b_str[OSMOSIS_AMOUNT_STR_LEN];
+    osmosis_formatAmount(amount_in_max_b_str, sizeof(amount_in_max_b_str),
+                         msg->lp_add.amount_in_max_b,
+                         msg->lp_add.denom_in_max_b);
 
-    float amount_in_max_a = atof(msg->lp_add.amount_in_max_a);
-    const char* denom_in_max_a = msg->lp_add.denom_in_max_a;
-    if (!strcmp(msg->lp_add.denom_in_max_a, "uosmo")) {
-      amount_in_max_a /= pow(10, OSMOSIS_PRECISION);
-      denom_in_max_a = "OSMO";
-    }
+    char amount_in_max_a_str[OSMOSIS_AMOUNT_STR_LEN];
+    osmosis_formatAmount(amount_in_max_a_str, sizeof(amount_in_max_a_str),
+                         msg->lp_add.amount_in_max_a,
+                         msg->lp_add.denom_in_max_a);
 
     /** Confirm transaction parameters on-screen */
     if (!confirm(ButtonRequestType_ButtonRequest_Other, "Add Liquidity",
-                 "Deposit %.6f %s and...", amount_in_max_b, denom_in_max_b)) {
+                 "Deposit %s and...", amount_in_max_b_str)) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
@@ -322,7 +304,7 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
     }
 
     if (!confirm(ButtonRequestType_ButtonRequest_Other, "Add Liquidity",
-                 "... %.6f %s?", amount_in_max_a, denom_in_max_a)) {
+                 "... %s?", amount_in_max_a_str)) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
@@ -385,24 +367,19 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
       return;
     }
 
-    float amount_out_min_b = atof(msg->lp_remove.amount_out_min_b);
-    const char* denom_out_min_b = msg->lp_remove.denom_out_min_b;
-    if (!strcmp(msg->lp_remove.denom_out_min_b, "uosmo")) {
-      amount_out_min_b /= pow(10, OSMOSIS_PRECISION);
-      denom_out_min_b = "OSMO";
-    }
+    char amount_out_min_b_str[OSMOSIS_AMOUNT_STR_LEN];
+    osmosis_formatAmount(amount_out_min_b_str, sizeof(amount_out_min_b_str),
+                         msg->lp_remove.amount_out_min_b,
+                         msg->lp_remove.denom_out_min_b);
 
-    float amount_out_min_a = atof(msg->lp_remove.amount_out_min_a);
-    const char* denom_out_min_a = msg->lp_remove.denom_out_min_a;
-    if (!strcmp(msg->lp_remove.denom_out_min_a, "uosmo")) {
-      amount_out_min_a /= pow(10, OSMOSIS_PRECISION);
-      denom_out_min_a = "OSMO";
-    }
+    char amount_out_min_a_str[OSMOSIS_AMOUNT_STR_LEN];
+    osmosis_formatAmount(amount_out_min_a_str, sizeof(amount_out_min_a_str),
+                         msg->lp_remove.amount_out_min_a,
+                         msg->lp_remove.denom_out_min_a);
 
     /** Confirm transaction parameters on-screen */
     if (!confirm(ButtonRequestType_ButtonRequest_Other, "Remove Liquidity",
-                 "Withdraw %.6f %s and...", amount_out_min_b,
-                 denom_out_min_b)) {
+                 "Withdraw %s and...", amount_out_min_b_str)) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
@@ -410,7 +387,7 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
     }
 
     if (!confirm(ButtonRequestType_ButtonRequest_Other, "Remove Liquidity",
-                 "... %.6f %s ?", amount_out_min_a, denom_out_min_a)) {
+                 "... %s ?", amount_out_min_a_str)) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
@@ -458,11 +435,15 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
       return;
     }
 
-    float amount = atof(msg->redelegate.amount) / pow(10, OSMOSIS_PRECISION);
+    // Redelegation is OSMO-denominated, so the amount is always scaled and
+    // labelled OSMO regardless of what denom the message carries.
+    char amount_str[OSMOSIS_AMOUNT_STR_LEN];
+    osmosis_formatAmount(amount_str, sizeof(amount_str), msg->redelegate.amount,
+                         "uosmo");
 
     /** Confirm transaction parameters on-screen */
     if (!confirm(ButtonRequestType_ButtonRequest_Other, "Redelegate",
-                 "Redelegate %.6f OSMO?", amount)) {
+                 "Redelegate %s?", amount_str)) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
@@ -559,24 +540,18 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
       return;
     }
 
-    float token_in_amount = atof(msg->swap.token_in_amount);
-    const char* token_in_denom = msg->swap.token_in_denom;
-    if (!strcmp(msg->swap.token_in_denom, "uosmo")) {
-      token_in_amount /= pow(10, OSMOSIS_PRECISION);
-      token_in_denom = "OSMO";
-    }
+    char token_in_str[OSMOSIS_AMOUNT_STR_LEN];
+    osmosis_formatAmount(token_in_str, sizeof(token_in_str),
+                         msg->swap.token_in_amount, msg->swap.token_in_denom);
 
-    float token_out_min_amount = atof(msg->swap.token_out_min_amount);
-    const char* token_out_denom = msg->swap.token_out_denom;
-    if (!strcmp(msg->swap.token_out_denom, "uosmo")) {
-      token_out_min_amount /= pow(10, OSMOSIS_PRECISION);
-      token_out_denom = "OSMO";
-    }
+    char token_out_min_str[OSMOSIS_AMOUNT_STR_LEN];
+    osmosis_formatAmount(token_out_min_str, sizeof(token_out_min_str),
+                         msg->swap.token_out_min_amount,
+                         msg->swap.token_out_denom);
 
     /** Confirm transaction parameters on-screen */
     if (!confirm(ButtonRequestType_ButtonRequest_Other, "Swap",
-                 "Swap %.6f %s for at least %.6f %s?", token_in_amount,
-                 token_in_denom, token_out_min_amount, token_out_denom)) {
+                 "Swap %s for at least %s?", token_in_str, token_out_min_str)) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
@@ -617,16 +592,13 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
       return;
     }
 
-    float amount = atof(msg->ibc_transfer.amount);
-    const char* denom = msg->ibc_transfer.denom;
-    if (!strcmp(msg->ibc_transfer.denom, "uosmo")) {
-      amount /= pow(10, OSMOSIS_PRECISION);
-      denom = "OSMO";
-    }
+    char amount_str[OSMOSIS_AMOUNT_STR_LEN];
+    osmosis_formatAmount(amount_str, sizeof(amount_str),
+                         msg->ibc_transfer.amount, msg->ibc_transfer.denom);
 
     /** Confirm transaction parameters on-screen */
     if (!confirm(ButtonRequestType_ButtonRequest_Other, "IBC Transfer",
-                 "Transfer %.6f %s?", amount, denom)) {
+                 "Transfer %s?", amount_str)) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();

--- a/lib/firmware/fsm_msg_osmosis.h
+++ b/lib/firmware/fsm_msg_osmosis.h
@@ -1,5 +1,16 @@
 #define OSMOSIS_LP_ASSET_PRECISION 18
 
+static bool osmosis_formatAmountOrFail(char* out, size_t out_len,
+                                       const char* value, const char* denom) {
+  if (osmosis_formatAmount(out, out_len, value, denom)) return true;
+
+  osmosis_signAbort();
+  fsm_sendFailure(FailureType_Failure_SyntaxError,
+                  "Invalid Osmosis amount or denomination");
+  layoutHome();
+  return false;
+}
+
 void fsm_msgOsmosisGetAddress(const OsmosisGetAddress* msg) {
   RESP_INIT(OsmosisAddress);
 
@@ -130,7 +141,8 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
 
   /** Confirm required transaction parameters exist */
   if (msg->has_send) {
-    if (!msg->send.has_to_address || !msg->send.has_amount) {
+    if (!msg->send.has_to_address || !msg->send.has_amount ||
+        !msg->send.has_denom) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_FirmwareError,
                       _("Message is missing required parameters"));
@@ -138,21 +150,39 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
       return;
     }
 
-    char amount_str[OSMOSIS_AMOUNT_STR_LEN];
-    osmosis_formatAmount(amount_str, sizeof(amount_str), msg->send.amount,
-                         msg->send.denom);
+    // MsgSend's legacy Amino serializer is intentionally uosmo-only. Enforce
+    // that invariant in firmware because callers can bypass host libraries and
+    // send OsmosisMsgAck directly over the wire.
+    if (strcmp(msg->send.denom, "uosmo") != 0) {
+      osmosis_signAbort();
+      fsm_sendFailure(FailureType_Failure_SyntaxError,
+                      "Only uosmo is supported for Osmosis MsgSend");
+      layoutHome();
+      return;
+    }
 
-    /** Confirm transaction parameters on screen */
-    if (!confirm_transaction_output(
-            ButtonRequestType_ButtonRequest_ConfirmOutput, amount_str,
-            msg->send.to_address)) {
+    char amount_str[OSMOSIS_AMOUNT_STR_LEN];
+    if (!osmosis_formatAmountOrFail(amount_str, sizeof(amount_str),
+                                    msg->send.amount, msg->send.denom)) {
+      return;
+    }
+
+    // Amount and destination are independent renderer-measured disclosures.
+    // A single wrapped "Send ... to ..." body could hide the destination.
+    if (!confirm_bytes(ButtonRequestType_ButtonRequest_ConfirmOutput,
+                       "Send Amount", (const uint8_t*)amount_str,
+                       strlen(amount_str)) ||
+        !confirm_bytes(ButtonRequestType_ButtonRequest_ConfirmOutput, "Send To",
+                       (const uint8_t*)msg->send.to_address,
+                       strlen(msg->send.to_address))) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
       return;
     }
 
-    if (!osmosis_signTxUpdateMsgSend(msg->send.amount, msg->send.to_address)) {
+    if (!osmosis_signTxUpdateMsgSend(msg->send.amount, msg->send.to_address,
+                                     msg->send.denom)) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_SyntaxError,
                       "Failed to include send message in transaction");
@@ -163,7 +193,8 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
   } else if (msg->has_delegate) {
     /** Confirm required transaction parameters exist */
     if (!msg->delegate.has_delegator_address ||
-        !msg->delegate.has_validator_address || !msg->delegate.has_amount) {
+        !msg->delegate.has_validator_address || !msg->delegate.has_amount ||
+        !msg->delegate.has_denom) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_FirmwareError,
                       _("Message is missing required parameters"));
@@ -172,8 +203,11 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
     }
 
     char amount_str[OSMOSIS_AMOUNT_STR_LEN];
-    osmosis_formatAmount(amount_str, sizeof(amount_str), msg->delegate.amount,
-                         msg->delegate.denom);
+    if (!osmosis_formatAmountOrFail(amount_str, sizeof(amount_str),
+                                    msg->delegate.amount,
+                                    msg->delegate.denom)) {
+      return;
+    }
 
     /** Confirm transaction parameters on-screen */
     if (!confirm_osmosis_address("Confirm Delegator Address",
@@ -192,8 +226,8 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
       return;
     }
 
-    if (!confirm(ButtonRequestType_ButtonRequest_Other, "Confirm Amount", "%s",
-                 amount_str)) {
+    if (!confirm_bytes(ButtonRequestType_ButtonRequest_Other, "Confirm Amount",
+                       (const uint8_t*)amount_str, strlen(amount_str))) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
@@ -212,7 +246,8 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
   } else if (msg->has_undelegate) {
     /** Confirm required transaction parameters exist */
     if (!msg->undelegate.has_delegator_address ||
-        !msg->undelegate.has_validator_address || !msg->undelegate.has_amount) {
+        !msg->undelegate.has_validator_address || !msg->undelegate.has_amount ||
+        !msg->undelegate.has_denom) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_FirmwareError,
                       _("Message is missing required parameters"));
@@ -221,8 +256,11 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
     }
 
     char amount_str[OSMOSIS_AMOUNT_STR_LEN];
-    osmosis_formatAmount(amount_str, sizeof(amount_str), msg->undelegate.amount,
-                         msg->undelegate.denom);
+    if (!osmosis_formatAmountOrFail(amount_str, sizeof(amount_str),
+                                    msg->undelegate.amount,
+                                    msg->undelegate.denom)) {
+      return;
+    }
 
     /** Confirm transaction parameters on-screen */
     if (!confirm_osmosis_address("Confirm Delegator Address",
@@ -241,8 +279,8 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
       return;
     }
 
-    if (!confirm(ButtonRequestType_ButtonRequest_Other, "Confirm Amount", "%s",
-                 amount_str)) {
+    if (!confirm_bytes(ButtonRequestType_ButtonRequest_Other, "Confirm Amount",
+                       (const uint8_t*)amount_str, strlen(amount_str))) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
@@ -271,40 +309,45 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
       return;
     }
 
-    char insoamt[33] = {0};
-    uint8_t outsoamt[34] = {0};
-    strlcpy(insoamt, msg->lp_add.share_out_amount,
-            sizeof(msg->lp_add.share_out_amount));
-
-    if (base_to_precision(outsoamt, (uint8_t*)insoamt, sizeof(outsoamt),
-                          strlen(insoamt), OSMOSIS_LP_ASSET_PRECISION) < 0) {
+    char outsoamt[34] = {0};
+    if (base_to_precision(
+            (uint8_t*)outsoamt, (const uint8_t*)msg->lp_add.share_out_amount,
+            sizeof(outsoamt), strlen(msg->lp_add.share_out_amount),
+            OSMOSIS_LP_ASSET_PRECISION) < 0) {
       osmosis_signAbort();
-      fsm_sendFailure(FailureType_Failure_Other, NULL);
+      fsm_sendFailure(FailureType_Failure_SyntaxError,
+                      "Invalid LP share amount");
       layoutHome();
       return;
     }
 
     char amount_in_max_b_str[OSMOSIS_AMOUNT_STR_LEN];
-    osmosis_formatAmount(amount_in_max_b_str, sizeof(amount_in_max_b_str),
-                         msg->lp_add.amount_in_max_b,
-                         msg->lp_add.denom_in_max_b);
+    if (!osmosis_formatAmountOrFail(
+            amount_in_max_b_str, sizeof(amount_in_max_b_str),
+            msg->lp_add.amount_in_max_b, msg->lp_add.denom_in_max_b)) {
+      return;
+    }
 
     char amount_in_max_a_str[OSMOSIS_AMOUNT_STR_LEN];
-    osmosis_formatAmount(amount_in_max_a_str, sizeof(amount_in_max_a_str),
-                         msg->lp_add.amount_in_max_a,
-                         msg->lp_add.denom_in_max_a);
+    if (!osmosis_formatAmountOrFail(
+            amount_in_max_a_str, sizeof(amount_in_max_a_str),
+            msg->lp_add.amount_in_max_a, msg->lp_add.denom_in_max_a)) {
+      return;
+    }
 
     /** Confirm transaction parameters on-screen */
-    if (!confirm(ButtonRequestType_ButtonRequest_Other, "Add Liquidity",
-                 "Deposit %s and...", amount_in_max_b_str)) {
+    if (!confirm_bytes(ButtonRequestType_ButtonRequest_Other, "Max Deposit A",
+                       (const uint8_t*)amount_in_max_a_str,
+                       strlen(amount_in_max_a_str))) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
       return;
     }
 
-    if (!confirm(ButtonRequestType_ButtonRequest_Other, "Add Liquidity",
-                 "... %s?", amount_in_max_a_str)) {
+    if (!confirm_bytes(ButtonRequestType_ButtonRequest_Other, "Max Deposit B",
+                       (const uint8_t*)amount_in_max_b_str,
+                       strlen(amount_in_max_b_str))) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
@@ -312,16 +355,16 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
     }
 
     if (!confirm(ButtonRequestType_ButtonRequest_Other, "Confirm Pool ID",
-                 "%lld", msg->lp_add.pool_id)) {
+                 "%" PRIu64, msg->lp_add.pool_id)) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
       return;
     }
 
-    if (!confirm(ButtonRequestType_ButtonRequest_Other,
-                 "Confirm Share Out Amount", "Receive %s GAMM-%lld shares?",
-                 outsoamt, msg->lp_add.pool_id)) {
+    if (!confirm_bytes(ButtonRequestType_ButtonRequest_Other,
+                       "Minimum LP Shares", (const uint8_t*)outsoamt,
+                       strlen(outsoamt))) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
@@ -354,40 +397,45 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
       return;
     }
 
-    char insoamt[33] = {0};
-    uint8_t outsoamt[34] = {0};
-    strlcpy(insoamt, msg->lp_remove.share_in_amount,
-            sizeof(msg->lp_remove.share_in_amount));
-
-    if (base_to_precision(outsoamt, (uint8_t*)insoamt, sizeof(outsoamt),
-                          strlen(insoamt), OSMOSIS_LP_ASSET_PRECISION) < 0) {
+    char outsoamt[34] = {0};
+    if (base_to_precision(
+            (uint8_t*)outsoamt, (const uint8_t*)msg->lp_remove.share_in_amount,
+            sizeof(outsoamt), strlen(msg->lp_remove.share_in_amount),
+            OSMOSIS_LP_ASSET_PRECISION) < 0) {
       osmosis_signAbort();
-      fsm_sendFailure(FailureType_Failure_Other, NULL);
+      fsm_sendFailure(FailureType_Failure_SyntaxError,
+                      "Invalid LP share amount");
       layoutHome();
       return;
     }
 
     char amount_out_min_b_str[OSMOSIS_AMOUNT_STR_LEN];
-    osmosis_formatAmount(amount_out_min_b_str, sizeof(amount_out_min_b_str),
-                         msg->lp_remove.amount_out_min_b,
-                         msg->lp_remove.denom_out_min_b);
+    if (!osmosis_formatAmountOrFail(
+            amount_out_min_b_str, sizeof(amount_out_min_b_str),
+            msg->lp_remove.amount_out_min_b, msg->lp_remove.denom_out_min_b)) {
+      return;
+    }
 
     char amount_out_min_a_str[OSMOSIS_AMOUNT_STR_LEN];
-    osmosis_formatAmount(amount_out_min_a_str, sizeof(amount_out_min_a_str),
-                         msg->lp_remove.amount_out_min_a,
-                         msg->lp_remove.denom_out_min_a);
+    if (!osmosis_formatAmountOrFail(
+            amount_out_min_a_str, sizeof(amount_out_min_a_str),
+            msg->lp_remove.amount_out_min_a, msg->lp_remove.denom_out_min_a)) {
+      return;
+    }
 
     /** Confirm transaction parameters on-screen */
-    if (!confirm(ButtonRequestType_ButtonRequest_Other, "Remove Liquidity",
-                 "Withdraw %s and...", amount_out_min_b_str)) {
+    if (!confirm_bytes(ButtonRequestType_ButtonRequest_Other,
+                       "Minimum Output A", (const uint8_t*)amount_out_min_a_str,
+                       strlen(amount_out_min_a_str))) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
       return;
     }
 
-    if (!confirm(ButtonRequestType_ButtonRequest_Other, "Remove Liquidity",
-                 "... %s ?", amount_out_min_a_str)) {
+    if (!confirm_bytes(ButtonRequestType_ButtonRequest_Other,
+                       "Minimum Output B", (const uint8_t*)amount_out_min_b_str,
+                       strlen(amount_out_min_b_str))) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
@@ -395,16 +443,16 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
     }
 
     if (!confirm(ButtonRequestType_ButtonRequest_Other, "Confirm Pool ID",
-                 "%lld", msg->lp_remove.pool_id)) {
+                 "%" PRIu64, msg->lp_remove.pool_id)) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
       return;
     }
 
-    if (!confirm(ButtonRequestType_ButtonRequest_Other, "Pool share amount",
-                 "Redeem %s GAMM-%lld shares?", outsoamt,
-                 msg->lp_remove.pool_id)) {
+    if (!confirm_bytes(ButtonRequestType_ButtonRequest_Other,
+                       "LP Shares to Redeem", (const uint8_t*)outsoamt,
+                       strlen(outsoamt))) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
@@ -427,7 +475,7 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
     if (!msg->redelegate.has_delegator_address ||
         !msg->redelegate.has_validator_src_address ||
         !msg->redelegate.has_validator_dst_address ||
-        !msg->redelegate.has_amount) {
+        !msg->redelegate.has_amount || !msg->redelegate.has_denom) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_FirmwareError,
                       _("Message is missing required parameters"));
@@ -435,15 +483,24 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
       return;
     }
 
-    // Redelegation is OSMO-denominated, so the amount is always scaled and
-    // labelled OSMO regardless of what denom the message carries.
+    if (strcmp(msg->redelegate.denom, "uosmo") != 0) {
+      osmosis_signAbort();
+      fsm_sendFailure(FailureType_Failure_SyntaxError,
+                      "Only uosmo is supported for Osmosis redelegation");
+      layoutHome();
+      return;
+    }
+
     char amount_str[OSMOSIS_AMOUNT_STR_LEN];
-    osmosis_formatAmount(amount_str, sizeof(amount_str), msg->redelegate.amount,
-                         "uosmo");
+    if (!osmosis_formatAmountOrFail(amount_str, sizeof(amount_str),
+                                    msg->redelegate.amount,
+                                    msg->redelegate.denom)) {
+      return;
+    }
 
     /** Confirm transaction parameters on-screen */
-    if (!confirm(ButtonRequestType_ButtonRequest_Other, "Redelegate",
-                 "Redelegate %s?", amount_str)) {
+    if (!confirm_bytes(ButtonRequestType_ButtonRequest_Other, "Redelegate",
+                       (const uint8_t*)amount_str, strlen(amount_str))) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
@@ -541,17 +598,26 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
     }
 
     char token_in_str[OSMOSIS_AMOUNT_STR_LEN];
-    osmosis_formatAmount(token_in_str, sizeof(token_in_str),
-                         msg->swap.token_in_amount, msg->swap.token_in_denom);
+    if (!osmosis_formatAmountOrFail(token_in_str, sizeof(token_in_str),
+                                    msg->swap.token_in_amount,
+                                    msg->swap.token_in_denom)) {
+      return;
+    }
 
     char token_out_min_str[OSMOSIS_AMOUNT_STR_LEN];
-    osmosis_formatAmount(token_out_min_str, sizeof(token_out_min_str),
-                         msg->swap.token_out_min_amount,
-                         msg->swap.token_out_denom);
+    if (!osmosis_formatAmountOrFail(
+            token_out_min_str, sizeof(token_out_min_str),
+            msg->swap.token_out_min_amount, msg->swap.token_out_denom)) {
+      return;
+    }
 
-    /** Confirm transaction parameters on-screen */
-    if (!confirm(ButtonRequestType_ButtonRequest_Other, "Swap",
-                 "Swap %s for at least %s?", token_in_str, token_out_min_str)) {
+    // Each signed asset is paged independently so neither the input denom nor
+    // the minimum output can fall below the OLED's three visible body rows.
+    if (!confirm_bytes(ButtonRequestType_ButtonRequest_Other, "Swap Input",
+                       (const uint8_t*)token_in_str, strlen(token_in_str)) ||
+        !confirm_bytes(ButtonRequestType_ButtonRequest_Other, "Minimum Output",
+                       (const uint8_t*)token_out_min_str,
+                       strlen(token_out_min_str))) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
@@ -559,7 +625,7 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
     }
 
     if (!confirm(ButtonRequestType_ButtonRequest_Other, "Confirm Pool ID",
-                 "%lld", msg->swap.pool_id)) {
+                 "%" PRIu64, msg->swap.pool_id)) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();
@@ -584,7 +650,8 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
         !msg->ibc_transfer.has_source_port ||
         !msg->ibc_transfer.has_revision_height ||
         !msg->ibc_transfer.has_revision_number ||
-        !msg->ibc_transfer.has_denom) {
+        !msg->ibc_transfer.has_denom || !msg->ibc_transfer.has_amount ||
+        !msg->ibc_transfer.has_receiver) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_FirmwareError,
                       _("Message is missing required parameters"));
@@ -593,12 +660,15 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
     }
 
     char amount_str[OSMOSIS_AMOUNT_STR_LEN];
-    osmosis_formatAmount(amount_str, sizeof(amount_str),
-                         msg->ibc_transfer.amount, msg->ibc_transfer.denom);
+    if (!osmosis_formatAmountOrFail(amount_str, sizeof(amount_str),
+                                    msg->ibc_transfer.amount,
+                                    msg->ibc_transfer.denom)) {
+      return;
+    }
 
     /** Confirm transaction parameters on-screen */
-    if (!confirm(ButtonRequestType_ButtonRequest_Other, "IBC Transfer",
-                 "Transfer %s?", amount_str)) {
+    if (!confirm_bytes(ButtonRequestType_ButtonRequest_Other, "IBC Transfer",
+                       (const uint8_t*)amount_str, strlen(amount_str))) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();

--- a/lib/firmware/fsm_msg_osmosis.h
+++ b/lib/firmware/fsm_msg_osmosis.h
@@ -674,8 +674,8 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
   }
 
   if (sign_tx->has_memo && (strlen(sign_tx->memo) > 0)) {
-    if (!confirm(ButtonRequestType_ButtonRequest_ConfirmMemo, _("Memo"), "%s",
-                 sign_tx->memo)) {
+    if (!confirm_bytes(ButtonRequestType_ButtonRequest_ConfirmMemo, _("Memo"),
+                       (const uint8_t*)sign_tx->memo, strlen(sign_tx->memo))) {
       osmosis_signAbort();
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();

--- a/lib/firmware/fsm_msg_solana.h
+++ b/lib/firmware/fsm_msg_solana.h
@@ -62,61 +62,10 @@ static bool solana_symbol_is_safe(const char* sym) {
   return true;
 }
 
-/* Display budget per confirm body: printable memos page as text, binary memos
- * page as hex so the FULL content is always shown — a memo can carry swap
- * intent (THORChain '=:ETH.ETH:...'), so nothing may be hidden behind a byte
- * count. Mirrors hive_confirm_slice. */
-#define SOL_MEMO_ASCII_CHUNK 72
-#define SOL_MEMO_HEX_CHUNK 40
-
 static bool solana_confirm_memo(const char* title, const uint8_t* s,
                                 uint16_t len) {
-  if (len == 0) {
-    return confirm(ButtonRequestType_ButtonRequest_ConfirmMemo, title,
-                   "Memo (empty)");
-  }
-  bool ascii = true;
-  for (uint16_t i = 0; i < len; i++) {
-    if (s[i] < 0x20 || s[i] > 0x7e) {
-      ascii = false;
-      break;
-    }
-  }
-  uint16_t chunk = ascii ? SOL_MEMO_ASCII_CHUNK : SOL_MEMO_HEX_CHUNK;
-  uint16_t pages = (uint16_t)((len + chunk - 1) / chunk);
-
-  for (uint16_t page = 0; page < pages; page++) {
-    uint16_t offset = (uint16_t)(page * chunk);
-    uint16_t take = (uint16_t)(len - offset);
-    if (take > chunk) take = chunk;
-
-    char page_title[32];
-    if (pages > 1 || !ascii) {
-      snprintf(page_title, sizeof(page_title),
-               ascii ? "%s %u/%u" : "%s Hex %u/%u", title, (unsigned)(page + 1),
-               (unsigned)pages);
-    } else {
-      strlcpy(page_title, title, sizeof(page_title));
-    }
-
-    if (ascii) {
-      char rendered[SOL_MEMO_ASCII_CHUNK + 1];
-      memcpy(rendered, s + offset, take);
-      rendered[take] = '\0';
-      if (!confirm(ButtonRequestType_ButtonRequest_ConfirmMemo, page_title,
-                   "%s", rendered))
-        return false;
-    } else {
-      char rendered[SOL_MEMO_HEX_CHUNK * 2 + 1];
-      for (uint16_t i = 0; i < take; i++) {
-        snprintf(rendered + 2 * i, 3, "%02x", s[offset + i]);
-      }
-      if (!confirm(ButtonRequestType_ButtonRequest_ConfirmMemo, page_title,
-                   "%s", rendered))
-        return false;
-    }
-  }
-  return true;
+  return confirm_bytes(ButtonRequestType_ButtonRequest_ConfirmMemo, title, s,
+                       len);
 }
 
 /* Priority fee = ceil(cu_price_micro_lamports * cu_limit / 1e6) lamports, and
@@ -888,45 +837,16 @@ void fsm_msgSolanaSignMessage(const SolanaSignMessage* msg) {
       layoutHome();
       return;
     }
-  } else /* blind message path */
-  /* Always require on-device confirmation (matches Ethereum behavior).
-   * Display message content if printable, hex preview otherwise. */
-  {
-    char msgBuf[129] = {0};
-    const char* typeLabel;
-    bool printable = true;
-    for (unsigned i = 0; i < msg->message.size; i++) {
-      if (msg->message.bytes[i] < 0x20 || msg->message.bytes[i] > 0x7e) {
-        printable = false;
-        break;
-      }
-    }
-    if (printable && msg->message.size <= sizeof(msgBuf) - 1) {
-      typeLabel = "Sign Message";
-      memcpy(msgBuf, msg->message.bytes, msg->message.size);
-      msgBuf[msg->message.size] = '\0';
-    } else {
-      typeLabel = "Sign Bytes";
-      /* Show hex preview (up to 64 hex chars = 32 bytes) */
-      unsigned show = msg->message.size;
-      if (show > 32) show = 32;
-      for (unsigned i = 0; i < show; i++) {
-        snprintf(&msgBuf[2 * i], 3, "%02x", msg->message.bytes[i]);
-      }
-      msgBuf[2 * show] = '\0';
-      if (msg->message.size > 32) {
-        snprintf(&msgBuf[64], sizeof(msgBuf) - 64, "... (%u bytes)",
-                 (unsigned)msg->message.size);
-      }
-    }
-    if (!confirm(ButtonRequestType_ButtonRequest_ProtectCall, _(typeLabel),
-                 "%s", msgBuf)) {
-      memzero(node, sizeof(*node));
-      fsm_sendFailure(FailureType_Failure_ActionCancelled,
-                      _("Signing cancelled"));
-      layoutHome();
-      return;
-    }
+  } else if (!confirm_bytes(ButtonRequestType_ButtonRequest_ProtectCall,
+                            "Sign Solana Message", msg->message.bytes,
+                            msg->message.size)) {
+    /* AdvancedMode permits the opaque primitive, but every signed byte still
+     * has to be reviewable; previews recreate the hidden-suffix bug. */
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                    _("Signing cancelled"));
+    layoutHome();
+    return;
   }
 
   /* Ed25519 sign */
@@ -1004,45 +924,14 @@ void fsm_msgSolanaSignOffchainMessage(const SolanaSignOffchainMessage* msg) {
   if (!node) return;
   hdnode_fill_public_key(node);
 
-  /* Confirm dialog. Format 0 (ASCII) is always renderable; format 1
-   * (UTF-8 limited) we render as printable bytes only — non-printable
-   * sequences fall through to a hex preview to avoid encoding
-   * surprises on the OLED. */
-  {
-    char msgBuf[129] = {0};
-    const char* typeLabel;
-    bool printable = true;
-    for (unsigned i = 0; i < msg->message.size; i++) {
-      if (msg->message.bytes[i] < 0x20 || msg->message.bytes[i] > 0x7e) {
-        printable = false;
-        break;
-      }
-    }
-    if (printable && msg->message.size <= sizeof(msgBuf) - 1) {
-      typeLabel = "Off-chain Message";
-      memcpy(msgBuf, msg->message.bytes, msg->message.size);
-      msgBuf[msg->message.size] = '\0';
-    } else {
-      typeLabel = "Off-chain Bytes";
-      unsigned show = msg->message.size;
-      if (show > 32) show = 32;
-      for (unsigned i = 0; i < show; i++) {
-        snprintf(&msgBuf[2 * i], 3, "%02x", msg->message.bytes[i]);
-      }
-      msgBuf[2 * show] = '\0';
-      if (msg->message.size > 32) {
-        snprintf(&msgBuf[64], sizeof(msgBuf) - 64, "... (%u bytes)",
-                 (unsigned)msg->message.size);
-      }
-    }
-    if (!confirm(ButtonRequestType_ButtonRequest_ProtectCall, _(typeLabel),
-                 "%s", msgBuf)) {
-      memzero(node, sizeof(*node));
-      fsm_sendFailure(FailureType_Failure_ActionCancelled,
-                      _("Signing cancelled"));
-      layoutHome();
-      return;
-    }
+  if (!confirm_bytes(ButtonRequestType_ButtonRequest_ProtectCall,
+                     "Sign Solana Off-chain Message", msg->message.bytes,
+                     msg->message.size)) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                    _("Signing cancelled"));
+    layoutHome();
+    return;
   }
 
   if (!solana_offchain_message_sign(node, msg, resp)) {

--- a/lib/firmware/fsm_msg_tendermint.h
+++ b/lib/firmware/fsm_msg_tendermint.h
@@ -94,7 +94,7 @@ void fsm_msgTendermintSignTx(const TendermintSignTx* msg) {
   RESP_INIT(TendermintMsgRequest);
 
   if (!tendermint_signTxInit(node, (void*)msg, sizeof(TendermintSignTx),
-                             msg->denom)) {
+                             msg->denom, TENDERMINT_SIGNING_GENERIC)) {
     tendermint_signAbort();
     memzero(node, sizeof(*node));
     fsm_sendFailure(FailureType_Failure_FirmwareError,
@@ -110,7 +110,20 @@ void fsm_msgTendermintSignTx(const TendermintSignTx* msg) {
 
 void fsm_msgTendermintMsgAck(const TendermintMsgAck* msg) {
   // Confirm transaction basics
-  CHECK_PARAM(tendermint_signingIsInited(), "Signing not in progress");
+  CHECK_PARAM(tendermint_signingIsInited(TENDERMINT_SIGNING_GENERIC),
+              "Tendermint signing not in progress");
+  const TendermintSignTx* sign_tx =
+      (const TendermintSignTx*)tendermint_getSignTx();
+  if (!msg->has_chain_name || !msg->has_denom ||
+      !msg->has_message_type_prefix ||
+      !tendermint_signingConfigMatches(msg->chain_name, msg->denom,
+                                       msg->message_type_prefix)) {
+    tendermint_signAbort();
+    fsm_sendFailure(FailureType_Failure_SyntaxError,
+                    "Tendermint ACK does not match signing session");
+    layoutHome();
+    return;
+  }
   if (!msg->has_send || !msg->send.has_to_address || !msg->send.has_amount) {
     tendermint_signAbort();
     // 8 + ^14 + 13 + 1 = 36
@@ -124,23 +137,28 @@ void fsm_msgTendermintMsgAck(const TendermintMsgAck* msg) {
   }
 
   const CoinType* coin = fsm_getCoin(true, msg->chain_name);
-  if (!coin || !coin->has_coin_shortcut || !coin->has_decimals) {
+  if (!coin) {
+    tendermint_signAbort();
+    layoutHome();
     return;
   }
-
-  const TendermintSignTx* sign_tx = (TendermintSignTx*)tendermint_getSignTx();
 
   switch (msg->send.address_type) {
     case OutputAddressType_TRANSFER:
     default: {
-      char amount_str[32];
-      char suffix[sizeof(coin->coin_shortcut) +
-                  1];  // sizeof(coin->coin_shortcut) includes space for the
-                       // terminator
-      strlcpy(suffix, " ", sizeof(suffix));
-      strlcat(suffix, coin->coin_shortcut, sizeof(suffix));
-      bn_format_uint64(msg->send.amount, NULL, suffix, coin->decimals, 0, false,
-                       amount_str, sizeof(amount_str));
+      /* The host-supplied denomination is part of the signed Amino JSON. Do
+       * not relabel or rescale it using unrelated coin metadata. */
+      char amount_str[48];
+      const int amount_len =
+          snprintf(amount_str, sizeof(amount_str), "%" PRIu64 " %s",
+                   msg->send.amount, msg->denom);
+      if (amount_len <= 0 || (size_t)amount_len >= sizeof(amount_str)) {
+        tendermint_signAbort();
+        fsm_sendFailure(FailureType_Failure_SyntaxError,
+                        "Invalid Tendermint amount display");
+        layoutHome();
+        return;
+      }
       if (!confirm_transaction_output(
               ButtonRequestType_ButtonRequest_ConfirmOutput, amount_str,
               msg->send.to_address)) {
@@ -170,8 +188,29 @@ void fsm_msgTendermintMsgAck(const TendermintMsgAck* msg) {
     return;
   }
 
-  if (sign_tx->has_memo && !confirm(ButtonRequestType_ButtonRequest_ConfirmMemo,
-                                    _("Memo"), "%s", sign_tx->memo)) {
+  if (sign_tx->has_memo &&
+      !confirm_bytes(ButtonRequestType_ButtonRequest_ConfirmMemo, _("Memo"),
+                     (const uint8_t*)sign_tx->memo, strlen(sign_tx->memo))) {
+    tendermint_signAbort();
+    fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
+    layoutHome();
+    return;
+  }
+
+  /* Review the exact session values that bind the signed JSON. These fields
+   * are host supplied, so a friendly chain label must never substitute for
+   * the denomination or message-type prefix actually hashed. */
+  if (!confirm_bytes(ButtonRequestType_ButtonRequest_Other, "Chain ID",
+                     (const uint8_t*)sign_tx->chain_id,
+                     strlen(sign_tx->chain_id)) ||
+      !confirm_bytes(ButtonRequestType_ButtonRequest_Other, "Chain Name",
+                     (const uint8_t*)sign_tx->chain_name,
+                     strlen(sign_tx->chain_name)) ||
+      !confirm_bytes(ButtonRequestType_ButtonRequest_Other, "Denomination",
+                     (const uint8_t*)sign_tx->denom, strlen(sign_tx->denom)) ||
+      !confirm_bytes(ButtonRequestType_ButtonRequest_Other, "Message Type",
+                     (const uint8_t*)sign_tx->message_type_prefix,
+                     strlen(sign_tx->message_type_prefix))) {
     tendermint_signAbort();
     fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
     layoutHome();
@@ -189,10 +228,8 @@ void fsm_msgTendermintMsgAck(const TendermintMsgAck* msg) {
   }
 
   if (!confirm(ButtonRequestType_ButtonRequest_SignTx, node_str,
-               "Sign %s transaction on %s? "
-               "It includes a fee of %" PRIu32 " %s and %" PRIu32 " gas.",
-               msg->chain_name, sign_tx->chain_id, sign_tx->fee_amount,
-               msg->denom, sign_tx->gas)) {
+               "Sign transaction? Fee: %" PRIu32 " %s. Gas: %" PRIu32 ".",
+               sign_tx->fee_amount, sign_tx->denom, sign_tx->gas)) {
     tendermint_signAbort();
     fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
     layoutHome();

--- a/lib/firmware/fsm_msg_ton.h
+++ b/lib/firmware/fsm_msg_ton.h
@@ -194,43 +194,16 @@ void fsm_msgTonSignMessage(const TonSignMessage* msg) {
   if (!node) return;
   hdnode_fill_public_key(node);
 
-  /* Always require on-device confirmation. Display message content if
-   * printable, hex preview otherwise. */
-  {
-    char msgBuf[129] = {0};
-    const char* typeLabel;
-    bool printable = true;
-    for (unsigned i = 0; i < msg->message.size; i++) {
-      if (msg->message.bytes[i] < 0x20 || msg->message.bytes[i] > 0x7e) {
-        printable = false;
-        break;
-      }
-    }
-    if (printable && msg->message.size <= sizeof(msgBuf) - 1) {
-      typeLabel = "Sign TON Message";
-      memcpy(msgBuf, msg->message.bytes, msg->message.size);
-      msgBuf[msg->message.size] = '\0';
-    } else {
-      typeLabel = "Sign TON Bytes";
-      unsigned show = msg->message.size;
-      if (show > 32) show = 32;
-      for (unsigned i = 0; i < show; i++) {
-        snprintf(&msgBuf[2 * i], 3, "%02x", msg->message.bytes[i]);
-      }
-      msgBuf[2 * show] = '\0';
-      if (msg->message.size > 32) {
-        snprintf(&msgBuf[64], sizeof(msgBuf) - 64, "... (%u bytes)",
-                 (unsigned)msg->message.size);
-      }
-    }
-    if (!confirm(ButtonRequestType_ButtonRequest_ProtectCall, _(typeLabel),
-                 "%s", msgBuf)) {
-      memzero(node, sizeof(*node));
-      fsm_sendFailure(FailureType_Failure_ActionCancelled,
-                      _("Signing cancelled"));
-      layoutHome();
-      return;
-    }
+  /* AdvancedMode permits the opaque primitive, but never permits a hidden
+   * suffix: review every signed byte using renderer-measured pages. */
+  if (!confirm_bytes(ButtonRequestType_ButtonRequest_ProtectCall,
+                     "Sign TON Message", msg->message.bytes,
+                     msg->message.size)) {
+    memzero(node, sizeof(*node));
+    fsm_sendFailure(FailureType_Failure_ActionCancelled,
+                    _("Signing cancelled"));
+    layoutHome();
+    return;
   }
 
   if (!ton_message_sign(node, msg, resp)) {

--- a/lib/firmware/fsm_msg_tron.h
+++ b/lib/firmware/fsm_msg_tron.h
@@ -212,11 +212,6 @@ void fsm_msgTronSignTx(TronSignTx* msg) {
   layoutHome();
 }
 
-#ifndef TRON_MSG_DISPLAY_MAX
-#define TRON_MSG_DISPLAY_MAX \
-  (38 * 3)  // mirrors ETH MSG_MAX (3 lines × 38 chars)
-#endif
-
 void fsm_msgTronSignMessage(TronSignMessage* msg) {
   RESP_INIT(TronMessageSignature);
 
@@ -233,37 +228,9 @@ void fsm_msgTronSignMessage(TronSignMessage* msg) {
     return;
   }
 
-  char msgBuf[TRON_MSG_DISPLAY_MAX + 1] = {0};
-  const char* typeIndicator;
-  bool canPrint = true;
-  unsigned ctr;
-
-  for (ctr = 0; ctr < msg->message.size; ctr++) {
-    if (isprint(msg->message.bytes[ctr]) == false) {
-      canPrint = false;
-      break;
-    }
-  }
-
-  if (canPrint) {
-    typeIndicator = "Sign TRON Message";
-    unsigned copy = msg->message.size;
-    if (copy > TRON_MSG_DISPLAY_MAX) copy = TRON_MSG_DISPLAY_MAX;
-    memcpy(msgBuf, msg->message.bytes, copy);
-    msgBuf[copy] = '\0';
-  } else {
-    typeIndicator = "Sign TRON Bytes";
-    unsigned hexBytes = msg->message.size;
-    if (hexBytes * 2 > TRON_MSG_DISPLAY_MAX) {
-      hexBytes = TRON_MSG_DISPLAY_MAX / 2;
-    }
-    for (ctr = 0; ctr < hexBytes; ctr++) {
-      snprintf(&msgBuf[2 * ctr], 3, "%02x", msg->message.bytes[ctr]);
-    }
-  }
-
-  if (!confirm(ButtonRequestType_ButtonRequest_ProtectCall, _(typeIndicator),
-               "%s", msgBuf)) {
+  if (!confirm_bytes(ButtonRequestType_ButtonRequest_ProtectCall,
+                     "Sign TRON Message", msg->message.bytes,
+                     msg->message.size)) {
     fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
     layoutHome();
     return;
@@ -303,37 +270,9 @@ void fsm_msgTronVerifyMessage(const TronVerifyMessage* msg) {
     return;
   }
 
-  char msgBuf[TRON_MSG_DISPLAY_MAX + 1] = {0};
-  const char* typeIndicator;
-  bool canPrint = true;
-  unsigned ctr;
-
-  for (ctr = 0; ctr < msg->message.size; ctr++) {
-    if (isprint(msg->message.bytes[ctr]) == false) {
-      canPrint = false;
-      break;
-    }
-  }
-
-  if (canPrint) {
-    typeIndicator = "Message Verified";
-    unsigned copy = msg->message.size;
-    if (copy > TRON_MSG_DISPLAY_MAX) copy = TRON_MSG_DISPLAY_MAX;
-    memcpy(msgBuf, msg->message.bytes, copy);
-    msgBuf[copy] = '\0';
-  } else {
-    typeIndicator = "Bytes Verified";
-    unsigned hexBytes = msg->message.size;
-    if (hexBytes * 2 > TRON_MSG_DISPLAY_MAX) {
-      hexBytes = TRON_MSG_DISPLAY_MAX / 2;
-    }
-    for (ctr = 0; ctr < hexBytes; ctr++) {
-      snprintf(&msgBuf[2 * ctr], 3, "%02x", msg->message.bytes[ctr]);
-    }
-  }
-
-  if (!confirm(ButtonRequestType_ButtonRequest_Other, _(typeIndicator), "%s",
-               msgBuf)) {
+  if (!confirm_bytes(ButtonRequestType_ButtonRequest_Other,
+                     "TRON Message Verified", msg->message.bytes,
+                     msg->message.size)) {
     fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
     layoutHome();
     return;

--- a/lib/firmware/hive.c
+++ b/lib/firmware/hive.c
@@ -297,6 +297,11 @@ static bool cur_varint(HiveCur* c, uint32_t* out) {
     if (shift == 28 && (b & 0xF0)) return false;  // overflow or 6th byte
     v |= (uint32_t)(b & 0x7F) << shift;
     if (!(b & 0x80)) {
+      // A multi-byte LEB128 whose final group is zero has a shorter encoding.
+      // hived re-serializes values canonically when checking a signature, so
+      // accepting an overlong form would make the device sign bytes the chain
+      // interprets and hashes differently.
+      if (shift > 0 && (b & 0x7F) == 0) return false;
       *out = v;
       return true;
     }
@@ -315,6 +320,53 @@ static bool cur_string(HiveCur* c, const uint8_t** s, uint16_t* slen,
   *slen = (uint16_t)n;
   c->p += n;
   return true;
+}
+
+/*
+ * Hive account names are rendered in compact multi-field confirmation screens,
+ * so they must be valid protocol names rather than arbitrary byte strings.
+ * This rejects embedded NUL/newline/control bytes that would truncate or
+ * reshape the OLED while later bytes remained covered by the signature.
+ */
+static bool hive_account_name_valid(const uint8_t* s, uint16_t len,
+                                    bool allow_empty) {
+  if (len == 0) return allow_empty;
+  if (len < 3 || len > 16) return false;
+
+  bool at_segment_start = true;
+  bool previous_hyphen = false;
+  for (uint16_t i = 0; i < len; i++) {
+    uint8_t ch = s[i];
+    if (at_segment_start) {
+      if (ch < 'a' || ch > 'z') return false;
+      at_segment_start = false;
+      previous_hyphen = false;
+    } else if (ch == '.') {
+      if (previous_hyphen || i + 1 == len) return false;
+      at_segment_start = true;
+    } else if ((ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9')) {
+      previous_hyphen = false;
+    } else if (ch == '-') {
+      previous_hyphen = true;
+    } else {
+      return false;
+    }
+  }
+  return !at_segment_start && !previous_hyphen;
+}
+
+static bool cur_account(HiveCur* c, const uint8_t** s, uint16_t* slen,
+                        bool allow_empty) {
+  if (!cur_string(c, s, slen, allow_empty ? 0 : 1, 16)) return false;
+  return hive_account_name_valid(*s, *slen, allow_empty);
+}
+
+static int hive_slice_cmp(const uint8_t* a, uint16_t a_len, const uint8_t* b,
+                          uint16_t b_len) {
+  uint16_t min_len = a_len < b_len ? a_len : b_len;
+  int cmp = memcmp(a, b, min_len);
+  if (cmp != 0) return cmp;
+  return (a_len > b_len) - (a_len < b_len);
 }
 
 /* Fixed-width little-endian readers, bounds-checked against the buffer. */
@@ -472,8 +524,8 @@ const char* hive_parseOperations(const uint8_t* tx, size_t len,
 
     switch (op_type) {
       case HIVE_OP_VOTE: {  // posting authority
-        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
-            !cur_string(&c, &op->target, &op->target_len, 1, 16) ||
+        if (!cur_account(&c, &op->acct, &op->acct_len, false) ||
+            !cur_account(&c, &op->target, &op->target_len, false) ||
             !cur_string(&c, &op->detail, &op->detail_len, 1, 256))
           return E_MALFORMED;
         if ((size_t)(c.end - c.p) < 2) return E_MALFORMED;
@@ -487,9 +539,9 @@ const char* hive_parseOperations(const uint8_t* tx, size_t len,
       case HIVE_OP_COMMENT: {  // posting authority
         const uint8_t *pa, *ppl, *permlink, *jm;
         uint16_t pa_len, ppl_len, permlink_len, jm_len;
-        if (!cur_string(&c, &pa, &pa_len, 0, 16) ||
+        if (!cur_account(&c, &pa, &pa_len, true) ||
             !cur_string(&c, &ppl, &ppl_len, 1, 256) ||
-            !cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
+            !cur_account(&c, &op->acct, &op->acct_len, false) ||
             !cur_string(&c, &permlink, &permlink_len, 1, 256) ||
             !cur_string(&c, &op->target, &op->target_len, 0, 256) ||
             !cur_string(&c, &op->detail, &op->detail_len, 1,
@@ -511,20 +563,40 @@ const char* hive_parseOperations(const uint8_t* tx, size_t len,
       case HIVE_OP_CUSTOM_JSON: {  // posting OR active authority
         uint32_t n_active, n_posting;
         if (!cur_varint(&c, &n_active)) return E_MALFORMED;
+        if (n_active > HIVE_MAX_CUSTOM_JSON_AUTHS) return E_RANGE;
+        const uint8_t* previous_auth = NULL;
+        uint16_t previous_auth_len = 0;
         for (uint32_t k = 0; k < n_active; k++) {
           const uint8_t* s;
           uint16_t sl;
-          if (!cur_string(&c, &s, &sl, 1, 16)) return E_MALFORMED;
+          if (!cur_account(&c, &s, &sl, false)) return E_MALFORMED;
+          if (previous_auth &&
+              hive_slice_cmp(previous_auth, previous_auth_len, s, sl) >= 0)
+            return E_MALFORMED;
+          op->auth_acct[op->n_auths] = s;
+          op->auth_acct_len[op->n_auths++] = sl;
+          previous_auth = s;
+          previous_auth_len = sl;
           if (!op->acct) {
             op->acct = s;
             op->acct_len = sl;
           }
         }
         if (!cur_varint(&c, &n_posting)) return E_MALFORMED;
+        if (n_posting > HIVE_MAX_CUSTOM_JSON_AUTHS - n_active) return E_RANGE;
+        previous_auth = NULL;
+        previous_auth_len = 0;
         for (uint32_t k = 0; k < n_posting; k++) {
           const uint8_t* s;
           uint16_t sl;
-          if (!cur_string(&c, &s, &sl, 1, 16)) return E_MALFORMED;
+          if (!cur_account(&c, &s, &sl, false)) return E_MALFORMED;
+          if (previous_auth &&
+              hive_slice_cmp(previous_auth, previous_auth_len, s, sl) >= 0)
+            return E_MALFORMED;
+          op->auth_acct[op->n_auths] = s;
+          op->auth_acct_len[op->n_auths++] = sl;
+          previous_auth = s;
+          previous_auth_len = sl;
           if (!op->acct) {
             op->acct = s;
             op->acct_len = sl;
@@ -538,7 +610,6 @@ const char* hive_parseOperations(const uint8_t* tx, size_t len,
             !cur_string(&c, &op->detail, &op->detail_len, 1,
                         HIVE_MAX_OPS_TX_LEN))
           return E_MALFORMED;
-        op->n_auths = (uint8_t)(n_active + n_posting);
         op->needs_active = (n_active > 0);
         if (op->needs_active)
           any_active = true;
@@ -548,8 +619,8 @@ const char* hive_parseOperations(const uint8_t* tx, size_t len,
       }
       case HIVE_OP_TRANSFER_TO_VESTING: {  // active authority
         // `to` may be empty — hived reads that as "power up to self".
-        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
-            !cur_string(&c, &op->target, &op->target_len, 0, 16) ||
+        if (!cur_account(&c, &op->acct, &op->acct_len, false) ||
+            !cur_account(&c, &op->target, &op->target_len, true) ||
             !cur_asset(&c, &op->assets[0], HIVE_SYM_HIVE))
           return E_MALFORMED;
         if (hive_assetAmount(op->assets[0]) == 0) return E_AMOUNT;
@@ -560,7 +631,7 @@ const char* hive_parseOperations(const uint8_t* tx, size_t len,
       case HIVE_OP_WITHDRAW_VESTING: {  // active authority
         // 0.000000 VESTS is meaningful here: it cancels an in-progress
         // power-down, so zero must NOT be rejected.
-        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
+        if (!cur_account(&c, &op->acct, &op->acct_len, false) ||
             !cur_asset(&c, &op->assets[0], HIVE_SYM_VESTS))
           return E_MALFORMED;
         op->n_assets = 1;
@@ -568,7 +639,7 @@ const char* hive_parseOperations(const uint8_t* tx, size_t len,
         break;
       }
       case HIVE_OP_LIMIT_ORDER_CREATE: {  // active authority
-        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
+        if (!cur_account(&c, &op->acct, &op->acct_len, false) ||
             !cur_u32(&c, &op->req_id) ||
             !cur_asset(&c, &op->assets[0], HIVE_SYM_HIVE | HIVE_SYM_HBD) ||
             !cur_asset(&c, &op->assets[1], HIVE_SYM_HIVE | HIVE_SYM_HBD) ||
@@ -587,14 +658,14 @@ const char* hive_parseOperations(const uint8_t* tx, size_t len,
         break;
       }
       case HIVE_OP_LIMIT_ORDER_CANCEL: {  // active authority
-        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
+        if (!cur_account(&c, &op->acct, &op->acct_len, false) ||
             !cur_u32(&c, &op->req_id))
           return E_MALFORMED;
         any_active = true;
         break;
       }
       case HIVE_OP_CONVERT: {  // active authority
-        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
+        if (!cur_account(&c, &op->acct, &op->acct_len, false) ||
             !cur_u32(&c, &op->req_id) ||
             !cur_asset(&c, &op->assets[0], HIVE_SYM_HBD))
           return E_MALFORMED;
@@ -605,7 +676,7 @@ const char* hive_parseOperations(const uint8_t* tx, size_t len,
       }
       case HIVE_OP_COMMENT_OPTIONS: {  // posting authority
         uint16_t percent_hbd;
-        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
+        if (!cur_account(&c, &op->acct, &op->acct_len, false) ||
             !cur_string(&c, &op->permlink, &op->permlink_len, 1, 256) ||
             !cur_asset(&c, &op->assets[0], HIVE_SYM_HBD) ||
             !cur_u16(&c, &percent_hbd) || !cur_bool(&c, &op->flag) ||
@@ -645,8 +716,8 @@ const char* hive_parseOperations(const uint8_t* tx, size_t len,
           const uint8_t* prev_acct = NULL;
           uint16_t prev_acct_len = 0;
           for (uint32_t k = 0; k < n_benef; k++) {
-            if (!cur_string(&c, &op->benef_acct[k], &op->benef_acct_len[k], 1,
-                            16) ||
+            if (!cur_account(&c, &op->benef_acct[k], &op->benef_acct_len[k],
+                             false) ||
                 !cur_u16(&c, &op->benef_weight[k]))
               return E_MALFORMED;
             if (op->benef_weight[k] > 10000) return E_RANGE;
@@ -654,12 +725,8 @@ const char* hive_parseOperations(const uint8_t* tx, size_t len,
             // enforces uniqueness. An unsorted list is rejected on-chain, so
             // signing it would only waste a device confirmation.
             if (prev_acct) {
-              uint16_t min_len = prev_acct_len < op->benef_acct_len[k]
-                                     ? prev_acct_len
-                                     : op->benef_acct_len[k];
-              int cmp = memcmp(prev_acct, op->benef_acct[k], min_len);
-              if (cmp > 0 ||
-                  (cmp == 0 && prev_acct_len >= op->benef_acct_len[k]))
+              if (hive_slice_cmp(prev_acct, prev_acct_len, op->benef_acct[k],
+                                 op->benef_acct_len[k]) >= 0)
                 return E_BENEFICIARIES;
             }
             prev_acct = op->benef_acct[k];
@@ -673,8 +740,8 @@ const char* hive_parseOperations(const uint8_t* tx, size_t len,
         break;
       }
       case HIVE_OP_TRANSFER_TO_SAVINGS: {  // active authority
-        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
-            !cur_string(&c, &op->target, &op->target_len, 1, 16) ||
+        if (!cur_account(&c, &op->acct, &op->acct_len, false) ||
+            !cur_account(&c, &op->target, &op->target_len, false) ||
             !cur_asset(&c, &op->assets[0], HIVE_SYM_HIVE | HIVE_SYM_HBD) ||
             !cur_string(&c, &op->detail, &op->detail_len, 0, HIVE_MAX_MEMO_LEN))
           return E_MALFORMED;
@@ -684,9 +751,9 @@ const char* hive_parseOperations(const uint8_t* tx, size_t len,
         break;
       }
       case HIVE_OP_TRANSFER_FROM_SAVINGS: {  // active authority
-        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
+        if (!cur_account(&c, &op->acct, &op->acct_len, false) ||
             !cur_u32(&c, &op->req_id) ||
-            !cur_string(&c, &op->target, &op->target_len, 1, 16) ||
+            !cur_account(&c, &op->target, &op->target_len, false) ||
             !cur_asset(&c, &op->assets[0], HIVE_SYM_HIVE | HIVE_SYM_HBD) ||
             !cur_string(&c, &op->detail, &op->detail_len, 0, HIVE_MAX_MEMO_LEN))
           return E_MALFORMED;
@@ -696,7 +763,7 @@ const char* hive_parseOperations(const uint8_t* tx, size_t len,
         break;
       }
       case HIVE_OP_CLAIM_REWARD_BALANCE: {  // posting authority
-        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
+        if (!cur_account(&c, &op->acct, &op->acct_len, false) ||
             !cur_asset(&c, &op->assets[0], HIVE_SYM_HIVE) ||
             !cur_asset(&c, &op->assets[1], HIVE_SYM_HBD) ||
             !cur_asset(&c, &op->assets[2], HIVE_SYM_VESTS))
@@ -711,8 +778,8 @@ const char* hive_parseOperations(const uint8_t* tx, size_t len,
       }
       case HIVE_OP_DELEGATE_VESTING_SHARES: {  // active authority
         // 0.000000 VESTS is meaningful: it removes an existing delegation.
-        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
-            !cur_string(&c, &op->target, &op->target_len, 1, 16) ||
+        if (!cur_account(&c, &op->acct, &op->acct_len, false) ||
+            !cur_account(&c, &op->target, &op->target_len, false) ||
             !cur_asset(&c, &op->assets[0], HIVE_SYM_VESTS))
           return E_MALFORMED;
         op->n_assets = 1;
@@ -721,7 +788,7 @@ const char* hive_parseOperations(const uint8_t* tx, size_t len,
       }
       case HIVE_OP_ACCOUNT_UPDATE2: {  // active or posting authority
         uint32_t ext_n;
-        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16))
+        if (!cur_account(&c, &op->acct, &op->acct_len, false))
           return E_MALFORMED;
         // SECURITY: account_update2 can rotate owner/active/posting/memo
         // keys. Only the profile-metadata form is in the table — this is the

--- a/lib/firmware/hive.c
+++ b/lib/firmware/hive.c
@@ -317,6 +317,118 @@ static bool cur_string(HiveCur* c, const uint8_t** s, uint16_t* slen,
   return true;
 }
 
+/* Fixed-width little-endian readers, bounds-checked against the buffer. */
+static bool cur_u16(HiveCur* c, uint16_t* out) {
+  if ((size_t)(c->end - c->p) < 2) return false;
+  *out = (uint16_t)((uint16_t)c->p[0] | ((uint16_t)c->p[1] << 8));
+  c->p += 2;
+  return true;
+}
+
+static bool cur_u32(HiveCur* c, uint32_t* out) {
+  if ((size_t)(c->end - c->p) < 4) return false;
+  *out = (uint32_t)c->p[0] | ((uint32_t)c->p[1] << 8) |
+         ((uint32_t)c->p[2] << 16) | ((uint32_t)c->p[3] << 24);
+  c->p += 4;
+  return true;
+}
+
+/*
+ * Graphene serializes bool as one byte. Anything other than 0/1 is a host
+ * serializer bug, not a truthy value — reject rather than normalize, so a
+ * malformed fill_or_kill or allow_votes can never be silently coerced.
+ */
+static bool cur_bool(HiveCur* c, bool* out) {
+  if (c->p >= c->end) return false;
+  uint8_t b = *c->p++;
+  if (b > 1) return false;
+  *out = (b == 1);
+  return true;
+}
+
+uint64_t hive_assetAmount(const uint8_t* a) {
+  uint64_t v = 0;
+  for (int i = 7; i >= 0; i--) v = (v << 8) | a[i];
+  return v;
+}
+
+uint8_t hive_assetPrecision(const uint8_t* a) { return a[8]; }
+
+const char* hive_assetSymbol(const uint8_t* a) { return (const char*)(a + 9); }
+
+/*
+ * One 16-byte Graphene asset: int64 LE amount, uint8 precision, 7-byte
+ * NUL-padded symbol.
+ *
+ * The symbol must be in `allowed` and carry its protocol-fixed precision.
+ * Both checks are load-bearing for display integrity: an unexpected symbol
+ * lets a host swap VESTS for HIVE (a ~2000x difference in real value behind
+ * an identical-looking number), and a wrong precision moves the decimal
+ * point on the confirmation screen relative to what the chain applies.
+ */
+static bool cur_asset(HiveCur* c, const uint8_t** out, uint32_t allowed) {
+  if ((size_t)(c->end - c->p) < HIVE_ASSET_LEN) return false;
+  const uint8_t* a = c->p;
+  const uint8_t* sym = a + 9;
+
+  uint32_t bit;
+  uint8_t want_precision;
+  size_t sym_len;
+  if (memcmp(sym, "HIVE", 4) == 0) {
+    bit = HIVE_SYM_HIVE;
+    want_precision = 3;
+    sym_len = 4;
+  } else if (memcmp(sym, "HBD", 3) == 0) {
+    bit = HIVE_SYM_HBD;
+    want_precision = 3;
+    sym_len = 3;
+  } else if (memcmp(sym, "VESTS", 5) == 0) {
+    bit = HIVE_SYM_VESTS;
+    want_precision = 6;
+    sym_len = 5;
+  } else {
+    return false;
+  }
+  // The prefix compares above would also accept a longer symbol sharing the
+  // prefix ("HBDX"); the padding check is what makes them exact, and it also
+  // guarantees hive_assetSymbol() returns a NUL-terminated C string.
+  for (size_t i = sym_len; i < 7; i++) {
+    if (sym[i] != 0) return false;
+  }
+  if (!(bit & allowed)) return false;
+  if (a[8] != want_precision) return false;
+  // Every asset field in this table is a quantity. A negative int64 would
+  // render as an enormous positive number through the unsigned formatter.
+  if (a[7] & 0x80) return false;
+
+  *out = a;
+  c->p += HIVE_ASSET_LEN;
+  return true;
+}
+
+/*
+ * Shared rejection reasons.
+ *
+ * These are diagnostics, not security surface: the protection is that the
+ * device REFUSES, and the host already knows which operation it sent. One
+ * bespoke sentence per failure site cost ~1.8KB of rodata on a part with
+ * single-digit KB of flash left, so failures are grouped by reason instead.
+ * The three that carry a distinct security meaning — an authority rotation,
+ * a detached comment_options, a wrong-tier request — stay separate so they
+ * are never confused with an ordinary parse failure in a bug report.
+ */
+static const char E_MALFORMED[] = "Hive tx: malformed operation";
+static const char E_RANGE[] = "Hive tx: value out of range";
+static const char E_AMOUNT[] = "Hive tx: amount must be greater than zero";
+static const char E_NOOP[] = "Hive tx: operation has no effect";
+static const char E_EXTENSIONS[] = "Hive tx: extensions must be empty";
+static const char E_BENEFICIARIES[] = "Hive tx: invalid beneficiaries";
+static const char E_SYMBOLS[] = "Hive tx: order symbols must differ";
+static const char E_AUTHORITY[] = "Hive tx: authority changes not supported";
+static const char E_BINDING[] =
+    "Hive tx: comment_options must follow its comment";
+static const char E_MIXED_TIER[] = "Hive tx: mixed posting/active ops";
+
 const char* hive_parseOperations(const uint8_t* tx, size_t len,
                                  HiveParsedTx* out) {
   memzero(out, sizeof(*out));
@@ -330,7 +442,7 @@ const char* hive_parseOperations(const uint8_t* tx, size_t len,
   HiveCur c = {tx + 10, tx + len};
 
   uint32_t op_count;
-  if (!cur_varint(&c, &op_count)) return "Hive tx: malformed op count";
+  if (!cur_varint(&c, &op_count)) return E_MALFORMED;
   if (op_count < 1 || op_count > HIVE_MAX_TX_OPS)
     return "Hive tx: op count must be 1-4";
   out->num_ops = (uint8_t)op_count;
@@ -340,7 +452,7 @@ const char* hive_parseOperations(const uint8_t* tx, size_t len,
   for (uint32_t i = 0; i < op_count; i++) {
     HiveTxOp* op = &out->ops[i];
     uint32_t op_type;
-    if (!cur_varint(&c, &op_type)) return "Hive tx: malformed op type";
+    if (!cur_varint(&c, &op_type)) return E_MALFORMED;
     op->op_type = op_type;
 
     switch (op_type) {
@@ -348,11 +460,11 @@ const char* hive_parseOperations(const uint8_t* tx, size_t len,
         if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
             !cur_string(&c, &op->target, &op->target_len, 1, 16) ||
             !cur_string(&c, &op->detail, &op->detail_len, 1, 256))
-          return "Hive vote: malformed fields";
-        if ((size_t)(c.end - c.p) < 2) return "Hive vote: missing weight";
+          return E_MALFORMED;
+        if ((size_t)(c.end - c.p) < 2) return E_MALFORMED;
         int16_t w = (int16_t)((uint16_t)c.p[0] | ((uint16_t)c.p[1] << 8));
         c.p += 2;
-        if (w < -10000 || w > 10000) return "Hive vote: weight out of range";
+        if (w < -10000 || w > 10000) return E_RANGE;
         op->weight = w;
         any_posting = true;
         break;
@@ -368,7 +480,7 @@ const char* hive_parseOperations(const uint8_t* tx, size_t len,
             !cur_string(&c, &op->detail, &op->detail_len, 1,
                         HIVE_MAX_OPS_TX_LEN) ||
             !cur_string(&c, &jm, &jm_len, 0, HIVE_MAX_OPS_TX_LEN))
-          return "Hive comment: malformed fields";
+          return E_MALFORMED;
         op->parent_author = pa;
         op->parent_author_len = pa_len;
         op->parent_permlink = ppl;
@@ -383,42 +495,240 @@ const char* hive_parseOperations(const uint8_t* tx, size_t len,
       }
       case HIVE_OP_CUSTOM_JSON: {  // posting OR active authority
         uint32_t n_active, n_posting;
-        if (!cur_varint(&c, &n_active))
-          return "Hive custom_json: malformed auths";
+        if (!cur_varint(&c, &n_active)) return E_MALFORMED;
         for (uint32_t k = 0; k < n_active; k++) {
           const uint8_t* s;
           uint16_t sl;
-          if (!cur_string(&c, &s, &sl, 1, 16))
-            return "Hive custom_json: malformed auths";
+          if (!cur_string(&c, &s, &sl, 1, 16)) return E_MALFORMED;
           if (!op->acct) {
             op->acct = s;
             op->acct_len = sl;
           }
         }
-        if (!cur_varint(&c, &n_posting))
-          return "Hive custom_json: malformed auths";
+        if (!cur_varint(&c, &n_posting)) return E_MALFORMED;
         for (uint32_t k = 0; k < n_posting; k++) {
           const uint8_t* s;
           uint16_t sl;
-          if (!cur_string(&c, &s, &sl, 1, 16))
-            return "Hive custom_json: malformed auths";
+          if (!cur_string(&c, &s, &sl, 1, 16)) return E_MALFORMED;
           if (!op->acct) {
             op->acct = s;
             op->acct_len = sl;
           }
         }
-        if (n_active + n_posting == 0)
-          return "Hive custom_json: no auth accounts";
+        if (n_active + n_posting == 0) return E_MALFORMED;
         // Both tiers on one op can never be satisfied by a single signature
         // (post-HF28 hived requires the exact authority) — malformed input.
-        if (n_active > 0 && n_posting > 0)
-          return "Hive custom_json: mixed active+posting auths";
+        if (n_active > 0 && n_posting > 0) return E_MIXED_TIER;
         if (!cur_string(&c, &op->target, &op->target_len, 1, 32) ||
             !cur_string(&c, &op->detail, &op->detail_len, 1,
                         HIVE_MAX_OPS_TX_LEN))
-          return "Hive custom_json: malformed id/json";
+          return E_MALFORMED;
         op->n_auths = (uint8_t)(n_active + n_posting);
         op->needs_active = (n_active > 0);
+        if (op->needs_active)
+          any_active = true;
+        else
+          any_posting = true;
+        break;
+      }
+      case HIVE_OP_TRANSFER_TO_VESTING: {  // active authority
+        // `to` may be empty — hived reads that as "power up to self".
+        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
+            !cur_string(&c, &op->target, &op->target_len, 0, 16) ||
+            !cur_asset(&c, &op->assets[0], HIVE_SYM_HIVE))
+          return E_MALFORMED;
+        if (hive_assetAmount(op->assets[0]) == 0) return E_AMOUNT;
+        op->n_assets = 1;
+        any_active = true;
+        break;
+      }
+      case HIVE_OP_WITHDRAW_VESTING: {  // active authority
+        // 0.000000 VESTS is meaningful here: it cancels an in-progress
+        // power-down, so zero must NOT be rejected.
+        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
+            !cur_asset(&c, &op->assets[0], HIVE_SYM_VESTS))
+          return E_MALFORMED;
+        op->n_assets = 1;
+        any_active = true;
+        break;
+      }
+      case HIVE_OP_LIMIT_ORDER_CREATE: {  // active authority
+        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
+            !cur_u32(&c, &op->req_id) ||
+            !cur_asset(&c, &op->assets[0], HIVE_SYM_HIVE | HIVE_SYM_HBD) ||
+            !cur_asset(&c, &op->assets[1], HIVE_SYM_HIVE | HIVE_SYM_HBD) ||
+            !cur_bool(&c, &op->flag) || !cur_u32(&c, &op->expiration))
+          return E_MALFORMED;
+        if (hive_assetAmount(op->assets[0]) == 0 ||
+            hive_assetAmount(op->assets[1]) == 0)
+          return E_AMOUNT;
+        // The internal market only pairs HIVE against HBD. A same-symbol
+        // order is rejected on-chain anyway, and on the OLED it would read
+        // as a harmless self-trade while burning the fill.
+        if (memcmp(op->assets[0] + 9, op->assets[1] + 9, 7) == 0)
+          return E_SYMBOLS;
+        op->n_assets = 2;
+        any_active = true;
+        break;
+      }
+      case HIVE_OP_LIMIT_ORDER_CANCEL: {  // active authority
+        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
+            !cur_u32(&c, &op->req_id))
+          return E_MALFORMED;
+        any_active = true;
+        break;
+      }
+      case HIVE_OP_CONVERT: {  // active authority
+        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
+            !cur_u32(&c, &op->req_id) ||
+            !cur_asset(&c, &op->assets[0], HIVE_SYM_HBD))
+          return E_MALFORMED;
+        if (hive_assetAmount(op->assets[0]) == 0) return E_AMOUNT;
+        op->n_assets = 1;
+        any_active = true;
+        break;
+      }
+      case HIVE_OP_COMMENT_OPTIONS: {  // posting authority
+        uint16_t percent_hbd;
+        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
+            !cur_string(&c, &op->permlink, &op->permlink_len, 1, 256) ||
+            !cur_asset(&c, &op->assets[0], HIVE_SYM_HBD) ||
+            !cur_u16(&c, &percent_hbd) || !cur_bool(&c, &op->flag) ||
+            !cur_bool(&c, &op->flag2))
+          return E_MALFORMED;
+        if (percent_hbd > 10000) return E_RANGE;
+        op->weight = (int16_t)percent_hbd;
+        op->n_assets = 1;
+
+        // SECURITY: this op redirects a post's payout. It binds to exactly
+        // one post, so it is accepted ONLY immediately after a comment op
+        // with the same author and permlink. Standing alone it could attach
+        // beneficiaries to a post the user published earlier and is not
+        // reviewing on this screen.
+        if (i == 0 || out->ops[i - 1].op_type != HIVE_OP_COMMENT)
+          return E_BINDING;
+        const HiveTxOp* prev = &out->ops[i - 1];
+        if (prev->acct_len != op->acct_len ||
+            memcmp(prev->acct, op->acct, op->acct_len) != 0 ||
+            prev->permlink_len != op->permlink_len ||
+            memcmp(prev->permlink, op->permlink, op->permlink_len) != 0)
+          return E_BINDING;
+
+        uint32_t ext_n;
+        if (!cur_varint(&c, &ext_n)) return E_MALFORMED;
+        // hived permits only one comment_payout_beneficiaries extension;
+        // two would let a host split 16 beneficiaries past a per-extension
+        // bound check.
+        if (ext_n > 1) return E_BENEFICIARIES;
+        if (ext_n == 1) {
+          uint32_t tag, n_benef;
+          if (!cur_varint(&c, &tag) || tag != 0) return E_BENEFICIARIES;
+          if (!cur_varint(&c, &n_benef) || n_benef < 1 ||
+              n_benef > HIVE_MAX_BENEFICIARIES)
+            return E_BENEFICIARIES;
+          uint32_t weight_sum = 0;
+          const uint8_t* prev_acct = NULL;
+          uint16_t prev_acct_len = 0;
+          for (uint32_t k = 0; k < n_benef; k++) {
+            if (!cur_string(&c, &op->benef_acct[k], &op->benef_acct_len[k], 1,
+                            16) ||
+                !cur_u16(&c, &op->benef_weight[k]))
+              return E_MALFORMED;
+            if (op->benef_weight[k] > 10000) return E_RANGE;
+            // hived requires strictly ascending account names, which also
+            // enforces uniqueness. An unsorted list is rejected on-chain, so
+            // signing it would only waste a device confirmation.
+            if (prev_acct) {
+              uint16_t min_len = prev_acct_len < op->benef_acct_len[k]
+                                     ? prev_acct_len
+                                     : op->benef_acct_len[k];
+              int cmp = memcmp(prev_acct, op->benef_acct[k], min_len);
+              if (cmp > 0 ||
+                  (cmp == 0 && prev_acct_len >= op->benef_acct_len[k]))
+                return E_BENEFICIARIES;
+            }
+            prev_acct = op->benef_acct[k];
+            prev_acct_len = op->benef_acct_len[k];
+            weight_sum += op->benef_weight[k];
+          }
+          if (weight_sum > 10000) return E_BENEFICIARIES;
+          op->n_benef = (uint8_t)n_benef;
+        }
+        any_posting = true;
+        break;
+      }
+      case HIVE_OP_TRANSFER_TO_SAVINGS: {  // active authority
+        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
+            !cur_string(&c, &op->target, &op->target_len, 1, 16) ||
+            !cur_asset(&c, &op->assets[0], HIVE_SYM_HIVE | HIVE_SYM_HBD) ||
+            !cur_string(&c, &op->detail, &op->detail_len, 0, HIVE_MAX_MEMO_LEN))
+          return E_MALFORMED;
+        if (hive_assetAmount(op->assets[0]) == 0) return E_AMOUNT;
+        op->n_assets = 1;
+        any_active = true;
+        break;
+      }
+      case HIVE_OP_TRANSFER_FROM_SAVINGS: {  // active authority
+        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
+            !cur_u32(&c, &op->req_id) ||
+            !cur_string(&c, &op->target, &op->target_len, 1, 16) ||
+            !cur_asset(&c, &op->assets[0], HIVE_SYM_HIVE | HIVE_SYM_HBD) ||
+            !cur_string(&c, &op->detail, &op->detail_len, 0, HIVE_MAX_MEMO_LEN))
+          return E_MALFORMED;
+        if (hive_assetAmount(op->assets[0]) == 0) return E_AMOUNT;
+        op->n_assets = 1;
+        any_active = true;
+        break;
+      }
+      case HIVE_OP_CLAIM_REWARD_BALANCE: {  // posting authority
+        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
+            !cur_asset(&c, &op->assets[0], HIVE_SYM_HIVE) ||
+            !cur_asset(&c, &op->assets[1], HIVE_SYM_HBD) ||
+            !cur_asset(&c, &op->assets[2], HIVE_SYM_VESTS))
+          return E_MALFORMED;
+        if (hive_assetAmount(op->assets[0]) == 0 &&
+            hive_assetAmount(op->assets[1]) == 0 &&
+            hive_assetAmount(op->assets[2]) == 0)
+          return E_NOOP;
+        op->n_assets = 3;
+        any_posting = true;
+        break;
+      }
+      case HIVE_OP_DELEGATE_VESTING_SHARES: {  // active authority
+        // 0.000000 VESTS is meaningful: it removes an existing delegation.
+        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16) ||
+            !cur_string(&c, &op->target, &op->target_len, 1, 16) ||
+            !cur_asset(&c, &op->assets[0], HIVE_SYM_VESTS))
+          return E_MALFORMED;
+        op->n_assets = 1;
+        any_active = true;
+        break;
+      }
+      case HIVE_OP_ACCOUNT_UPDATE2: {  // active or posting authority
+        uint32_t ext_n;
+        if (!cur_string(&c, &op->acct, &op->acct_len, 1, 16))
+          return E_MALFORMED;
+        // SECURITY: account_update2 can rotate owner/active/posting/memo
+        // keys. Only the profile-metadata form is in the table — this is the
+        // op-9/10 device-derived-keys invariant applied field-level. Any
+        // authority field present is a hard reject; do NOT soften this
+        // without the authority-management design review.
+        for (int k = 0; k < 4; k++) {
+          bool present;
+          if (!cur_bool(&c, &present)) return E_MALFORMED;
+          if (present) return E_AUTHORITY;
+        }
+        if (!cur_string(&c, &op->detail, &op->detail_len, 0,
+                        HIVE_MAX_OPS_TX_LEN) ||
+            !cur_string(&c, &op->json_metadata, &op->json_metadata_len, 0,
+                        HIVE_MAX_OPS_TX_LEN))
+          return E_MALFORMED;
+        if (op->detail_len == 0 && op->json_metadata_len == 0) return E_NOOP;
+        if (!cur_varint(&c, &ext_n)) return E_MALFORMED;
+        if (ext_n != 0) return E_EXTENSIONS;
+        // json_metadata is an active-key field; a posting_json_metadata-only
+        // update is a posting-tier profile change.
+        op->needs_active = (op->detail_len > 0);
         if (op->needs_active)
           any_active = true;
         else
@@ -440,12 +750,12 @@ const char* hive_parseOperations(const uint8_t* tx, size_t len,
   }
 
   uint32_t ext_count;
-  if (!cur_varint(&c, &ext_count)) return "Hive tx: malformed extensions";
-  if (ext_count != 0) return "Hive tx: extensions must be empty";
+  if (!cur_varint(&c, &ext_count)) return E_MALFORMED;
+  if (ext_count != 0) return E_EXTENSIONS;
   if (c.p != c.end) return "Hive tx: trailing bytes";
 
   // One signature cannot satisfy posting- and active-tier ops at once.
-  if (any_posting && any_active) return "Hive tx: mixed posting/active ops";
+  if (any_posting && any_active) return E_MIXED_TIER;
   out->needs_active = any_active;
   return NULL;
 }

--- a/lib/firmware/hive.c
+++ b/lib/firmware/hive.c
@@ -354,8 +354,14 @@ uint64_t hive_assetAmount(const uint8_t* asset) {
 
 uint8_t hive_assetPrecision(const uint8_t* asset) { return asset[8]; }
 
+// Wire symbol → display symbol. The chain serializes the pre-rebrand names;
+// the user knows the post-rebrand ones. cur_asset() has already validated the
+// symbol and its NUL padding, so the compares below are exact.
 const char* hive_assetSymbol(const uint8_t* asset) {
-  return (const char*)(asset + 9);
+  const char* sym = (const char*)(asset + 9);
+  if (memcmp(sym, "STEEM", 6) == 0) return "HIVE";
+  if (memcmp(sym, "SBD", 4) == 0) return "HBD";
+  return sym;
 }
 
 /*
@@ -376,11 +382,18 @@ static bool cur_asset(HiveCur* c, const uint8_t** out, uint32_t allowed) {
   uint32_t bit;
   uint8_t want_precision;
   size_t sym_len;
-  if (memcmp(sym, "HIVE", 4) == 0) {
+  // WIRE symbols, not display symbols: the 2020 rebrand renamed the tokens but
+  // NOT their on-chain serialization, so hived still encodes HIVE as "STEEM"
+  // and HBD as "SBD". Accepting the display spellings would let us sign bytes
+  // hived can never validate — its signature check re-serializes the operation
+  // and recovers a key from different bytes, surfacing as the misleading
+  // "missing required active authority". hive_assetSymbol() maps back for the
+  // OLED so the user still reads HIVE/HBD.
+  if (memcmp(sym, "STEEM", 5) == 0) {
     bit = HIVE_SYM_HIVE;
     want_precision = 3;
-    sym_len = 4;
-  } else if (memcmp(sym, "HBD", 3) == 0) {
+    sym_len = 5;
+  } else if (memcmp(sym, "SBD", 3) == 0) {
     bit = HIVE_SYM_HBD;
     want_precision = 3;
     sym_len = 3;

--- a/lib/firmware/hive.c
+++ b/lib/firmware/hive.c
@@ -346,15 +346,17 @@ static bool cur_bool(HiveCur* c, bool* out) {
   return true;
 }
 
-uint64_t hive_assetAmount(const uint8_t* a) {
+uint64_t hive_assetAmount(const uint8_t* asset) {
   uint64_t v = 0;
-  for (int i = 7; i >= 0; i--) v = (v << 8) | a[i];
+  for (int i = 7; i >= 0; i--) v = (v << 8) | asset[i];
   return v;
 }
 
-uint8_t hive_assetPrecision(const uint8_t* a) { return a[8]; }
+uint8_t hive_assetPrecision(const uint8_t* asset) { return asset[8]; }
 
-const char* hive_assetSymbol(const uint8_t* a) { return (const char*)(a + 9); }
+const char* hive_assetSymbol(const uint8_t* asset) {
+  return (const char*)(asset + 9);
+}
 
 /*
  * One 16-byte Graphene asset: int64 LE amount, uint8 precision, 7-byte

--- a/lib/firmware/osmosis.c
+++ b/lib/firmware/osmosis.c
@@ -618,6 +618,24 @@ bool osmosis_signTxFinalize(uint8_t* public_key, uint8_t* signature) {
                            NULL) == 0;
 }
 
+/*
+ * Cosmos amounts arrive as integer base-unit strings. These screens used to
+ * render them with atof() + "%.6f", which rounds anything past ~7 significant
+ * digits — on the very screen the user approves — and linked newlib's floating
+ * point engine into a ROM budget with no room for it. bn_format_uint64 places
+ * the decimal point in integer math, the same way the Hive and Ethereum
+ * confirm screens do.
+ */
+void osmosis_formatAmount(char* out, size_t out_len, const char* value,
+                          const char* denom) {
+  if (strcmp(denom, "uosmo") != 0) {
+    snprintf(out, out_len, "%s %s", value, denom);
+    return;
+  }
+  bn_format_uint64(strtoull(value, NULL, 10), NULL, " OSMO", OSMOSIS_PRECISION,
+                   0, true, out, out_len);
+}
+
 bool osmosis_signingIsInited(void) { return initialized; }
 
 bool osmosis_signingIsFinished(void) { return msgs_remaining == 0; }

--- a/lib/firmware/osmosis.c
+++ b/lib/firmware/osmosis.c
@@ -96,7 +96,52 @@ bool osmosis_signTxInit(const HDNode* _node, const OsmosisSignTx* _msg) {
   return success;
 }
 
-bool osmosis_signTxUpdateMsgSend(const char* amount, const char* to_address) {
+static bool osmosis_isCanonicalAmount(const char* value) {
+  if (!value) return false;
+  const size_t len = strlen(value);
+  if (len == 0 || len > OSMOSIS_MAX_AMOUNT_DIGITS ||
+      (len > 1 && value[0] == '0')) {
+    return false;
+  }
+  for (size_t i = 0; i < len; i++) {
+    if (value[i] < '0' || value[i] > '9') return false;
+  }
+  return true;
+}
+
+static bool osmosis_isCanonicalUint64(const char* value) {
+  if (!osmosis_isCanonicalAmount(value)) return false;
+
+  uint64_t parsed = 0;
+  for (size_t i = 0; value[i]; i++) {
+    const uint8_t digit = (uint8_t)(value[i] - '0');
+    if (parsed > (UINT64_MAX - digit) / 10) return false;
+    parsed = parsed * 10 + digit;
+  }
+  return true;
+}
+
+static bool osmosis_isValidDenom(const char* denom) {
+  if (!denom) return false;
+  const size_t len = strlen(denom);
+  if (len == 0 || len > OSMOSIS_MAX_DENOM_LEN) return false;
+
+  // Cosmos/Osmosis denominations are printable identifiers, not arbitrary
+  // JSON. This includes native, IBC and factory-style paths while excluding
+  // whitespace, quotes, backslashes and control bytes.
+  for (size_t i = 0; i < len; i++) {
+    const char c = denom[i];
+    if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+          (c >= '0' && c <= '9') || c == '/' || c == ':' || c == '.' ||
+          c == '_' || c == '-')) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool osmosis_signTxUpdateMsgSend(const char* amount, const char* to_address,
+                                 const char* denom) {
   const char mainnetp[] = "osmo";
   const char testnetp[] = "tosmo";
   const char* pfix;
@@ -105,7 +150,9 @@ bool osmosis_signTxUpdateMsgSend(const char* amount, const char* to_address) {
   size_t decoded_len;
   char hrp[45] = {0};
   uint8_t decoded[38] = {0};
-  if (!bech32_decode(hrp, decoded, &decoded_len, to_address)) {
+  if (!osmosis_isCanonicalUint64(amount) || !denom ||
+      strcmp(denom, "uosmo") != 0 ||
+      !bech32_decode(hrp, decoded, &decoded_len, to_address)) {
     return false;
   }
 
@@ -626,14 +673,32 @@ bool osmosis_signTxFinalize(uint8_t* public_key, uint8_t* signature) {
  * the decimal point in integer math, the same way the Hive and Ethereum
  * confirm screens do.
  */
-void osmosis_formatAmount(char* out, size_t out_len, const char* value,
+bool osmosis_formatAmount(char* out, size_t out_len, const char* value,
                           const char* denom) {
-  if (strcmp(denom, "uosmo") != 0) {
-    snprintf(out, out_len, "%s %s", value, denom);
-    return;
+  if (!out || out_len == 0) return false;
+  out[0] = '\0';
+  if (!osmosis_isCanonicalAmount(value) || !osmosis_isValidDenom(denom) ||
+      (strcmp(denom, "uosmo") == 0 && !osmosis_isCanonicalUint64(value))) {
+    return false;
   }
-  bn_format_uint64(strtoull(value, NULL, 10), NULL, " OSMO", OSMOSIS_PRECISION,
-                   0, true, out, out_len);
+
+  int written;
+  if (strcmp(denom, "uosmo") == 0) {
+    char scaled[OSMOSIS_MAX_AMOUNT_DIGITS + 2];
+    if (base_to_precision((uint8_t*)scaled, (const uint8_t*)value,
+                          sizeof(scaled), strlen(value),
+                          OSMOSIS_PRECISION) < 0) {
+      return false;
+    }
+    written = snprintf(out, out_len, "%s OSMO", scaled);
+  } else {
+    written = snprintf(out, out_len, "%s %s", value, denom);
+  }
+  if (written < 0 || (size_t)written >= out_len) {
+    out[0] = '\0';
+    return false;
+  }
+  return true;
 }
 
 bool osmosis_signingIsInited(void) { return initialized; }

--- a/lib/firmware/osmosis.c
+++ b/lib/firmware/osmosis.c
@@ -150,8 +150,7 @@ bool osmosis_signTxUpdateMsgSend(const char* amount, const char* to_address,
   size_t decoded_len;
   char hrp[45] = {0};
   uint8_t decoded[38] = {0};
-  if (!osmosis_isCanonicalUint64(amount) || !denom ||
-      strcmp(denom, "uosmo") != 0 ||
+  if (!osmosis_isCanonicalUint64(amount) || !osmosis_isValidDenom(denom) ||
       !bech32_decode(hrp, decoded, &decoded_len, to_address)) {
     return false;
   }
@@ -172,10 +171,17 @@ bool osmosis_signTxUpdateMsgSend(const char* amount, const char* to_address,
   const char* const prelude = "{\"type\":\"cosmos-sdk/MsgSend\",\"value\":{";
   sha256_Update(&ctx, (uint8_t*)prelude, strlen(prelude));
 
-  // 21 + ^20 + 19 = ^60
-  success &= tendermint_snprintf(
-      &ctx, buffer, sizeof(buffer),
-      "\"amount\":[{\"amount\":\"%s\",\"denom\":\"uosmo\"}]", amount);
+  // IBC and factory denoms may exceed the fixed 64-byte scratch buffer.
+  // These values are canonical and JSON-safe, so hash the field in segments.
+  static const char amount_prefix[] = "\"amount\":[{\"amount\":\"";
+  static const char denom_prefix[] = "\",\"denom\":\"";
+  static const char coin_suffix[] = "\"}]";
+  sha256_Update(&ctx, (const uint8_t*)amount_prefix,
+                sizeof(amount_prefix) - 1);
+  sha256_Update(&ctx, (const uint8_t*)amount, strlen(amount));
+  sha256_Update(&ctx, (const uint8_t*)denom_prefix, sizeof(denom_prefix) - 1);
+  sha256_Update(&ctx, (const uint8_t*)denom, strlen(denom));
+  sha256_Update(&ctx, (const uint8_t*)coin_suffix, sizeof(coin_suffix) - 1);
 
   // 17 + 45 + 1 = 63
   success &= tendermint_snprintf(&ctx, buffer, sizeof(buffer),

--- a/lib/firmware/osmosis.c
+++ b/lib/firmware/osmosis.c
@@ -176,8 +176,7 @@ bool osmosis_signTxUpdateMsgSend(const char* amount, const char* to_address,
   static const char amount_prefix[] = "\"amount\":[{\"amount\":\"";
   static const char denom_prefix[] = "\",\"denom\":\"";
   static const char coin_suffix[] = "\"}]";
-  sha256_Update(&ctx, (const uint8_t*)amount_prefix,
-                sizeof(amount_prefix) - 1);
+  sha256_Update(&ctx, (const uint8_t*)amount_prefix, sizeof(amount_prefix) - 1);
   sha256_Update(&ctx, (const uint8_t*)amount, strlen(amount));
   sha256_Update(&ctx, (const uint8_t*)denom_prefix, sizeof(denom_prefix) - 1);
   sha256_Update(&ctx, (const uint8_t*)denom, strlen(denom));

--- a/lib/firmware/signtx_tendermint.c
+++ b/lib/firmware/signtx_tendermint.c
@@ -36,19 +36,19 @@ static CONFIDENTIAL HDNode node;
 static SHA256_CTX ctx;
 static bool has_message;
 static bool initialized;
+static TendermintSigningType signing_type;
 static uint32_t msgs_remaining;
 static TendermintSignTx tmsg;
 
 const void* tendermint_getSignTx(void) { return (void*)&tmsg; }
 
 bool tendermint_signTxInit(const HDNode* _node, const void* _msg,
-                           const size_t msgsize, const char* denom) {
-  initialized = true;
-  msgs_remaining = ((TendermintSignTx*)_msg)->msg_count;
-  has_message = false;
-
-  memzero(&node, sizeof(node));
-  memcpy(&node, _node, sizeof(node));
+                           const size_t msgsize, const char* denom,
+                           TendermintSigningType type) {
+  tendermint_signAbort();
+  if (!_node || !_msg || !denom ||
+      (type != TENDERMINT_SIGNING_COSMOS && type != TENDERMINT_SIGNING_GENERIC))
+    return false;
 
   /*
     _msg is expected to be of type TendermintSignTx, CosmosSignTx or
@@ -65,6 +65,11 @@ bool tendermint_signTxInit(const HDNode* _node, const void* _msg,
     return false;
   }
 
+  const TendermintSignTx* common = (const TendermintSignTx*)_msg;
+  if (!common->has_msg_count || common->msg_count == 0) return false;
+
+  msgs_remaining = common->msg_count;
+  memcpy(&node, _node, sizeof(node));
   memcpy((void*)&tmsg, _msg, msgsize);
 
   bool success = true;
@@ -103,13 +108,24 @@ bool tendermint_signTxInit(const HDNode* _node, const void* _msg,
   // 10
   sha256_Update(&ctx, (uint8_t*)"\",\"msgs\":[", 10);
 
-  return success;
+  if (!success) {
+    tendermint_signAbort();
+    return false;
+  }
+  initialized = true;
+  signing_type = type;
+  return true;
+}
+
+static bool tendermint_canUpdate(void) {
+  return initialized && msgs_remaining > 0;
 }
 
 bool tendermint_signTxUpdateMsgSend(const uint64_t amount,
                                     const char* to_address,
                                     const char* chainstr, const char* denom,
                                     const char* msgTypePrefix) {
+  if (!tendermint_canUpdate()) return false;
   char buffer[128];
   size_t decoded_len;
   char hrp[45];
@@ -163,8 +179,10 @@ bool tendermint_signTxUpdateMsgSend(const uint64_t amount,
   success &=
       tendermint_snprintf(&ctx, buffer, sizeof(buffer), "%s\"}}", to_address);
 
-  has_message = true;
-  msgs_remaining--;
+  if (success) {
+    has_message = true;
+    msgs_remaining--;
+  }
   return success;
 }
 
@@ -173,6 +191,7 @@ bool tendermint_signTxUpdateMsgDelegate(const uint64_t amount,
                                         const char* validator_address,
                                         const char* chainstr, const char* denom,
                                         const char* msgTypePrefix) {
+  if (!tendermint_canUpdate()) return false;
   char buffer[128];
   size_t decoded_len;
   char hrp[45];
@@ -226,8 +245,10 @@ bool tendermint_signTxUpdateMsgDelegate(const uint64_t amount,
   success &= tendermint_snprintf(&ctx, buffer, sizeof(buffer), "%s\"}}",
                                  validator_address);
 
-  has_message = true;
-  msgs_remaining--;
+  if (success) {
+    has_message = true;
+    msgs_remaining--;
+  }
   return success;
 }
 bool tendermint_signTxUpdateMsgUndelegate(const uint64_t amount,
@@ -236,6 +257,7 @@ bool tendermint_signTxUpdateMsgUndelegate(const uint64_t amount,
                                           const char* chainstr,
                                           const char* denom,
                                           const char* msgTypePrefix) {
+  if (!tendermint_canUpdate()) return false;
   char buffer[128];
   size_t decoded_len;
   char hrp[45];
@@ -289,8 +311,10 @@ bool tendermint_signTxUpdateMsgUndelegate(const uint64_t amount,
   success &= tendermint_snprintf(&ctx, buffer, sizeof(buffer), "%s\"}}",
                                  validator_address);
 
-  has_message = true;
-  msgs_remaining--;
+  if (success) {
+    has_message = true;
+    msgs_remaining--;
+  }
   return success;
 }
 
@@ -298,6 +322,7 @@ bool tendermint_signTxUpdateMsgRedelegate(
     const uint64_t amount, const char* delegator_address,
     const char* validator_src_address, const char* validator_dst_address,
     const char* chainstr, const char* denom, const char* msgTypePrefix) {
+  if (!tendermint_canUpdate()) return false;
   char buffer[128];
   size_t decoded_len;
   char hrp[45];
@@ -359,8 +384,10 @@ bool tendermint_signTxUpdateMsgRedelegate(
   success &= tendermint_snprintf(&ctx, buffer, sizeof(buffer), "%s\"}}",
                                  validator_src_address);
 
-  has_message = true;
-  msgs_remaining--;
+  if (success) {
+    has_message = true;
+    msgs_remaining--;
+  }
   return success;
 }
 
@@ -369,6 +396,7 @@ bool tendermint_signTxUpdateMsgRewards(const uint64_t* amount,
                                        const char* validator_address,
                                        const char* chainstr, const char* denom,
                                        const char* msgTypePrefix) {
+  if (!tendermint_canUpdate()) return false;
   char buffer[128];
   size_t decoded_len;
   char hrp[45];
@@ -425,8 +453,10 @@ bool tendermint_signTxUpdateMsgRewards(const uint64_t* amount,
   success &= tendermint_snprintf(&ctx, buffer, sizeof(buffer), "%s\"}}",
                                  validator_address);
 
-  has_message = true;
-  msgs_remaining--;
+  if (success) {
+    has_message = true;
+    msgs_remaining--;
+  }
   return success;
 }
 
@@ -435,6 +465,7 @@ bool tendermint_signTxUpdateMsgIBCTransfer(
     const char* source_channel, const char* source_port,
     const char* revision_number, const char* revision_height,
     const char* chainstr, const char* denom, const char* msgTypePrefix) {
+  if (!tendermint_canUpdate()) return false;
   char buffer[128];
   size_t decoded_len;
   char hrp[45];
@@ -505,12 +536,15 @@ bool tendermint_signTxUpdateMsgIBCTransfer(
                                  "\",\"denom\":\"%s\"}}}",
                                  amount, denom);
 
-  has_message = true;
-  msgs_remaining--;
+  if (success) {
+    has_message = true;
+    msgs_remaining--;
+  }
   return success;
 }
 
 bool tendermint_signTxFinalize(uint8_t* public_key, uint8_t* signature) {
+  if (!initialized || msgs_remaining != 0 || !has_message) return false;
   char buffer[128];
 
   // 14 + ^20 + 2 = ^36
@@ -528,12 +562,26 @@ bool tendermint_signTxFinalize(uint8_t* public_key, uint8_t* signature) {
                            NULL) == 0;
 }
 
-bool tendermint_signingIsInited(void) { return initialized; }
+bool tendermint_signingIsInited(TendermintSigningType type) {
+  return initialized && signing_type == type;
+}
 
-bool tendermint_signingIsFinished(void) { return msgs_remaining == 0; }
+bool tendermint_signingConfigMatches(const char* chain_name, const char* denom,
+                                     const char* message_type_prefix) {
+  return tendermint_signingIsInited(TENDERMINT_SIGNING_GENERIC) && chain_name &&
+         denom && message_type_prefix &&
+         strcmp(chain_name, tmsg.chain_name) == 0 &&
+         strcmp(denom, tmsg.denom) == 0 &&
+         strcmp(message_type_prefix, tmsg.message_type_prefix) == 0;
+}
+
+bool tendermint_signingIsFinished(void) {
+  return initialized && msgs_remaining == 0;
+}
 
 void tendermint_signAbort(void) {
   initialized = false;
+  signing_type = TENDERMINT_SIGNING_NONE;
   has_message = false;
   msgs_remaining = 0;
   memzero(&tmsg, sizeof(tmsg));

--- a/lib/firmware/thorchain.c
+++ b/lib/firmware/thorchain.c
@@ -20,6 +20,7 @@
 #include "keepkey/firmware/thorchain.h"
 #include "keepkey/board/confirm_sm.h"
 #include "keepkey/board/util.h"
+#include "keepkey/firmware/app_confirm.h"
 #include "keepkey/firmware/home_sm.h"
 #include "keepkey/firmware/storage.h"
 #include "keepkey/firmware/tendermint.h"
@@ -240,52 +241,8 @@ void thorchain_signAbort(void) {
  * best-effort structured summary. */
 bool thorchain_confirm_full_memo(const char* title, const char* memo,
                                  size_t len) {
-  enum { ASCII_CHUNK = 72, HEX_CHUNK = 40 };
-  if (len == 0) {
-    /* An empty memo would otherwise fall through to the hex branch below with
-     * take == 0, leaving `rendered` uninitialized when passed to %s. */
-    return confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
-                   "(empty)");
-  }
-  bool ascii = true;
-  for (size_t i = 0; i < len; i++) {
-    if ((uint8_t)memo[i] < 0x20 || (uint8_t)memo[i] > 0x7e) {
-      ascii = false;
-      break;
-    }
-  }
-  size_t chunk = ascii ? ASCII_CHUNK : HEX_CHUNK;
-  size_t pages = (len + chunk - 1) / chunk;
-  if (pages == 0) pages = 1;
-
-  for (size_t page = 0; page < pages; page++) {
-    size_t offset = page * chunk;
-    size_t take = len - offset;
-    if (take > chunk) take = chunk;
-
-    char page_title[24];
-    snprintf(page_title, sizeof(page_title),
-             ascii ? "%s %u/%u" : "%s Hex %u/%u", title, (unsigned)(page + 1),
-             (unsigned)pages);
-
-    if (ascii) {
-      char rendered[ASCII_CHUNK + 1];
-      memcpy(rendered, memo + offset, take);
-      rendered[take] = '\0';
-      if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, page_title,
-                   "%s", rendered))
-        return false;
-    } else {
-      char rendered[HEX_CHUNK * 2 + 1];
-      for (size_t i = 0; i < take; i++) {
-        snprintf(rendered + 2 * i, 3, "%02x", (uint8_t)memo[offset + i]);
-      }
-      if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput, page_title,
-                   "%s", rendered))
-        return false;
-    }
-  }
-  return true;
+  return confirm_bytes(ButtonRequestType_ButtonRequest_ConfirmOutput, title,
+                       (const uint8_t*)memo, len);
 }
 
 bool thorchain_parseConfirmMemo(const char* swapStr, size_t size) {

--- a/scripts/build/docker/device/release.sh
+++ b/scripts/build/docker/device/release.sh
@@ -7,8 +7,8 @@ IMAGETAG=kktech/firmware:v15
 
 docker image inspect $IMAGETAG > /dev/null || docker pull $IMAGETAG
 
-# Extra cmake flags pass straight through (reproducible-build verification of
-# the other variants): ./release.sh -DKK_BITCOIN_ONLY=ON  /  -DKK_ZCASH_PRIVACY=ON
+# Extra cmake flags pass straight through. The only alternate release product
+# is bitcoin-only: ./release.sh -DKK_BITCOIN_ONLY=ON
 EXTRA_CMAKE_FLAGS="$*"
 
 docker run -t \

--- a/tools/check_sram_budget.py
+++ b/tools/check_sram_budget.py
@@ -6,7 +6,7 @@ static allocation (_ebss) and the top-of-RAM stack (_stack) — drops below the
 per-variant budget, or when the largest single stack frame (-fstack-usage)
 leaves less than the configured margin inside that reserve.
 
-Why this exists: RC7's zcash-privacy build shipped with an 11,232-byte gap
+Why this exists: RC7's privacy-enabled build shipped with an 11,232-byte gap
 while msg_write() carried a 12,416-byte automatic TrezorFrameBuffer — every
 USB response overwrote static memory, hard-faulting on boot. The linker also
 ASSERTs a 16 KiB floor (tools/firmware/keepkey.ld); this script is the
@@ -15,7 +15,7 @@ observability + frame-margin half of that gate.
 Usage:
   check_sram_budget.py --elf bin/...firmware.keepkey.elf \
       --su-tar bin/stack-usage.tgz --budgets tools/sram-budgets.json \
-      --variant zcash-privacy
+      --variant full
 """
 
 import argparse

--- a/tools/firmware/keepkey.ld
+++ b/tools/firmware/keepkey.ld
@@ -74,7 +74,7 @@ _codelen = SIZEOF(.text) + SIZEOF(.data) + SIZEOF(.ARM.exidx) + SIZEOF(.version)
 
 /* Runtime SRAM gate: everything between the end of static allocation (.bss)
  * and the top-of-RAM stack is the ONLY memory the running firmware has for
- * call frames. RC7's zcash-privacy variant shipped with an 11.2 KB gap while
+ * call frames. RC7's privacy-enabled build shipped with an 11.2 KB gap while
  * msg_write() put a 12.4 KB frame on the stack — a guaranteed boot-path
  * overwrite of static memory. Never again: require a 16 KiB reserve at link
  * time, for every variant. (Initial limit — replace with measured worst-case

--- a/tools/sram-budgets.json
+++ b/tools/sram-budgets.json
@@ -1,10 +1,9 @@
 {
-  "_comment": "Per-variant SRAM budgets enforced by tools/check_sram_budget.py in CI (and a 16 KiB linker ASSERT in tools/firmware/keepkey.ld). reserve_min = minimum bytes between _ebss and _stack; frame_margin = minimum bytes left after subtracting the largest -fstack-usage frame from the reserve. Initial limits chosen after the RC7 zcash-privacy overflow (11,232 B gap vs a 12,416 B msg_write frame); replace with measured worst-case high-water + margin once hardware instrumentation reports real numbers. Any change to these budgets, and any single-commit SRAM increase above 256 B, needs explicit review.",
+  "_comment": "Per-product SRAM budgets enforced by tools/check_sram_budget.py in CI (and a 16 KiB linker ASSERT in tools/firmware/keepkey.ld). reserve_min = minimum bytes between _ebss and _stack; frame_margin = minimum bytes left after subtracting the largest -fstack-usage frame from the reserve. Initial limits chosen after the RC7 privacy-enabled overflow (11,232 B gap vs a 12,416 B msg_write frame); replace with measured worst-case high-water + margin once hardware instrumentation reports real numbers. Any change to these budgets, and any single-commit SRAM increase above 256 B, needs explicit review.",
   "reserve_min": 16384,
   "frame_margin": 4096,
   "variants": {
     "full": {},
-    "bitcoin-only": {},
-    "zcash-privacy": {}
+    "bitcoin-only": {}
   }
 }

--- a/unittests/firmware/CMakeLists.txt
+++ b/unittests/firmware/CMakeLists.txt
@@ -17,6 +17,7 @@ if(NOT ${KK_BITCOIN_ONLY})
       hive.cpp
       mayachain.cpp
       nano.cpp
+      osmosis.cpp
       ripple.cpp
       signed_metadata.cpp
       solana.cpp

--- a/unittests/firmware/CMakeLists.txt
+++ b/unittests/firmware/CMakeLists.txt
@@ -11,8 +11,10 @@ set(sources
 if(NOT ${KK_BITCOIN_ONLY})
   list(APPEND sources
       authenticator.cpp
+      binance.cpp
       coins.cpp
       cosmos.cpp
+      eip712.cpp
       eos.cpp
       ethereum.cpp
       hive.cpp

--- a/unittests/firmware/CMakeLists.txt
+++ b/unittests/firmware/CMakeLists.txt
@@ -10,6 +10,7 @@ set(sources
 # coin+token table.
 if(NOT ${KK_BITCOIN_ONLY})
   list(APPEND sources
+      authenticator.cpp
       coins.cpp
       cosmos.cpp
       eos.cpp

--- a/unittests/firmware/authenticator.cpp
+++ b/unittests/firmware/authenticator.cpp
@@ -14,20 +14,29 @@ void setup(void);
 bool kkconfirm_preload(int nYes, int nNo);
 int kkconfirm_drain(void);
 
+static void ensure_auth_storage_initialized(void) {
+  static bool initialized = false;
+  if (!initialized) {
+    setup();
+    storage_init();
+    initialized = true;
+  }
+}
+
 TEST(Authenticator, WipeCancellationFailsClosed) {
+  ensure_auth_storage_initialized();
   ASSERT_TRUE(kkconfirm_preload(0, 1));
   EXPECT_EQ(AUTH_CANCELLED, wipeAuthData());
   EXPECT_EQ(0, kkconfirm_drain());
 }
 
 TEST(Authenticator, AddAndRemoveCancellationFailsClosed) {
+  ensure_auth_storage_initialized();
   ASSERT_TRUE(kkconfirm_preload(1, 0));
-  setup();
-  storage_init();
   EXPECT_EQ(NOERR, wipeAuthData());
   EXPECT_EQ(0, kkconfirm_drain());
 
-  char cancelled_add[] = "example:alice:JBSWY3DPEHPK3PXP";
+  char cancelled_add[] = "example:alice:JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP";
   ASSERT_TRUE(kkconfirm_preload(0, 1));
   EXPECT_EQ(AUTH_CANCELLED, addAuthAccount(cancelled_add));
   EXPECT_EQ(0, kkconfirm_drain());
@@ -35,7 +44,7 @@ TEST(Authenticator, AddAndRemoveCancellationFailsClosed) {
   char account[DOMAIN_SIZE + ACCOUNT_SIZE + 2] = {0};
   EXPECT_EQ(NOACC, getAuthAccount("0", account));
 
-  char accepted_add[] = "example:alice:JBSWY3DPEHPK3PXP";
+  char accepted_add[] = "example:alice:JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP";
   ASSERT_TRUE(kkconfirm_preload(2, 0));
   EXPECT_EQ(NOERR, addAuthAccount(accepted_add));
   EXPECT_EQ(0, kkconfirm_drain());
@@ -67,4 +76,36 @@ TEST(Authenticator, RejectsAmbiguousDisplayFieldsBeforeMutation) {
 
   char remove_control[] = "example:bad\naccount";
   EXPECT_EQ(TOKERR, removeAuthAccount(remove_control));
+}
+
+TEST(Authenticator, RejectsWeakAndDuplicateSecrets) {
+  ensure_auth_storage_initialized();
+  ASSERT_TRUE(kkconfirm_preload(1, 0));
+  EXPECT_EQ(NOERR, wipeAuthData());
+  EXPECT_EQ(0, kkconfirm_drain());
+
+  char weak[] = "example:weak:MY";
+  EXPECT_EQ(BADSECRET, addAuthAccount(weak));
+
+  // The final invalid block fails after earlier blocks have decoded; the
+  // implementation must still take its cleanup path.
+  char partially_decoded[] = "example:invalid:JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PX!";
+  EXPECT_EQ(BADSECRET, addAuthAccount(partially_decoded));
+
+  char first[] = "example:alice:JBSWY3DPEHPK3PXPJBSWY3DPEHPK3PXP";
+  ASSERT_TRUE(kkconfirm_preload(2, 0));
+  EXPECT_EQ(NOERR, addAuthAccount(first));
+  EXPECT_EQ(0, kkconfirm_drain());
+
+  char duplicate[] = "example:alice:KRSXG5DSNFXGOIDBKRSXG5DSNFXGOIDB";
+  EXPECT_EQ(DUPLICATE, addAuthAccount(duplicate));
+
+  char account[DOMAIN_SIZE + ACCOUNT_SIZE + 2] = {0};
+  EXPECT_EQ(NOACC, getAuthAccount("1", account));
+
+  char remove[] = "example:alice";
+  ASSERT_TRUE(kkconfirm_preload(1, 0));
+  EXPECT_EQ(NOERR, removeAuthAccount(remove));
+  EXPECT_EQ(0, kkconfirm_drain());
+  EXPECT_EQ(NOACC, getAuthAccount("0", account));
 }

--- a/unittests/firmware/authenticator.cpp
+++ b/unittests/firmware/authenticator.cpp
@@ -1,0 +1,70 @@
+extern "C" {
+#include <stdint.h>
+
+#include "trezor/crypto/sha2.h"
+#include "keepkey/firmware/authenticator.h"
+#include "keepkey/firmware/storage.h"
+
+void setup(void);
+}
+
+#include "gtest/gtest.h"
+
+// Shared emulator confirmation driver from thorchain.cpp.
+bool kkconfirm_preload(int nYes, int nNo);
+int kkconfirm_drain(void);
+
+TEST(Authenticator, WipeCancellationFailsClosed) {
+  ASSERT_TRUE(kkconfirm_preload(0, 1));
+  EXPECT_EQ(AUTH_CANCELLED, wipeAuthData());
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+TEST(Authenticator, AddAndRemoveCancellationFailsClosed) {
+  ASSERT_TRUE(kkconfirm_preload(1, 0));
+  setup();
+  storage_init();
+  EXPECT_EQ(NOERR, wipeAuthData());
+  EXPECT_EQ(0, kkconfirm_drain());
+
+  char cancelled_add[] = "example:alice:JBSWY3DPEHPK3PXP";
+  ASSERT_TRUE(kkconfirm_preload(0, 1));
+  EXPECT_EQ(AUTH_CANCELLED, addAuthAccount(cancelled_add));
+  EXPECT_EQ(0, kkconfirm_drain());
+
+  char account[DOMAIN_SIZE + ACCOUNT_SIZE + 2] = {0};
+  EXPECT_EQ(NOACC, getAuthAccount("0", account));
+
+  char accepted_add[] = "example:alice:JBSWY3DPEHPK3PXP";
+  ASSERT_TRUE(kkconfirm_preload(2, 0));
+  EXPECT_EQ(NOERR, addAuthAccount(accepted_add));
+  EXPECT_EQ(0, kkconfirm_drain());
+
+  char cancelled_remove[] = "example:alice";
+  ASSERT_TRUE(kkconfirm_preload(0, 1));
+  EXPECT_EQ(AUTH_CANCELLED, removeAuthAccount(cancelled_remove));
+  EXPECT_EQ(0, kkconfirm_drain());
+  EXPECT_EQ(NOERR, getAuthAccount("0", account));
+  EXPECT_STREQ("example:alice", account);
+
+  ASSERT_TRUE(kkconfirm_preload(1, 0));
+  EXPECT_EQ(NOERR, wipeAuthData());
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+TEST(Authenticator, RejectsAmbiguousDisplayFieldsBeforeMutation) {
+  char long_domain[] = "domain-is-too-long:alice:JBSWY3DPEHPK3PXP";
+  EXPECT_EQ(TOKERR, addAuthAccount(long_domain));
+
+  char control_domain[] = "bad\ndomain:alice:JBSWY3DPEHPK3PXP";
+  EXPECT_EQ(TOKERR, addAuthAccount(control_domain));
+
+  char long_account[] = "example:account-is-too-long:JBSWY3DPEHPK3PXP";
+  EXPECT_EQ(TOKERR, addAuthAccount(long_account));
+
+  char remove_long[] = "example:account-is-too-long";
+  EXPECT_EQ(TOKERR, removeAuthAccount(remove_long));
+
+  char remove_control[] = "example:bad\naccount";
+  EXPECT_EQ(TOKERR, removeAuthAccount(remove_control));
+}

--- a/unittests/firmware/binance.cpp
+++ b/unittests/firmware/binance.cpp
@@ -1,0 +1,83 @@
+extern "C" {
+#include "keepkey/transport/interface.h"
+#include "keepkey/firmware/binance.h"
+}
+
+#include "gtest/gtest.h"
+
+#include <cstring>
+#include "trezor/crypto/secp256k1.h"
+
+static BinanceTransferMsg transfer(const char* denom, int64_t amount) {
+  BinanceTransferMsg msg = {};
+  msg.inputs_count = 1;
+  msg.outputs_count = 1;
+  msg.inputs[0].coins_count = 1;
+  msg.outputs[0].coins_count = 1;
+  msg.inputs[0].has_address = true;
+  msg.outputs[0].has_address = true;
+  strcpy(msg.inputs[0].address, "tbnb1hgm0p7khfk85zpz5v0j8wnej3a90w709zzlffd");
+  strcpy(msg.outputs[0].address, "tbnb1ss57e8sa7xnwq030k2ctr775uac9gjzglqhvpy");
+  msg.inputs[0].coins[0].has_amount = true;
+  msg.outputs[0].coins[0].has_amount = true;
+  msg.inputs[0].coins[0].amount = amount;
+  msg.outputs[0].coins[0].amount = amount;
+  msg.inputs[0].coins[0].has_denom = true;
+  msg.outputs[0].coins[0].has_denom = true;
+  strcpy(msg.inputs[0].coins[0].denom, denom);
+  strcpy(msg.outputs[0].coins[0].denom, denom);
+  return msg;
+}
+
+TEST(Binance, DenomBoundsAndGrammar) {
+  EXPECT_TRUE(binance_isValidDenom("BNB"));
+  EXPECT_TRUE(binance_isValidDenom("RUNE-B1A"));
+  EXPECT_TRUE(binance_isValidDenom("ABCDEFGH-123"));
+  EXPECT_TRUE(binance_isValidDenom("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
+  EXPECT_FALSE(binance_isValidDenom("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
+  EXPECT_FALSE(binance_isValidDenom("bnb"));
+  EXPECT_FALSE(binance_isValidDenom("BNB\""));
+  EXPECT_FALSE(binance_isValidDenom("BN B"));
+  EXPECT_FALSE(binance_isValidDenom(""));
+}
+
+TEST(Binance, TransferValidationFailsClosed) {
+  BinanceTransferMsg msg = transfer("RUNE-B1A", 1000000000);
+  EXPECT_TRUE(binance_validateTransfer(&msg));
+
+  msg = transfer("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", 1000000000);
+  EXPECT_TRUE(binance_validateTransfer(&msg));
+
+  msg = transfer("BNB", 0);
+  EXPECT_FALSE(binance_validateTransfer(&msg));
+  msg = transfer("BNB", -1);
+  EXPECT_FALSE(binance_validateTransfer(&msg));
+
+  msg = transfer("BNB", 1);
+  msg.outputs[0].coins[0].amount = 2;
+  EXPECT_FALSE(binance_validateTransfer(&msg));
+
+  msg = transfer("BNB", 1);
+  msg.outputs[0].coins[0].has_denom = false;
+  EXPECT_FALSE(binance_validateTransfer(&msg));
+}
+
+TEST(Binance, SigningSessionRequiresCanonicalEnvelopeState) {
+  HDNode node = {};
+  node.curve = &secp256k1_info;
+  BinanceSignTx envelope = {};
+  EXPECT_FALSE(binance_signTxInit(&node, &envelope));
+  EXPECT_FALSE(binance_signingIsInited());
+
+  envelope.has_msg_count = true;
+  envelope.msg_count = 1;
+  envelope.has_account_number = true;
+  envelope.has_chain_id = true;
+  strcpy(envelope.chain_id, "Binance-Chain-Nile");
+  envelope.has_sequence = true;
+  envelope.has_source = true;
+  EXPECT_TRUE(binance_signTxInit(&node, &envelope));
+  EXPECT_TRUE(binance_signingIsInited());
+  EXPECT_FALSE(binance_signingIsFinished());
+  binance_signAbort();
+}

--- a/unittests/firmware/cosmos.cpp
+++ b/unittests/firmware/cosmos.cpp
@@ -3,6 +3,7 @@ extern "C" {
 #include "keepkey/firmware/cosmos.h"
 #include "keepkey/firmware/signtx_tendermint.h"
 #include "keepkey/firmware/tendermint.h"
+#include "messages-tendermint.pb.h"
 #include "trezor/crypto/secp256k1.h"
 }
 
@@ -54,10 +55,14 @@ TEST(Cosmos, CosmosSignTx) {
       true, 0,              // sequence
       true, 1               // msg_count
   };
-  ASSERT_TRUE(tendermint_signTxInit(&node, &msg, sizeof(CosmosSignTx), "uatom"));
+  ASSERT_TRUE(tendermint_signTxInit(&node, &msg, sizeof(CosmosSignTx), "uatom",
+                                    TENDERMINT_SIGNING_COSMOS));
+  EXPECT_TRUE(tendermint_signingIsInited(TENDERMINT_SIGNING_COSMOS));
+  EXPECT_FALSE(tendermint_signingIsInited(TENDERMINT_SIGNING_GENERIC));
 
-  ASSERT_TRUE(tendermint_signTxUpdateMsgSend(100000, "cosmos18vhdczjut44gpsy804crfhnd5nq003nz0nf20v", "cosmos", "uatom", "cosmos-sdk"));
-
+  ASSERT_TRUE(tendermint_signTxUpdateMsgSend(
+      100000, "cosmos18vhdczjut44gpsy804crfhnd5nq003nz0nf20v", "cosmos",
+      "uatom", "cosmos-sdk"));
 
   uint8_t public_key[33];
   uint8_t signature[64];
@@ -71,4 +76,39 @@ TEST(Cosmos, CosmosSignTx) {
                         "\x14\x36\x64\x7f\xac\x5a\xbd\xc2\x9f\x54\xae\x3d\x7e"
                         "\x47\x56\x43\xca\x33\xc7\xad\x2c\x8a\x53\x2b\x39",
              64) == 0);
+}
+
+TEST(Cosmos, TendermintSessionBindsProtocolAndAssetConfiguration) {
+  HDNode node = {};
+  node.curve = &secp256k1_info;
+  TendermintSignTx msg = {};
+  msg.has_account_number = true;
+  msg.has_chain_id = true;
+  strcpy(msg.chain_id, "chain-1");
+  msg.has_fee_amount = true;
+  msg.fee_amount = 1;
+  msg.has_gas = true;
+  msg.gas = 1;
+  msg.has_sequence = true;
+  msg.has_msg_count = true;
+  msg.msg_count = 1;
+  msg.has_chain_name = true;
+  strcpy(msg.chain_name, "Cosmos");
+  msg.has_denom = true;
+  strcpy(msg.denom, "uatom");
+  msg.has_message_type_prefix = true;
+  strcpy(msg.message_type_prefix, "cosmos-sdk");
+
+  ASSERT_TRUE(tendermint_signTxInit(&node, &msg, sizeof(msg), msg.denom,
+                                    TENDERMINT_SIGNING_GENERIC));
+  EXPECT_TRUE(tendermint_signingIsInited(TENDERMINT_SIGNING_GENERIC));
+  EXPECT_FALSE(tendermint_signingIsInited(TENDERMINT_SIGNING_COSMOS));
+  EXPECT_TRUE(tendermint_signingConfigMatches("Cosmos", "uatom", "cosmos-sdk"));
+  EXPECT_FALSE(
+      tendermint_signingConfigMatches("Cosmos", "uosmo", "cosmos-sdk"));
+  EXPECT_FALSE(
+      tendermint_signingConfigMatches("Osmosis", "uatom", "cosmos-sdk"));
+  EXPECT_FALSE(
+      tendermint_signingConfigMatches("Cosmos", "uatom", "other-prefix"));
+  tendermint_signAbort();
 }

--- a/unittests/firmware/eip712.cpp
+++ b/unittests/firmware/eip712.cpp
@@ -1,0 +1,67 @@
+extern "C" {
+#include "keepkey/firmware/eip712.h"
+}
+
+#include "gtest/gtest.h"
+
+#include <cstring>
+
+TEST(EIP712, AddressRequiresCanonicalTwentyByteHex) {
+  uint8_t encoded[32] = {0};
+  ASSERT_EQ(SUCCESS,
+            encAddress("0x00112233445566778899aabbccddeeff00112233", encoded));
+  for (size_t i = 0; i < 12; i++) EXPECT_EQ(0, encoded[i]);
+  EXPECT_EQ(0x00, encoded[12]);
+  EXPECT_EQ(0x11, encoded[13]);
+  EXPECT_EQ(0x33, encoded[31]);
+
+  EXPECT_NE(SUCCESS, encAddress("0x112233", encoded));
+  EXPECT_NE(SUCCESS,
+            encAddress("00112233445566778899aabbccddeeff00112233", encoded));
+  EXPECT_NE(SUCCESS,
+            encAddress("0x00112233445566778899aabbccddeeff0011223g", encoded));
+  EXPECT_NE(SUCCESS, encAddress("0x00112233445566778899aabbccddeeff0011223344",
+                                encoded));
+}
+
+TEST(EIP712, DynamicBytesRequireCompleteHexOctets) {
+  uint8_t encoded[32] = {0};
+  EXPECT_EQ(SUCCESS, encodeBytes("0x", encoded));
+  EXPECT_EQ(SUCCESS, encodeBytes("0x00a1FF", encoded));
+  EXPECT_NE(SUCCESS, encodeBytes("00a1", encoded));
+  EXPECT_NE(SUCCESS, encodeBytes("0x0", encoded));
+  EXPECT_NE(SUCCESS, encodeBytes("0x0z", encoded));
+}
+
+TEST(EIP712, FixedBytesRequireExactDeclaredLength) {
+  uint8_t encoded[32];
+  memset(encoded, 0xa5, sizeof(encoded));
+  ASSERT_EQ(SUCCESS, encodeBytesN("bytes4", "0x0011aAff", encoded));
+  EXPECT_EQ(0x00, encoded[0]);
+  EXPECT_EQ(0x11, encoded[1]);
+  EXPECT_EQ(0xaa, encoded[2]);
+  EXPECT_EQ(0xff, encoded[3]);
+  for (size_t i = 4; i < sizeof(encoded); i++) EXPECT_EQ(0, encoded[i]);
+
+  EXPECT_NE(SUCCESS, encodeBytesN("bytes4", "0x0011aa", encoded));
+  EXPECT_NE(SUCCESS, encodeBytesN("bytes4", "0x0011aaff00", encoded));
+  EXPECT_NE(SUCCESS, encodeBytesN("bytes0", "0x", encoded));
+  EXPECT_NE(SUCCESS, encodeBytesN("bytes33", "0x", encoded));
+  EXPECT_NE(SUCCESS, encodeBytesN("bytes4x", "0x0011aaff", encoded));
+}
+
+TEST(EIP712, MissingTypedValueFailsWithoutDereferencingNull) {
+  char types_json[] =
+      "{\"types\":{\"Mail\":[{\"name\":\"from\",\"type\":\"address\"},"
+      "{\"name\":\"note\",\"type\":\"string\"}]}}";
+  char values_json[] = "{\"message\":{\"note\":\"hello\"}}";
+  json_t type_nodes[16] = {};
+  json_t value_nodes[8] = {};
+  const json_t* types = json_create(types_json, type_nodes, 16);
+  const json_t* values = json_create(values_json, value_nodes, 8);
+  ASSERT_NE(nullptr, types);
+  ASSERT_NE(nullptr, values);
+
+  uint8_t hash[32] = {};
+  EXPECT_EQ(JSON_TYPE_WNOVAL, encode(types, values, "Mail", hash));
+}

--- a/unittests/firmware/eos.cpp
+++ b/unittests/firmware/eos.cpp
@@ -7,6 +7,23 @@ extern "C" {
 
 #include <string>
 
+TEST(EOS, UnknownActionsRequireAdvancedMode) {
+  EXPECT_FALSE(eos_unknownActionPolicyAllows(false));
+  EXPECT_TRUE(eos_unknownActionPolicyAllows(true));
+}
+
+TEST(EOS, NewAccountCannotDowngradeToUnknownAction) {
+  EosActionCommon common = {};
+  common.has_account = true;
+  common.account = EOS_eosio;
+  common.has_name = true;
+  common.name = EOS_NewAccount;
+  EXPECT_TRUE(eos_isSupportedAction(&common));
+
+  common.account = 0x1111111111111111ULL;
+  EXPECT_FALSE(eos_isSupportedAction(&common));
+}
+
 TEST(EOS, FormatNameVec) {
   struct {
     uint64_t value;

--- a/unittests/firmware/ethereum.cpp
+++ b/unittests/firmware/ethereum.cpp
@@ -47,6 +47,19 @@ TEST(Ethereum, AddressChecksum) {
   test_checksum("D1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb");
 }
 
+TEST(Ethereum, TypedHashSigningRequiresAdvancedMode) {
+  EXPECT_FALSE(ethereum_typed_hash_policy_allows(false));
+  EXPECT_TRUE(ethereum_typed_hash_policy_allows(true));
+}
+
+TEST(Ethereum, DomainOnlyPrimaryTypeRequiresExactMatch) {
+  EXPECT_TRUE(ethereum_eip712_is_domain_primary_type("EIP712Domain"));
+  EXPECT_FALSE(ethereum_eip712_is_domain_primary_type("EIP"));
+  EXPECT_FALSE(ethereum_eip712_is_domain_primary_type("EIP712Domain[]"));
+  EXPECT_FALSE(ethereum_eip712_is_domain_primary_type(""));
+  EXPECT_FALSE(ethereum_eip712_is_domain_primary_type(nullptr));
+}
+
 static const uint8_t DAI_MAINNET_ADDRESS[20] = {
     0x6b, 0x17, 0x54, 0x74, 0xe8, 0x90, 0x94, 0xc4, 0x4d, 0xa9,
     0x8b, 0x95, 0x4e, 0xed, 0xea, 0xc4, 0x95, 0x27, 0x1d, 0x0f};

--- a/unittests/firmware/ethereum.cpp
+++ b/unittests/firmware/ethereum.cpp
@@ -47,7 +47,8 @@ TEST(Ethereum, AddressChecksum) {
   test_checksum("D1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb");
 }
 
-static EthereumSignTx liquidity_tx(bool known_token) {
+static EthereumSignTx liquidity_tx(bool known_token, bool add = true,
+                                   const char* ticker = "DAI") {
   EthereumSignTx msg;
   memset(&msg, 0, sizeof(msg));
   msg.has_chain_id = true;
@@ -57,10 +58,11 @@ static EthereumSignTx liquidity_tx(bool known_token) {
   memcpy(msg.to.bytes, UNISWAP_ROUTER_ADDRESS, 20);
   msg.has_data_initial_chunk = true;
   msg.data_initial_chunk.size = 4 + 6 * 32;
-  memcpy(msg.data_initial_chunk.bytes, "\xf3\x05\xd7\x19", 4);
+  memcpy(msg.data_initial_chunk.bytes,
+         add ? "\xf3\x05\xd7\x19" : "\x02\x75\x1c\xec", 4);
 
   const TokenType* token = nullptr;
-  EXPECT_TRUE(tokenByTicker(1, "DAI", &token));
+  EXPECT_TRUE(tokenByTicker(1, ticker, &token));
   if (token == nullptr) return msg;
   uint8_t unknown[20];
   memset(unknown, 0xa5, sizeof(unknown));
@@ -77,8 +79,40 @@ static EthereumSignTx liquidity_tx(bool known_token) {
   memset(msg.data_initial_chunk.bytes + 4 + 5 * 32 - 20, 0x11, 20);
   msg.data_initial_chunk.bytes[4 + 6 * 32 - 1] = 1;
   msg.has_value = true;
-  msg.value.size = 1;
-  msg.value.bytes[0] = 1;
+  if (add) {
+    msg.value.size = 1;
+    msg.value.bytes[0] = 1;
+  }
+  return msg;
+}
+
+static void set_word_u64(EthereumSignTx& msg, size_t word, uint64_t value) {
+  uint8_t* out = msg.data_initial_chunk.bytes + 4 + word * 32;
+  memset(out, 0, 32);
+  for (size_t i = 0; i < 8; i++) {
+    out[31 - i] = static_cast<uint8_t>(value);
+    value >>= 8;
+  }
+}
+
+static EthereumSignTx approve_liquidity_tx() {
+  EthereumSignTx msg;
+  memset(&msg, 0, sizeof(msg));
+  msg.has_chain_id = true;
+  msg.chain_id = 1;
+  msg.has_to = true;
+  msg.to.size = 20;
+  // Canonical mainnet DAI/WETH Uniswap V2 pair.
+  const uint8_t pair[20] = {0xa4, 0x78, 0xc2, 0x97, 0x5a, 0xb1, 0xea,
+                            0x89, 0xe8, 0x19, 0x68, 0x11, 0xf5, 0x1a,
+                            0x7b, 0x7a, 0xde, 0x33, 0xeb, 0x11};
+  memcpy(msg.to.bytes, pair, sizeof(pair));
+  msg.has_data_initial_chunk = true;
+  msg.data_initial_chunk.size = 4 + 2 * 32;
+  memcpy(msg.data_initial_chunk.bytes, "\x09\x5e\xa7\xb3", 4);
+  memcpy(msg.data_initial_chunk.bytes + 4 + 12, UNISWAP_ROUTER_ADDRESS, 20);
+  msg.data_initial_chunk.bytes[4 + 2 * 32 - 1] = 1;
+  msg.has_value = true;
   return msg;
 }
 
@@ -118,4 +152,82 @@ TEST(Ethereum, LiquidityCancellationFailsClosed) {
 TEST(Ethereum, LiquidityRejectsUnknownTokenBeforeConfirmation) {
   EthereumSignTx msg = liquidity_tx(false);
   EXPECT_FALSE(zx_confirmZxLiquidTx(msg.data_initial_chunk.size, &msg));
+}
+
+TEST(Ethereum, LiquidityClearSigningIsMainnetOnly) {
+  EthereumSignTx msg = liquidity_tx(true);
+  EXPECT_TRUE(zx_isZxLiquidTx(&msg));
+
+  msg.chain_id = 137;
+  EXPECT_FALSE(zx_isZxLiquidTx(&msg));
+  msg.chain_id = 1;
+  msg.has_chain_id = false;
+  EXPECT_FALSE(zx_isZxLiquidTx(&msg));
+}
+
+TEST(Ethereum, LiquidityRejectsTruncatedDeadlineAndNoncanonicalAddresses) {
+  EthereumSignTx msg = liquidity_tx(true);
+  msg.data_initial_chunk.bytes[4 + 5 * 32] = 1;
+  EXPECT_FALSE(zx_isZxLiquidTx(&msg));
+  EXPECT_FALSE(zx_confirmZxLiquidTx(msg.data_initial_chunk.size, &msg));
+
+  msg = liquidity_tx(true);
+  msg.data_initial_chunk.bytes[4] = 1;
+  EXPECT_FALSE(zx_isZxLiquidTx(&msg));
+
+  msg = liquidity_tx(true);
+  msg.data_initial_chunk.bytes[4 + 4 * 32] = 1;
+  EXPECT_FALSE(zx_isZxLiquidTx(&msg));
+}
+
+TEST(Ethereum, RemoveLiquidityRejectsNativeValue) {
+  EthereumSignTx msg = liquidity_tx(true, false);
+  EXPECT_TRUE(zx_isZxLiquidTx(&msg));
+  msg.value.size = 1;
+  msg.value.bytes[0] = 1;
+  EXPECT_FALSE(zx_isZxLiquidTx(&msg));
+}
+
+TEST(Ethereum, RemoveLiquidityFormatsPrimaryAmountAsLpTokens) {
+  EthereumSignTx add = liquidity_tx(true, true, "USDC");
+  set_word_u64(add, 1, UINT64_C(1000000000000000000));
+  char formatted[96];
+  ASSERT_TRUE(
+      zx_formatZxLiquidityPrimaryAmount(&add, formatted, sizeof(formatted)));
+  EXPECT_STREQ("1000000000000 USDC", formatted);
+
+  EthereumSignTx remove = liquidity_tx(true, false, "USDC");
+  set_word_u64(remove, 1, UINT64_C(1000000000000000000));
+  ASSERT_TRUE(
+      zx_formatZxLiquidityPrimaryAmount(&remove, formatted, sizeof(formatted)));
+  EXPECT_STREQ("1 LP", formatted);
+}
+
+TEST(Ethereum, LiquidityFormatsFullUint256WithoutBlankConfirmation) {
+  EthereumSignTx msg = liquidity_tx(true);
+  memset(msg.data_initial_chunk.bytes + 4 + 32, 0xff, 32);
+  char formatted[96];
+  ASSERT_TRUE(
+      zx_formatZxLiquidityPrimaryAmount(&msg, formatted, sizeof(formatted)));
+  EXPECT_GT(strlen(formatted), 32u);
+
+  ASSERT_TRUE(kkconfirm_preload(0, 1));
+  EXPECT_FALSE(zx_confirmZxLiquidTx(msg.data_initial_chunk.size, &msg));
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+TEST(Ethereum, LpApprovalRequiresMainnetDerivedPairAndCanonicalSpender) {
+  EthereumSignTx msg = approve_liquidity_tx();
+  EXPECT_TRUE(zx_isZxApproveLiquid(&msg));
+
+  msg.to.bytes[0] ^= 1;
+  EXPECT_FALSE(zx_isZxApproveLiquid(&msg));
+
+  msg = approve_liquidity_tx();
+  msg.chain_id = 137;
+  EXPECT_FALSE(zx_isZxApproveLiquid(&msg));
+
+  msg = approve_liquidity_tx();
+  msg.data_initial_chunk.bytes[4] = 1;
+  EXPECT_FALSE(zx_isZxApproveLiquid(&msg));
 }

--- a/unittests/firmware/ethereum.cpp
+++ b/unittests/firmware/ethereum.cpp
@@ -1,10 +1,18 @@
 extern "C" {
+#include "keepkey/firmware/ethereum.h"
+#include "keepkey/firmware/ethereum_contracts/zxappliquid.h"
+#include "keepkey/firmware/ethereum_contracts/zxliquidtx.h"
+#include "keepkey/firmware/ethereum_tokens.h"
 #include "trezor/crypto/address.h"
 }
 
 #include "gtest/gtest.h"
 
+#include <cstring>
 #include <string>
+
+bool kkconfirm_preload(int nYes, int nNo);
+int kkconfirm_drain(void);
 
 static uint8_t bin_from_ascii(char c) {
   if ('a' <= c && c <= 'f') return c - 'a' + 0xa;
@@ -16,7 +24,7 @@ static uint8_t bin_from_ascii(char c) {
   __builtin_unreachable();
 }
 
-static void test_checksum(const std::string &addr) {
+static void test_checksum(const std::string& addr) {
   uint8_t addr_bin[20];
   for (size_t i = 0; i < addr.size(); i += 2) {
     addr_bin[i / 2] = bin_from_ascii(addr[i + 1]) | bin_from_ascii(addr[i])
@@ -37,4 +45,77 @@ TEST(Ethereum, AddressChecksum) {
   test_checksum("fB6916095ca1df60bB79Ce92cE3Ea74c37c5d359");
   test_checksum("dbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB");
   test_checksum("D1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb");
+}
+
+static EthereumSignTx liquidity_tx(bool known_token) {
+  EthereumSignTx msg;
+  memset(&msg, 0, sizeof(msg));
+  msg.has_chain_id = true;
+  msg.chain_id = 1;
+  msg.has_to = true;
+  msg.to.size = 20;
+  memcpy(msg.to.bytes, UNISWAP_ROUTER_ADDRESS, 20);
+  msg.has_data_initial_chunk = true;
+  msg.data_initial_chunk.size = 4 + 6 * 32;
+  memcpy(msg.data_initial_chunk.bytes, "\xf3\x05\xd7\x19", 4);
+
+  const TokenType* token = nullptr;
+  EXPECT_TRUE(tokenByTicker(1, "DAI", &token));
+  if (token == nullptr) return msg;
+  uint8_t unknown[20];
+  memset(unknown, 0xa5, sizeof(unknown));
+  memcpy(
+      msg.data_initial_chunk.bytes + 4 + 32 - 20,
+      known_token ? reinterpret_cast<const uint8_t*>(token->address) : unknown,
+      20);
+
+  // Token desired/minimum and native minimum.
+  msg.data_initial_chunk.bytes[4 + 2 * 32 - 1] = 1;
+  msg.data_initial_chunk.bytes[4 + 3 * 32 - 1] = 1;
+  msg.data_initial_chunk.bytes[4 + 4 * 32 - 1] = 1;
+  // Recipient and deadline.
+  memset(msg.data_initial_chunk.bytes + 4 + 5 * 32 - 20, 0x11, 20);
+  msg.data_initial_chunk.bytes[4 + 6 * 32 - 1] = 1;
+  msg.has_value = true;
+  msg.value.size = 1;
+  msg.value.bytes[0] = 1;
+  return msg;
+}
+
+TEST(Ethereum, LiquiditySelectorChecksDeclaredCalldataLength) {
+  EthereumSignTx msg;
+  memset(&msg, 0, sizeof(msg));
+  msg.has_to = true;
+  msg.to.size = 20;
+  memcpy(msg.to.bytes, UNISWAP_ROUTER_ADDRESS, 20);
+  msg.has_data_initial_chunk = true;
+  msg.data_initial_chunk.size = 3;
+  memcpy(msg.data_initial_chunk.bytes, "\xf3\x05\xd7", 3);
+  EXPECT_FALSE(zx_isZxLiquidTx(&msg));
+
+  msg.data_initial_chunk.size = 4;
+  memcpy(msg.data_initial_chunk.bytes, "\x09\x5e\xa7\xb3", 4);
+  EXPECT_FALSE(zx_isZxApproveLiquid(&msg));
+
+  msg.data_initial_chunk.size = 4 + 2 * 32 + 1;
+  memcpy(msg.data_initial_chunk.bytes, "\x09\x5e\xa7\xb3", 4);
+  memcpy(msg.data_initial_chunk.bytes + 4 + 32 - 20, UNISWAP_ROUTER_ADDRESS,
+         20);
+  EXPECT_FALSE(zx_isZxApproveLiquid(&msg));
+
+  msg.data_initial_chunk.size = 4 + 6 * 32 + 1;
+  memcpy(msg.data_initial_chunk.bytes, "\xf3\x05\xd7\x19", 4);
+  EXPECT_FALSE(zx_isZxLiquidTx(&msg));
+}
+
+TEST(Ethereum, LiquidityCancellationFailsClosed) {
+  EthereumSignTx msg = liquidity_tx(true);
+  ASSERT_TRUE(kkconfirm_preload(0, 1));
+  EXPECT_FALSE(zx_confirmZxLiquidTx(msg.data_initial_chunk.size, &msg));
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+TEST(Ethereum, LiquidityRejectsUnknownTokenBeforeConfirmation) {
+  EthereumSignTx msg = liquidity_tx(false);
+  EXPECT_FALSE(zx_confirmZxLiquidTx(msg.data_initial_chunk.size, &msg));
 }

--- a/unittests/firmware/ethereum.cpp
+++ b/unittests/firmware/ethereum.cpp
@@ -47,8 +47,16 @@ TEST(Ethereum, AddressChecksum) {
   test_checksum("D1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb");
 }
 
-static EthereumSignTx liquidity_tx(bool known_token, bool add = true,
-                                   const char* ticker = "DAI") {
+static const uint8_t DAI_MAINNET_ADDRESS[20] = {
+    0x6b, 0x17, 0x54, 0x74, 0xe8, 0x90, 0x94, 0xc4, 0x4d, 0xa9,
+    0x8b, 0x95, 0x4e, 0xed, 0xea, 0xc4, 0x95, 0x27, 0x1d, 0x0f};
+static const uint8_t USDC_MAINNET_ADDRESS[20] = {
+    0xa0, 0xb8, 0x69, 0x91, 0xc6, 0x21, 0x8b, 0x36, 0xc1, 0xd1,
+    0x9d, 0x4a, 0x2e, 0x9e, 0xb0, 0xce, 0x36, 0x06, 0xeb, 0x48};
+
+static EthereumSignTx liquidity_tx(
+    bool known_token, bool add = true,
+    const uint8_t* token_address = DAI_MAINNET_ADDRESS) {
   EthereumSignTx msg;
   memset(&msg, 0, sizeof(msg));
   msg.has_chain_id = true;
@@ -61,9 +69,9 @@ static EthereumSignTx liquidity_tx(bool known_token, bool add = true,
   memcpy(msg.data_initial_chunk.bytes,
          add ? "\xf3\x05\xd7\x19" : "\x02\x75\x1c\xec", 4);
 
-  const TokenType* token = nullptr;
-  EXPECT_TRUE(tokenByTicker(1, ticker, &token));
-  if (token == nullptr) return msg;
+  const TokenType* token = tokenByChainAddress(1, token_address);
+  EXPECT_NE(UnknownToken, token);
+  if (token == UnknownToken) return msg;
   uint8_t unknown[20];
   memset(unknown, 0xa5, sizeof(unknown));
   memcpy(
@@ -189,14 +197,14 @@ TEST(Ethereum, RemoveLiquidityRejectsNativeValue) {
 }
 
 TEST(Ethereum, RemoveLiquidityFormatsPrimaryAmountAsLpTokens) {
-  EthereumSignTx add = liquidity_tx(true, true, "USDC");
+  EthereumSignTx add = liquidity_tx(true, true, USDC_MAINNET_ADDRESS);
   set_word_u64(add, 1, UINT64_C(1000000000000000000));
   char formatted[96];
   ASSERT_TRUE(
       zx_formatZxLiquidityPrimaryAmount(&add, formatted, sizeof(formatted)));
   EXPECT_STREQ("1000000000000 USDC", formatted);
 
-  EthereumSignTx remove = liquidity_tx(true, false, "USDC");
+  EthereumSignTx remove = liquidity_tx(true, false, USDC_MAINNET_ADDRESS);
   set_word_u64(remove, 1, UINT64_C(1000000000000000000));
   ASSERT_TRUE(
       zx_formatZxLiquidityPrimaryAmount(&remove, formatted, sizeof(formatted)));

--- a/unittests/firmware/hive.cpp
+++ b/unittests/firmware/hive.cpp
@@ -1,4 +1,6 @@
 extern "C" {
+#include "keepkey/board/font.h"
+#include "keepkey/board/layout.h"
 #include "keepkey/firmware/hive.h"
 }
 
@@ -370,6 +372,31 @@ TEST(Hive, CustomJsonRetainsAndBoundsEveryAuthorization) {
       wrap_ops({custom_json_op({}, {"alice", "alice"}, "follow", "[]")});
   EXPECT_NE(nullptr,
             hive_parseOperations(duplicate.data(), duplicate.size(), &parsed));
+}
+
+TEST(Hive, DisplayPaginationUsesRenderedBodyRows) {
+  const std::string payload =
+      "%%%%%%%%%%%%%%%% %%%%%%%%%%%%%%%% %%%%%%%%%%%%%%%% %%%%%%%%%%%%%%%%";
+  ASSERT_GT(calc_str_line(get_body_font(), payload.c_str(), BODY_WIDTH),
+            BODY_ROWS);
+
+  std::string reconstructed;
+  size_t offset = 0;
+  unsigned pages = 0;
+  while (offset < payload.size()) {
+    size_t take = calc_str_page(get_body_font(), payload.data() + offset,
+                                payload.size() - offset, BODY_WIDTH, BODY_ROWS);
+    ASSERT_GT(take, 0u);
+    const std::string page = payload.substr(offset, take);
+    EXPECT_LE(calc_str_line(get_body_font(), page.c_str(), BODY_WIDTH),
+              BODY_ROWS);
+    reconstructed += page;
+    offset += take;
+    pages++;
+  }
+
+  EXPECT_GT(pages, 1u);
+  EXPECT_EQ(payload, reconstructed);
 }
 
 // ── Phase-3 op table ────────────────────────────────────────────────────────

--- a/unittests/firmware/hive.cpp
+++ b/unittests/firmware/hive.cpp
@@ -64,15 +64,26 @@ std::vector<uint8_t> comment_tx(const std::string& parent_author,
   return tx;
 }
 
+// Call sites pass DISPLAY symbols ("HIVE"/"HBD") because that is what the test
+// is about; this helper writes what the chain actually serializes. Verified
+// against hived itself via condenser_api.get_transaction_hex — see
+// Hive.SerializationMatchesHived.
+std::string wire_symbol(const std::string& display) {
+  if (display == "HIVE") return "STEEM";
+  if (display == "HBD") return "SBD";
+  return display;
+}
+
 void append_asset(std::vector<uint8_t>& out, int64_t amount, uint8_t precision,
                   const std::string& symbol) {
+  const std::string wire = wire_symbol(symbol);
   uint64_t raw = static_cast<uint64_t>(amount);
   for (int i = 0; i < 8; i++) {
     out.push_back(static_cast<uint8_t>(raw >> (8 * i)));
   }
   out.push_back(precision);
   for (size_t i = 0; i < 7; i++) {
-    out.push_back(i < symbol.size() ? static_cast<uint8_t>(symbol[i]) : 0);
+    out.push_back(i < wire.size() ? static_cast<uint8_t>(wire[i]) : 0);
   }
 }
 
@@ -780,4 +791,85 @@ TEST(Hive, TrailingBytesRejected) {
 
   HiveParsedTx parsed;
   EXPECT_NE(nullptr, hive_parseOperations(tx.data(), tx.size(), &parsed));
+}
+
+// ---------------------------------------------------------------------------
+// Golden vectors produced by hived itself:
+//
+//   curl -X POST https://api.hive.blog -H 'Content-Type: application/json' \
+//     -d '{"jsonrpc":"2.0","method":"condenser_api.get_transaction_hex",
+//          "params":[<tx>],"id":1}'
+//
+// These exist because our serializer and this parser were byte-exact mirrors
+// of EACH OTHER while both disagreed with the chain: we wrote "HIVE"/"HBD"
+// where hived writes "STEEM"/"SBD". Two wrongs cancelled and every test
+// passed, but the device signed bytes hived could not validate — it reported
+// "missing required active authority", because signature recovery over
+// different bytes yields a key in no authority. A vector the chain generated
+// is the only kind that can catch that class of bug.
+// ---------------------------------------------------------------------------
+
+std::vector<uint8_t> from_hex(const std::string& hex) {
+  std::vector<uint8_t> out;
+  for (size_t i = 0; i + 1 < hex.size(); i += 2) {
+    out.push_back(static_cast<uint8_t>(std::stoul(hex.substr(i, 2), nullptr, 16)));
+  }
+  return out;
+}
+
+// Header shared by both vectors below: ref_block_num 4660 / prefix 0xdeadbeef
+// (0/0 for the second) and expiration 2021-01-14T02:19:44.
+//
+// get_transaction_hex serializes a full transaction, so its output ends with a
+// varint count of the `signatures` array. The device is handed the digest
+// preimage, which stops after the extensions varint — so the trailing "00"
+// from hived's hex is dropped in the goldens below. Everything before it must
+// match byte for byte.
+TEST(Hive, SerializationMatchesHivedLimitOrderCreate) {
+  const std::string golden =
+      "3412efbeadde40aaff5f010505616c6963652a000000dc05000000000000035354"
+      "45454d00009001000000000000035342440000000001b0f5536500";
+
+  std::vector<uint8_t> tx;
+  append_u16_le(tx, 4660);
+  append_u32_le(tx, 0xdeadbeef);
+  append_u32_le(tx, 0x5fffaa40);
+  append_varint(tx, 1);
+  std::vector<uint8_t> op = limit_order_create_op("alice", 42, 1500, "HIVE", 400,
+                                                  "HBD", true, 0x6553f5b0);
+  tx.insert(tx.end(), op.begin(), op.end());
+  append_varint(tx, 0);  // extensions
+
+  EXPECT_EQ(from_hex(golden), tx);
+
+  // and the parser accepts what the chain produces
+  HiveParsedTx parsed;
+  ASSERT_EQ(nullptr, hive_parseOperations(tx.data(), tx.size(), &parsed));
+  EXPECT_STREQ("HIVE", hive_assetSymbol(parsed.ops[0].assets[0]));
+  EXPECT_STREQ("HBD", hive_assetSymbol(parsed.ops[0].assets[1]));
+}
+
+TEST(Hive, SerializationMatchesHivedClaimRewardBalance) {
+  const std::string golden =
+      "00000000000040aaff5f012705616c696365e8030000000000000353544545"
+      "4d0000d0070000000000000353424400000000c0c62d0000000000065645535453"
+      "000000";
+
+  std::vector<uint8_t> tx;
+  append_u16_le(tx, 0);
+  append_u32_le(tx, 0);
+  append_u32_le(tx, 0x5fffaa40);
+  append_varint(tx, 1);
+  append_varint(tx, HIVE_OP_CLAIM_REWARD_BALANCE);
+  append_string(tx, "alice");
+  append_asset(tx, 1000, 3, "HIVE");
+  append_asset(tx, 2000, 3, "HBD");
+  append_asset(tx, 3000000, 6, "VESTS");
+  append_varint(tx, 0);  // extensions
+
+  EXPECT_EQ(from_hex(golden), tx);
+
+  HiveParsedTx parsed;
+  ASSERT_EQ(nullptr, hive_parseOperations(tx.data(), tx.size(), &parsed));
+  EXPECT_STREQ("VESTS", hive_assetSymbol(parsed.ops[0].assets[2]));
 }

--- a/unittests/firmware/hive.cpp
+++ b/unittests/firmware/hive.cpp
@@ -102,13 +102,10 @@ std::vector<uint8_t> wrap_ops(const std::vector<std::vector<uint8_t>>& ops) {
   return tx;
 }
 
-std::vector<uint8_t> limit_order_create_op(const std::string& owner,
-                                           uint32_t orderid, int64_t sell,
-                                           const std::string& sell_symbol,
-                                           int64_t receive,
-                                           const std::string& receive_symbol,
-                                           bool fill_or_kill,
-                                           uint32_t expiration) {
+std::vector<uint8_t> limit_order_create_op(
+    const std::string& owner, uint32_t orderid, int64_t sell,
+    const std::string& sell_symbol, int64_t receive,
+    const std::string& receive_symbol, bool fill_or_kill, uint32_t expiration) {
   std::vector<uint8_t> op;
   append_varint(op, HIVE_OP_LIMIT_ORDER_CREATE);
   append_string(op, owner);
@@ -202,6 +199,21 @@ std::vector<uint8_t> account_update2_op(const std::string& json_metadata,
   return op;
 }
 
+std::vector<uint8_t> custom_json_op(
+    const std::vector<std::string>& active_auths,
+    const std::vector<std::string>& posting_auths, const std::string& id,
+    const std::string& json) {
+  std::vector<uint8_t> op;
+  append_varint(op, HIVE_OP_CUSTOM_JSON);
+  append_varint(op, static_cast<uint32_t>(active_auths.size()));
+  for (const std::string& auth : active_auths) append_string(op, auth);
+  append_varint(op, static_cast<uint32_t>(posting_auths.size()));
+  for (const std::string& auth : posting_auths) append_string(op, auth);
+  append_string(op, id);
+  append_string(op, json);
+  return op;
+}
+
 }  // namespace
 
 TEST(Hive, Slip48PathValidation) {
@@ -254,11 +266,12 @@ TEST(Hive, CommentParserRetainsEveryDisplayedField) {
 // binary transaction preimage (chain_id || serialized_tx) on any chain id.
 TEST(Hive, MessagePrintableAcceptsAsciiRejectsBinary) {
   const char* login = "keepkey-login-challenge:1700000000";
-  EXPECT_TRUE(hive_message_is_printable(
-      reinterpret_cast<const uint8_t*>(login), strlen(login)));
+  EXPECT_TRUE(hive_message_is_printable(reinterpret_cast<const uint8_t*>(login),
+                                        strlen(login)));
 
   // Empty message is trivially printable.
-  EXPECT_TRUE(hive_message_is_printable(reinterpret_cast<const uint8_t*>(""), 0));
+  EXPECT_TRUE(
+      hive_message_is_printable(reinterpret_cast<const uint8_t*>(""), 0));
 
   // Any non-printable byte (control char / high bit) is refused.
   const uint8_t withNul[] = {'h', 'i', 0x00, 'x'};
@@ -290,14 +303,82 @@ TEST(Hive, TopLevelCommentRetainsCategoryAndEmptyTitle) {
   EXPECT_EQ("{}", slice(op.json_metadata, op.json_metadata_len));
 }
 
+TEST(Hive, RejectsNonCanonicalVarints) {
+  std::vector<uint8_t> op;
+  append_varint(op, HIVE_OP_VOTE);
+  append_string(op, "alice");
+  append_string(op, "bob");
+  append_string(op, "post");
+  append_u16_le(op, 10000);
+
+  HiveParsedTx parsed;
+
+  // Operation count 1 encoded as 0x81 0x00 instead of canonical 0x01.
+  std::vector<uint8_t> overlong_count = wrap_ops({op});
+  overlong_count[10] = 0x81;
+  overlong_count.insert(overlong_count.begin() + 11, 0x00);
+  EXPECT_NE(nullptr, hive_parseOperations(overlong_count.data(),
+                                          overlong_count.size(), &parsed));
+
+  // The voter string length 5 encoded as 0x85 0x00.
+  std::vector<uint8_t> overlong_string = wrap_ops({op});
+  overlong_string[12] = 0x85;
+  overlong_string.insert(overlong_string.begin() + 13, 0x00);
+  EXPECT_NE(nullptr, hive_parseOperations(overlong_string.data(),
+                                          overlong_string.size(), &parsed));
+}
+
+TEST(Hive, RejectsAccountNamesThatCanSpoofTheDisplay) {
+  HiveParsedTx parsed;
+  const std::vector<std::string> invalid = {
+      "al\nice", std::string("ali\0ce", 6), "Alice", "alice-", ".alice", "a"};
+  for (const std::string& account : invalid) {
+    std::vector<uint8_t> op;
+    append_varint(op, HIVE_OP_TRANSFER_TO_SAVINGS);
+    append_string(op, account);
+    append_string(op, "bob");
+    append_asset(op, 1000, 3, "HIVE");
+    append_string(op, "");
+    std::vector<uint8_t> tx = wrap_ops({op});
+    EXPECT_NE(nullptr, hive_parseOperations(tx.data(), tx.size(), &parsed));
+  }
+}
+
+TEST(Hive, CustomJsonRetainsAndBoundsEveryAuthorization) {
+  HiveParsedTx parsed;
+  std::vector<uint8_t> tx =
+      wrap_ops({custom_json_op({}, {"alice", "bob", "carol"}, "follow", "[]")});
+  ASSERT_EQ(nullptr, hive_parseOperations(tx.data(), tx.size(), &parsed));
+  const HiveTxOp& op = parsed.ops[0];
+  ASSERT_EQ(3, op.n_auths);
+  EXPECT_EQ("alice", slice(op.auth_acct[0], op.auth_acct_len[0]));
+  EXPECT_EQ("bob", slice(op.auth_acct[1], op.auth_acct_len[1]));
+  EXPECT_EQ("carol", slice(op.auth_acct[2], op.auth_acct_len[2]));
+  EXPECT_FALSE(parsed.needs_active);
+
+  std::vector<uint8_t> too_many = wrap_ops({custom_json_op(
+      {}, {"alice", "bob", "carol", "dave", "erin"}, "follow", "[]")});
+  EXPECT_NE(nullptr,
+            hive_parseOperations(too_many.data(), too_many.size(), &parsed));
+
+  std::vector<uint8_t> unsorted =
+      wrap_ops({custom_json_op({}, {"bob", "alice"}, "follow", "[]")});
+  EXPECT_NE(nullptr,
+            hive_parseOperations(unsorted.data(), unsorted.size(), &parsed));
+
+  std::vector<uint8_t> duplicate =
+      wrap_ops({custom_json_op({}, {"alice", "alice"}, "follow", "[]")});
+  EXPECT_NE(nullptr,
+            hive_parseOperations(duplicate.data(), duplicate.size(), &parsed));
+}
+
 // ── Phase-3 op table ────────────────────────────────────────────────────────
 
 // The op that started this: a HIVE->HBD internal-market swap. Every field the
 // approval screen shows must survive the parse.
 TEST(Hive, LimitOrderCreateRetainsEveryDisplayedField) {
-  std::vector<uint8_t> tx = wrap_ops(
-      {limit_order_create_op("alice", 42, 1500, "HIVE", 400, "HBD", true,
-                             1700003600)});
+  std::vector<uint8_t> tx = wrap_ops({limit_order_create_op(
+      "alice", 42, 1500, "HIVE", 400, "HBD", true, 1700003600)});
 
   HiveParsedTx parsed;
   ASSERT_EQ(nullptr, hive_parseOperations(tx.data(), tx.size(), &parsed));
@@ -337,8 +418,7 @@ TEST(Hive, LimitOrderRejectsDegenerateOrders) {
             hive_parseOperations(zero_recv.data(), zero_recv.size(), &parsed));
 
   // VESTS never trades on the internal market.
-  std::vector<uint8_t> vests = wrap_ops(
-      {limit_order_vests_op()});
+  std::vector<uint8_t> vests = wrap_ops({limit_order_vests_op()});
   EXPECT_NE(nullptr, hive_parseOperations(vests.data(), vests.size(), &parsed));
 }
 
@@ -470,9 +550,9 @@ TEST(Hive, CommentOptionsMustBindToItsComment) {
       wrap_ops({comment_options_op("alice", "my-post", {})});
   EXPECT_NE(nullptr, hive_parseOperations(alone.data(), alone.size(), &parsed));
 
-  std::vector<uint8_t> wrong_permlink = wrap_ops(
-      {comment_op("alice", "my-post"),
-       comment_options_op("alice", "other-post", {})});
+  std::vector<uint8_t> wrong_permlink =
+      wrap_ops({comment_op("alice", "my-post"),
+                comment_options_op("alice", "other-post", {})});
   EXPECT_NE(nullptr, hive_parseOperations(wrong_permlink.data(),
                                           wrong_permlink.size(), &parsed));
 
@@ -482,9 +562,9 @@ TEST(Hive, CommentOptionsMustBindToItsComment) {
   EXPECT_NE(nullptr, hive_parseOperations(wrong_author.data(),
                                           wrong_author.size(), &parsed));
 
-  std::vector<uint8_t> ok = wrap_ops(
-      {comment_op("alice", "my-post"), comment_options_op("alice", "my-post",
-                                                          {})});
+  std::vector<uint8_t> ok =
+      wrap_ops({comment_op("alice", "my-post"),
+                comment_options_op("alice", "my-post", {})});
   ASSERT_EQ(nullptr, hive_parseOperations(ok.data(), ok.size(), &parsed));
   EXPECT_EQ(2, parsed.num_ops);
   EXPECT_EQ(10000, parsed.ops[1].weight);  // percent_hbd
@@ -546,15 +626,15 @@ TEST(Hive, AccountUpdate2RejectsAuthorityChanges) {
   // json_metadata is an active-key field.
   std::vector<uint8_t> active =
       wrap_ops({account_update2_op("{\"profile\":{}}", "", false)});
-  ASSERT_EQ(nullptr, hive_parseOperations(active.data(), active.size(),
-                                          &parsed));
+  ASSERT_EQ(nullptr,
+            hive_parseOperations(active.data(), active.size(), &parsed));
   EXPECT_TRUE(parsed.needs_active);
 
   // posting_json_metadata alone stays on the posting tier.
   std::vector<uint8_t> posting =
       wrap_ops({account_update2_op("", "{\"profile\":{}}", false)});
-  ASSERT_EQ(nullptr, hive_parseOperations(posting.data(), posting.size(),
-                                          &parsed));
+  ASSERT_EQ(nullptr,
+            hive_parseOperations(posting.data(), posting.size(), &parsed));
   EXPECT_FALSE(parsed.needs_active);
 }
 
@@ -812,7 +892,8 @@ TEST(Hive, TrailingBytesRejected) {
 std::vector<uint8_t> from_hex(const std::string& hex) {
   std::vector<uint8_t> out;
   for (size_t i = 0; i + 1 < hex.size(); i += 2) {
-    out.push_back(static_cast<uint8_t>(std::stoul(hex.substr(i, 2), nullptr, 16)));
+    out.push_back(
+        static_cast<uint8_t>(std::stoul(hex.substr(i, 2), nullptr, 16)));
   }
   return out;
 }
@@ -835,8 +916,8 @@ TEST(Hive, SerializationMatchesHivedLimitOrderCreate) {
   append_u32_le(tx, 0xdeadbeef);
   append_u32_le(tx, 0x5fffaa40);
   append_varint(tx, 1);
-  std::vector<uint8_t> op = limit_order_create_op("alice", 42, 1500, "HIVE", 400,
-                                                  "HBD", true, 0x6553f5b0);
+  std::vector<uint8_t> op = limit_order_create_op("alice", 42, 1500, "HIVE",
+                                                  400, "HBD", true, 0x6553f5b0);
   tx.insert(tx.end(), op.begin(), op.end());
   append_varint(tx, 0);  // extensions
 

--- a/unittests/firmware/hive.cpp
+++ b/unittests/firmware/hive.cpp
@@ -64,6 +64,133 @@ std::vector<uint8_t> comment_tx(const std::string& parent_author,
   return tx;
 }
 
+void append_asset(std::vector<uint8_t>& out, int64_t amount, uint8_t precision,
+                  const std::string& symbol) {
+  uint64_t raw = static_cast<uint64_t>(amount);
+  for (int i = 0; i < 8; i++) {
+    out.push_back(static_cast<uint8_t>(raw >> (8 * i)));
+  }
+  out.push_back(precision);
+  for (size_t i = 0; i < 7; i++) {
+    out.push_back(i < symbol.size() ? static_cast<uint8_t>(symbol[i]) : 0);
+  }
+}
+
+// Wrap already-serialized ops in the 10-byte TaPoS header, op count and the
+// empty extensions varint that hive_parseOperations expects.
+std::vector<uint8_t> wrap_ops(const std::vector<std::vector<uint8_t>>& ops) {
+  std::vector<uint8_t> tx;
+  append_u16_le(tx, 12345);
+  append_u32_le(tx, 67890);
+  append_u32_le(tx, 1700000000);
+  append_varint(tx, static_cast<uint32_t>(ops.size()));
+  for (const std::vector<uint8_t>& op : ops) {
+    tx.insert(tx.end(), op.begin(), op.end());
+  }
+  append_varint(tx, 0);
+  return tx;
+}
+
+std::vector<uint8_t> limit_order_create_op(const std::string& owner,
+                                           uint32_t orderid, int64_t sell,
+                                           const std::string& sell_symbol,
+                                           int64_t receive,
+                                           const std::string& receive_symbol,
+                                           bool fill_or_kill,
+                                           uint32_t expiration) {
+  std::vector<uint8_t> op;
+  append_varint(op, HIVE_OP_LIMIT_ORDER_CREATE);
+  append_string(op, owner);
+  append_u32_le(op, orderid);
+  append_asset(op, sell, 3, sell_symbol);
+  append_asset(op, receive, 3, receive_symbol);
+  op.push_back(fill_or_kill ? 1 : 0);
+  append_u32_le(op, expiration);
+  return op;
+}
+
+// A limit order priced in VESTS at its CORRECT precision (6), so the
+// rejection comes from the symbol whitelist rather than the precision check.
+std::vector<uint8_t> limit_order_vests_op() {
+  std::vector<uint8_t> op;
+  append_varint(op, HIVE_OP_LIMIT_ORDER_CREATE);
+  append_string(op, "alice");
+  append_u32_le(op, 1);
+  append_asset(op, 100, 6, "VESTS");
+  append_asset(op, 100, 3, "HBD");
+  op.push_back(0);
+  append_u32_le(op, 1);
+  return op;
+}
+
+// transfer_to_vesting with a caller-chosen symbol/precision, so the asset
+// validator can be probed with values a correct host would never send.
+std::vector<uint8_t> power_up_op(int64_t amount, uint8_t precision,
+                                 const std::string& symbol) {
+  std::vector<uint8_t> op;
+  append_varint(op, HIVE_OP_TRANSFER_TO_VESTING);
+  append_string(op, "alice");
+  append_string(op, "bob");
+  append_asset(op, amount, precision, symbol);
+  return op;
+}
+
+std::vector<uint8_t> comment_op(const std::string& author,
+                                const std::string& permlink) {
+  std::vector<uint8_t> op;
+  append_varint(op, HIVE_OP_COMMENT);
+  append_string(op, "");
+  append_string(op, "hive-100");
+  append_string(op, author);
+  append_string(op, permlink);
+  append_string(op, "Title");
+  append_string(op, "Body");
+  append_string(op, "{}");
+  return op;
+}
+
+// beneficiaries: (account, basis-point weight) pairs; empty = no extension.
+std::vector<uint8_t> comment_options_op(
+    const std::string& author, const std::string& permlink,
+    const std::vector<std::pair<std::string, uint16_t>>& beneficiaries) {
+  std::vector<uint8_t> op;
+  append_varint(op, HIVE_OP_COMMENT_OPTIONS);
+  append_string(op, author);
+  append_string(op, permlink);
+  append_asset(op, 1000000, 3, "HBD");
+  append_u16_le(op, 10000);
+  op.push_back(1);
+  op.push_back(1);
+  if (beneficiaries.empty()) {
+    append_varint(op, 0);
+  } else {
+    append_varint(op, 1);
+    append_varint(op, 0);
+    append_varint(op, static_cast<uint32_t>(beneficiaries.size()));
+    for (const auto& b : beneficiaries) {
+      append_string(op, b.first);
+      append_u16_le(op, b.second);
+    }
+  }
+  return op;
+}
+
+std::vector<uint8_t> account_update2_op(const std::string& json_metadata,
+                                        const std::string& posting_metadata,
+                                        bool authority_present) {
+  std::vector<uint8_t> op;
+  append_varint(op, HIVE_OP_ACCOUNT_UPDATE2);
+  append_string(op, "alice");
+  op.push_back(authority_present ? 1 : 0);
+  op.push_back(0);
+  op.push_back(0);
+  op.push_back(0);
+  append_string(op, json_metadata);
+  append_string(op, posting_metadata);
+  append_varint(op, 0);
+  return op;
+}
+
 }  // namespace
 
 TEST(Hive, Slip48PathValidation) {
@@ -150,4 +277,507 @@ TEST(Hive, TopLevelCommentRetainsCategoryAndEmptyTitle) {
   EXPECT_EQ("post-permlink", slice(op.permlink, op.permlink_len));
   EXPECT_EQ(0, op.target_len);
   EXPECT_EQ("{}", slice(op.json_metadata, op.json_metadata_len));
+}
+
+// ── Phase-3 op table ────────────────────────────────────────────────────────
+
+// The op that started this: a HIVE->HBD internal-market swap. Every field the
+// approval screen shows must survive the parse.
+TEST(Hive, LimitOrderCreateRetainsEveryDisplayedField) {
+  std::vector<uint8_t> tx = wrap_ops(
+      {limit_order_create_op("alice", 42, 1500, "HIVE", 400, "HBD", true,
+                             1700003600)});
+
+  HiveParsedTx parsed;
+  ASSERT_EQ(nullptr, hive_parseOperations(tx.data(), tx.size(), &parsed));
+  ASSERT_EQ(1, parsed.num_ops);
+  const HiveTxOp& op = parsed.ops[0];
+  EXPECT_EQ(HIVE_OP_LIMIT_ORDER_CREATE, op.op_type);
+  EXPECT_EQ("alice", slice(op.acct, op.acct_len));
+  EXPECT_EQ(42u, op.req_id);
+  EXPECT_EQ(1700003600u, op.expiration);
+  EXPECT_TRUE(op.flag);  // fill_or_kill
+  ASSERT_EQ(2, op.n_assets);
+  EXPECT_EQ(1500u, hive_assetAmount(op.assets[0]));
+  EXPECT_STREQ("HIVE", hive_assetSymbol(op.assets[0]));
+  EXPECT_EQ(3, hive_assetPrecision(op.assets[0]));
+  EXPECT_EQ(400u, hive_assetAmount(op.assets[1]));
+  EXPECT_STREQ("HBD", hive_assetSymbol(op.assets[1]));
+  // Trading needs the active key.
+  EXPECT_TRUE(parsed.needs_active);
+}
+
+TEST(Hive, LimitOrderRejectsDegenerateOrders) {
+  HiveParsedTx parsed;
+
+  // A same-symbol pair is a no-op trade on screen but still burns the fill.
+  std::vector<uint8_t> same = wrap_ops(
+      {limit_order_create_op("alice", 1, 100, "HIVE", 100, "HIVE", false, 1)});
+  EXPECT_NE(nullptr, hive_parseOperations(same.data(), same.size(), &parsed));
+
+  std::vector<uint8_t> zero_sell = wrap_ops(
+      {limit_order_create_op("alice", 1, 0, "HIVE", 100, "HBD", false, 1)});
+  EXPECT_NE(nullptr,
+            hive_parseOperations(zero_sell.data(), zero_sell.size(), &parsed));
+
+  std::vector<uint8_t> zero_recv = wrap_ops(
+      {limit_order_create_op("alice", 1, 100, "HIVE", 0, "HBD", false, 1)});
+  EXPECT_NE(nullptr,
+            hive_parseOperations(zero_recv.data(), zero_recv.size(), &parsed));
+
+  // VESTS never trades on the internal market.
+  std::vector<uint8_t> vests = wrap_ops(
+      {limit_order_vests_op()});
+  EXPECT_NE(nullptr, hive_parseOperations(vests.data(), vests.size(), &parsed));
+}
+
+TEST(Hive, LimitOrderCancelParses) {
+  std::vector<uint8_t> op;
+  append_varint(op, HIVE_OP_LIMIT_ORDER_CANCEL);
+  append_string(op, "alice");
+  append_u32_le(op, 42);
+  std::vector<uint8_t> tx = wrap_ops({op});
+
+  HiveParsedTx parsed;
+  ASSERT_EQ(nullptr, hive_parseOperations(tx.data(), tx.size(), &parsed));
+  EXPECT_EQ("alice", slice(parsed.ops[0].acct, parsed.ops[0].acct_len));
+  EXPECT_EQ(42u, parsed.ops[0].req_id);
+  EXPECT_TRUE(parsed.needs_active);
+}
+
+// The asset validator is what stops a host from moving the decimal point or
+// swapping a ~2000x-more-valuable symbol behind an identical-looking number.
+TEST(Hive, AssetValidatorPinsSymbolAndPrecision) {
+  HiveParsedTx parsed;
+
+  std::vector<uint8_t> ok = wrap_ops({power_up_op(1000, 3, "HIVE")});
+  EXPECT_EQ(nullptr, hive_parseOperations(ok.data(), ok.size(), &parsed));
+
+  // transfer_to_vesting is HIVE-only; HBD and VESTS are out of the whitelist.
+  std::vector<uint8_t> hbd = wrap_ops({power_up_op(1000, 3, "HBD")});
+  EXPECT_NE(nullptr, hive_parseOperations(hbd.data(), hbd.size(), &parsed));
+  std::vector<uint8_t> vests = wrap_ops({power_up_op(1000, 6, "VESTS")});
+  EXPECT_NE(nullptr, hive_parseOperations(vests.data(), vests.size(), &parsed));
+
+  // Right symbol, wrong precision: 1000 would render as 0.001 vs 1.000.
+  std::vector<uint8_t> prec = wrap_ops({power_up_op(1000, 6, "HIVE")});
+  EXPECT_NE(nullptr, hive_parseOperations(prec.data(), prec.size(), &parsed));
+
+  // A negative int64 would print as an enormous positive number.
+  std::vector<uint8_t> negative = wrap_ops({power_up_op(-1000, 3, "HIVE")});
+  EXPECT_NE(nullptr,
+            hive_parseOperations(negative.data(), negative.size(), &parsed));
+
+  // Unknown symbol, and a longer symbol sharing an accepted prefix.
+  std::vector<uint8_t> unknown = wrap_ops({power_up_op(1000, 3, "SBD")});
+  EXPECT_NE(nullptr,
+            hive_parseOperations(unknown.data(), unknown.size(), &parsed));
+  std::vector<uint8_t> prefixed = wrap_ops({power_up_op(1000, 3, "HIVEX")});
+  EXPECT_NE(nullptr,
+            hive_parseOperations(prefixed.data(), prefixed.size(), &parsed));
+}
+
+// Zero is a real instruction for some ops and nonsense for others; the parser
+// must not apply one blanket rule.
+TEST(Hive, ZeroAmountSemanticsDifferPerOp) {
+  HiveParsedTx parsed;
+
+  // Zero HIVE power-up: nothing to do, reject.
+  std::vector<uint8_t> power_up = wrap_ops({power_up_op(0, 3, "HIVE")});
+  EXPECT_NE(nullptr,
+            hive_parseOperations(power_up.data(), power_up.size(), &parsed));
+
+  // Zero VESTS withdraw_vesting: cancels an in-progress power-down, accept.
+  std::vector<uint8_t> stop_pd;
+  {
+    std::vector<uint8_t> op;
+    append_varint(op, HIVE_OP_WITHDRAW_VESTING);
+    append_string(op, "alice");
+    append_asset(op, 0, 6, "VESTS");
+    stop_pd = wrap_ops({op});
+  }
+  EXPECT_EQ(nullptr,
+            hive_parseOperations(stop_pd.data(), stop_pd.size(), &parsed));
+
+  // Zero VESTS delegation: removes an existing delegation, accept.
+  std::vector<uint8_t> undelegate;
+  {
+    std::vector<uint8_t> op;
+    append_varint(op, HIVE_OP_DELEGATE_VESTING_SHARES);
+    append_string(op, "alice");
+    append_string(op, "bob");
+    append_asset(op, 0, 6, "VESTS");
+    undelegate = wrap_ops({op});
+  }
+  EXPECT_EQ(nullptr, hive_parseOperations(undelegate.data(), undelegate.size(),
+                                          &parsed));
+
+  // claim_reward_balance with all three at zero: nothing to claim, reject.
+  std::vector<uint8_t> empty_claim;
+  {
+    std::vector<uint8_t> op;
+    append_varint(op, HIVE_OP_CLAIM_REWARD_BALANCE);
+    append_string(op, "alice");
+    append_asset(op, 0, 3, "HIVE");
+    append_asset(op, 0, 3, "HBD");
+    append_asset(op, 0, 6, "VESTS");
+    empty_claim = wrap_ops({op});
+  }
+  EXPECT_NE(nullptr, hive_parseOperations(empty_claim.data(),
+                                          empty_claim.size(), &parsed));
+}
+
+TEST(Hive, ClaimRewardBalanceKeepsAssetOrder) {
+  std::vector<uint8_t> op;
+  append_varint(op, HIVE_OP_CLAIM_REWARD_BALANCE);
+  append_string(op, "alice");
+  append_asset(op, 1234, 3, "HIVE");
+  append_asset(op, 5678, 3, "HBD");
+  append_asset(op, 90123456, 6, "VESTS");
+  std::vector<uint8_t> tx = wrap_ops({op});
+
+  HiveParsedTx parsed;
+  ASSERT_EQ(nullptr, hive_parseOperations(tx.data(), tx.size(), &parsed));
+  ASSERT_EQ(3, parsed.ops[0].n_assets);
+  EXPECT_EQ(1234u, hive_assetAmount(parsed.ops[0].assets[0]));
+  EXPECT_STREQ("HIVE", hive_assetSymbol(parsed.ops[0].assets[0]));
+  EXPECT_EQ(5678u, hive_assetAmount(parsed.ops[0].assets[1]));
+  EXPECT_STREQ("HBD", hive_assetSymbol(parsed.ops[0].assets[1]));
+  EXPECT_EQ(90123456u, hive_assetAmount(parsed.ops[0].assets[2]));
+  EXPECT_STREQ("VESTS", hive_assetSymbol(parsed.ops[0].assets[2]));
+  // Claiming rewards is a posting-tier action.
+  EXPECT_FALSE(parsed.needs_active);
+}
+
+// SECURITY: comment_options redirects a post's payout. Detached from its
+// comment it could retarget a post the user published earlier and is not
+// reviewing on screen.
+TEST(Hive, CommentOptionsMustBindToItsComment) {
+  HiveParsedTx parsed;
+
+  std::vector<uint8_t> alone =
+      wrap_ops({comment_options_op("alice", "my-post", {})});
+  EXPECT_NE(nullptr, hive_parseOperations(alone.data(), alone.size(), &parsed));
+
+  std::vector<uint8_t> wrong_permlink = wrap_ops(
+      {comment_op("alice", "my-post"),
+       comment_options_op("alice", "other-post", {})});
+  EXPECT_NE(nullptr, hive_parseOperations(wrong_permlink.data(),
+                                          wrong_permlink.size(), &parsed));
+
+  std::vector<uint8_t> wrong_author =
+      wrap_ops({comment_op("alice", "my-post"),
+                comment_options_op("mallory", "my-post", {})});
+  EXPECT_NE(nullptr, hive_parseOperations(wrong_author.data(),
+                                          wrong_author.size(), &parsed));
+
+  std::vector<uint8_t> ok = wrap_ops(
+      {comment_op("alice", "my-post"), comment_options_op("alice", "my-post",
+                                                          {})});
+  ASSERT_EQ(nullptr, hive_parseOperations(ok.data(), ok.size(), &parsed));
+  EXPECT_EQ(2, parsed.num_ops);
+  EXPECT_EQ(10000, parsed.ops[1].weight);  // percent_hbd
+  EXPECT_FALSE(parsed.needs_active);
+}
+
+TEST(Hive, CommentOptionsBeneficiaryRules) {
+  HiveParsedTx parsed;
+
+  std::vector<uint8_t> ok =
+      wrap_ops({comment_op("alice", "my-post"),
+                comment_options_op("alice", "my-post",
+                                   {{"aaron", 1000}, {"zoe", 500}})});
+  ASSERT_EQ(nullptr, hive_parseOperations(ok.data(), ok.size(), &parsed));
+  ASSERT_EQ(2, parsed.ops[1].n_benef);
+  EXPECT_EQ("aaron", slice(parsed.ops[1].benef_acct[0],
+                           parsed.ops[1].benef_acct_len[0]));
+  EXPECT_EQ(1000, parsed.ops[1].benef_weight[0]);
+  EXPECT_EQ("zoe", slice(parsed.ops[1].benef_acct[1],
+                         parsed.ops[1].benef_acct_len[1]));
+
+  // hived requires strictly ascending names; unsorted is rejected on-chain.
+  std::vector<uint8_t> unsorted =
+      wrap_ops({comment_op("alice", "my-post"),
+                comment_options_op("alice", "my-post",
+                                   {{"zoe", 500}, {"aaron", 1000}})});
+  EXPECT_NE(nullptr,
+            hive_parseOperations(unsorted.data(), unsorted.size(), &parsed));
+
+  // Duplicates are the same violation.
+  std::vector<uint8_t> duped =
+      wrap_ops({comment_op("alice", "my-post"),
+                comment_options_op("alice", "my-post",
+                                   {{"aaron", 500}, {"aaron", 500}})});
+  EXPECT_NE(nullptr, hive_parseOperations(duped.data(), duped.size(), &parsed));
+
+  // Weights may not add up to more than 100%.
+  std::vector<uint8_t> overweight =
+      wrap_ops({comment_op("alice", "my-post"),
+                comment_options_op("alice", "my-post",
+                                   {{"aaron", 6000}, {"zoe", 5000}})});
+  EXPECT_NE(nullptr, hive_parseOperations(overweight.data(), overweight.size(),
+                                          &parsed));
+}
+
+// SECURITY: account_update2 can rotate account keys. Only the profile-metadata
+// form is in the table — the op-9/10 exclusion applied field-level.
+TEST(Hive, AccountUpdate2RejectsAuthorityChanges) {
+  HiveParsedTx parsed;
+
+  std::vector<uint8_t> authority =
+      wrap_ops({account_update2_op("{\"profile\":{}}", "", true)});
+  EXPECT_NE(nullptr,
+            hive_parseOperations(authority.data(), authority.size(), &parsed));
+
+  std::vector<uint8_t> empty = wrap_ops({account_update2_op("", "", false)});
+  EXPECT_NE(nullptr, hive_parseOperations(empty.data(), empty.size(), &parsed));
+
+  // json_metadata is an active-key field.
+  std::vector<uint8_t> active =
+      wrap_ops({account_update2_op("{\"profile\":{}}", "", false)});
+  ASSERT_EQ(nullptr, hive_parseOperations(active.data(), active.size(),
+                                          &parsed));
+  EXPECT_TRUE(parsed.needs_active);
+
+  // posting_json_metadata alone stays on the posting tier.
+  std::vector<uint8_t> posting =
+      wrap_ops({account_update2_op("", "{\"profile\":{}}", false)});
+  ASSERT_EQ(nullptr, hive_parseOperations(posting.data(), posting.size(),
+                                          &parsed));
+  EXPECT_FALSE(parsed.needs_active);
+}
+
+TEST(Hive, SavingsWithdrawRetainsDisplayedFields) {
+  std::vector<uint8_t> op;
+  append_varint(op, HIVE_OP_TRANSFER_FROM_SAVINGS);
+  append_string(op, "alice");
+  append_u32_le(op, 7);
+  append_string(op, "bob");
+  append_asset(op, 2500, 3, "HBD");
+  append_string(op, "rent");
+  std::vector<uint8_t> tx = wrap_ops({op});
+
+  HiveParsedTx parsed;
+  ASSERT_EQ(nullptr, hive_parseOperations(tx.data(), tx.size(), &parsed));
+  // request_id sits BETWEEN from and to on the wire — the easiest field-order
+  // bug to make in this op, and the one that would swap displayed accounts.
+  EXPECT_EQ("alice", slice(parsed.ops[0].acct, parsed.ops[0].acct_len));
+  EXPECT_EQ(7u, parsed.ops[0].req_id);
+  EXPECT_EQ("bob", slice(parsed.ops[0].target, parsed.ops[0].target_len));
+  EXPECT_EQ("rent", slice(parsed.ops[0].detail, parsed.ops[0].detail_len));
+  EXPECT_EQ(2500u, hive_assetAmount(parsed.ops[0].assets[0]));
+  EXPECT_TRUE(parsed.needs_active);
+}
+
+TEST(Hive, SavingsDepositRetainsDisplayedFields) {
+  std::vector<uint8_t> op;
+  append_varint(op, HIVE_OP_TRANSFER_TO_SAVINGS);
+  append_string(op, "alice");
+  append_string(op, "bob");
+  append_asset(op, 1500, 3, "HIVE");
+  append_string(op, "");
+  std::vector<uint8_t> tx = wrap_ops({op});
+
+  HiveParsedTx parsed;
+  ASSERT_EQ(nullptr, hive_parseOperations(tx.data(), tx.size(), &parsed));
+  EXPECT_EQ("alice", slice(parsed.ops[0].acct, parsed.ops[0].acct_len));
+  EXPECT_EQ("bob", slice(parsed.ops[0].target, parsed.ops[0].target_len));
+  EXPECT_EQ(0, parsed.ops[0].detail_len);  // empty memo is legal
+  EXPECT_EQ(1500u, hive_assetAmount(parsed.ops[0].assets[0]));
+}
+
+// An empty `to` means "power up to self" on Hive, not a malformed field.
+TEST(Hive, PowerUpAcceptsEmptyDestination) {
+  std::vector<uint8_t> op;
+  append_varint(op, HIVE_OP_TRANSFER_TO_VESTING);
+  append_string(op, "alice");
+  append_string(op, "");
+  append_asset(op, 1000, 3, "HIVE");
+  std::vector<uint8_t> tx = wrap_ops({op});
+
+  HiveParsedTx parsed;
+  ASSERT_EQ(nullptr, hive_parseOperations(tx.data(), tx.size(), &parsed));
+  EXPECT_EQ(0, parsed.ops[0].target_len);
+}
+
+// Truncating any op body by one byte must be refused, never partially parsed:
+// the signature covers the whole buffer, so a short read would mean signing
+// bytes the device never looked at.
+TEST(Hive, TruncatedOpBodiesRejected) {
+  std::vector<std::vector<uint8_t>> bodies;
+  bodies.push_back(
+      limit_order_create_op("alice", 1, 100, "HIVE", 50, "HBD", false, 9));
+  bodies.push_back(power_up_op(1000, 3, "HIVE"));
+  {
+    std::vector<uint8_t> op;
+    append_varint(op, HIVE_OP_CLAIM_REWARD_BALANCE);
+    append_string(op, "alice");
+    append_asset(op, 1, 3, "HIVE");
+    append_asset(op, 1, 3, "HBD");
+    append_asset(op, 1, 6, "VESTS");
+    bodies.push_back(op);
+  }
+  {
+    std::vector<uint8_t> op;
+    append_varint(op, HIVE_OP_TRANSFER_FROM_SAVINGS);
+    append_string(op, "alice");
+    append_u32_le(op, 7);
+    append_string(op, "bob");
+    append_asset(op, 2500, 3, "HBD");
+    append_string(op, "memo");
+    bodies.push_back(op);
+  }
+
+  HiveParsedTx parsed;
+  for (const std::vector<uint8_t>& body : bodies) {
+    ASSERT_EQ(nullptr, hive_parseOperations(wrap_ops({body}).data(),
+                                            wrap_ops({body}).size(), &parsed));
+    for (size_t cut = 1; cut < body.size(); cut++) {
+      std::vector<uint8_t> truncated(body.begin(), body.end() - cut);
+      std::vector<uint8_t> tx = wrap_ops({truncated});
+      EXPECT_NE(nullptr, hive_parseOperations(tx.data(), tx.size(), &parsed))
+          << "op type " << (unsigned)body[0] << " truncated by " << cut;
+    }
+  }
+}
+
+TEST(Hive, CommentOptionsExtensionShapeRejected) {
+  HiveParsedTx parsed;
+  const std::vector<uint8_t> comment = comment_op("alice", "my-post");
+
+  // More than one extension could split beneficiaries past a per-extension cap.
+  {
+    std::vector<uint8_t> op;
+    append_varint(op, HIVE_OP_COMMENT_OPTIONS);
+    append_string(op, "alice");
+    append_string(op, "my-post");
+    append_asset(op, 1000000, 3, "HBD");
+    append_u16_le(op, 10000);
+    op.push_back(1);
+    op.push_back(1);
+    append_varint(op, 2);
+    std::vector<uint8_t> tx = wrap_ops({comment, op});
+    EXPECT_NE(nullptr, hive_parseOperations(tx.data(), tx.size(), &parsed));
+  }
+  // Only comment_payout_beneficiaries (tag 0) is in the table.
+  {
+    std::vector<uint8_t> op;
+    append_varint(op, HIVE_OP_COMMENT_OPTIONS);
+    append_string(op, "alice");
+    append_string(op, "my-post");
+    append_asset(op, 1000000, 3, "HBD");
+    append_u16_le(op, 10000);
+    op.push_back(1);
+    op.push_back(1);
+    append_varint(op, 1);
+    append_varint(op, 1);  // tag != 0
+    std::vector<uint8_t> tx = wrap_ops({comment, op});
+    EXPECT_NE(nullptr, hive_parseOperations(tx.data(), tx.size(), &parsed));
+  }
+  // Zero beneficiaries in a present extension is malformed, not "none".
+  {
+    std::vector<uint8_t> tx =
+        wrap_ops({comment, comment_options_op("alice", "my-post", {})});
+    ASSERT_EQ(nullptr, hive_parseOperations(tx.data(), tx.size(), &parsed));
+    std::vector<uint8_t> op;
+    append_varint(op, HIVE_OP_COMMENT_OPTIONS);
+    append_string(op, "alice");
+    append_string(op, "my-post");
+    append_asset(op, 1000000, 3, "HBD");
+    append_u16_le(op, 10000);
+    op.push_back(1);
+    op.push_back(1);
+    append_varint(op, 1);
+    append_varint(op, 0);
+    append_varint(op, 0);  // n_benef = 0
+    std::vector<uint8_t> bad = wrap_ops({comment, op});
+    EXPECT_NE(nullptr, hive_parseOperations(bad.data(), bad.size(), &parsed));
+  }
+}
+
+TEST(Hive, AccountUpdate2RejectsNonEmptyExtensions) {
+  std::vector<uint8_t> op;
+  append_varint(op, HIVE_OP_ACCOUNT_UPDATE2);
+  append_string(op, "alice");
+  for (int i = 0; i < 4; i++) op.push_back(0);
+  append_string(op, "{\"profile\":{}}");
+  append_string(op, "");
+  append_varint(op, 1);  // extensions must be empty
+  std::vector<uint8_t> tx = wrap_ops({op});
+
+  HiveParsedTx parsed;
+  EXPECT_NE(nullptr, hive_parseOperations(tx.data(), tx.size(), &parsed));
+}
+
+// Graphene bools are one byte; anything but 0/1 is a host serializer bug.
+TEST(Hive, RejectsNonCanonicalBool) {
+  // limit_order_create's fill_or_kill byte, set to 2.
+  std::vector<uint8_t> op;
+  append_varint(op, HIVE_OP_LIMIT_ORDER_CREATE);
+  append_string(op, "alice");
+  append_u32_le(op, 1);
+  append_asset(op, 100, 3, "HIVE");
+  append_asset(op, 50, 3, "HBD");
+  op.push_back(2);
+  append_u32_le(op, 9);
+  std::vector<uint8_t> tx = wrap_ops({op});
+
+  HiveParsedTx parsed;
+  EXPECT_NE(nullptr, hive_parseOperations(tx.data(), tx.size(), &parsed));
+}
+
+TEST(Hive, MixedTierOpsRejected) {
+  // vote is posting-tier, convert is active-tier; one signature cannot
+  // satisfy both post-HF28.
+  std::vector<uint8_t> vote;
+  append_varint(vote, HIVE_OP_VOTE);
+  append_string(vote, "alice");
+  append_string(vote, "bob");
+  append_string(vote, "a-post");
+  append_u16_le(vote, 10000);
+
+  std::vector<uint8_t> convert;
+  append_varint(convert, HIVE_OP_CONVERT);
+  append_string(convert, "alice");
+  append_u32_le(convert, 1);
+  append_asset(convert, 1000, 3, "HBD");
+
+  std::vector<uint8_t> tx = wrap_ops({vote, convert});
+  HiveParsedTx parsed;
+  EXPECT_NE(nullptr, hive_parseOperations(tx.data(), tx.size(), &parsed));
+}
+
+TEST(Hive, ExcludedAndUnknownOpsStillRejected) {
+  HiveParsedTx parsed;
+
+  // Ops 2/9/10 keep their dedicated message types — never fold them in.
+  for (uint32_t excluded : {static_cast<uint32_t>(HIVE_OP_TRANSFER),
+                            static_cast<uint32_t>(HIVE_OP_ACCOUNT_CREATE),
+                            static_cast<uint32_t>(HIVE_OP_ACCOUNT_UPDATE)}) {
+    std::vector<uint8_t> op;
+    append_varint(op, excluded);
+    append_string(op, "alice");
+    std::vector<uint8_t> tx = wrap_ops({op});
+    EXPECT_NE(nullptr, hive_parseOperations(tx.data(), tx.size(), &parsed));
+  }
+
+  // Anything outside the table is refused; there is no blind-sign fallback.
+  // 49 = recurrent_transfer, a real op deliberately not in the table.
+  std::vector<uint8_t> unknown;
+  append_varint(unknown, 49);
+  append_string(unknown, "alice");
+  std::vector<uint8_t> tx = wrap_ops({unknown});
+  EXPECT_NE(nullptr, hive_parseOperations(tx.data(), tx.size(), &parsed));
+}
+
+// Trailing bytes after a well-formed op must not be silently accepted: the
+// signature covers them, so what the device displays would be a subset of
+// what it signs.
+TEST(Hive, TrailingBytesRejected) {
+  std::vector<uint8_t> tx = wrap_ops(
+      {limit_order_create_op("alice", 1, 100, "HIVE", 50, "HBD", false, 1)});
+  tx.push_back(0xff);
+
+  HiveParsedTx parsed;
+  EXPECT_NE(nullptr, hive_parseOperations(tx.data(), tx.size(), &parsed));
 }

--- a/unittests/firmware/osmosis.cpp
+++ b/unittests/firmware/osmosis.cpp
@@ -1,0 +1,47 @@
+extern "C" {
+// interface.h first: it is what neutralises the `delete` field in
+// messages.pb.h, which is a keyword in C++.
+#include "keepkey/transport/interface.h"
+#include "keepkey/firmware/osmosis.h"
+}
+
+#include "gtest/gtest.h"
+
+#include <string>
+
+static std::string fmt(const char *value, const char *denom) {
+  char out[OSMOSIS_AMOUNT_STR_LEN] = {0};
+  osmosis_formatAmount(out, sizeof(out), value, denom);
+  return std::string(out);
+}
+
+TEST(Osmosis, FormatAmountScalesUosmo) {
+  EXPECT_EQ(fmt("1500000", "uosmo"), "1.500000 OSMO");
+  EXPECT_EQ(fmt("1000000", "uosmo"), "1.000000 OSMO");
+  EXPECT_EQ(fmt("0", "uosmo"), "0.000000 OSMO");
+  // Sub-unit amounts keep every digit rather than collapsing to zero.
+  EXPECT_EQ(fmt("500", "uosmo"), "0.000500 OSMO");
+  EXPECT_EQ(fmt("1", "uosmo"), "0.000001 OSMO");
+}
+
+/*
+ * The reason this formatter exists. A float carries ~7 significant decimal
+ * digits, so the old atof() + "%.6f" path rendered large amounts rounded on
+ * the screen the user approves — 123456789.123456 OSMO came out as
+ * 123456792.000000. Integer formatting is exact at any magnitude.
+ */
+TEST(Osmosis, FormatAmountIsExactBeyondFloatPrecision) {
+  EXPECT_EQ(fmt("123456789123456", "uosmo"), "123456789.123456 OSMO");
+  EXPECT_EQ(fmt("999999999999999", "uosmo"), "999999999.999999 OSMO");
+  EXPECT_EQ(fmt("18446744073709551615", "uosmo"), "18446744073709.551615 OSMO");
+}
+
+TEST(Osmosis, FormatAmountLeavesUnknownDenomsAlone) {
+  // The device does not know the precision of an arbitrary denom, so the
+  // base-unit integer is shown verbatim — never scaled by a guess.
+  EXPECT_EQ(fmt("1500000", "uatom"), "1500000 uatom");
+  EXPECT_EQ(fmt("42", "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA6"),
+            "42 ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA6");
+  // "uosmo" must match exactly — a lookalike denom is not OSMO.
+  EXPECT_EQ(fmt("1500000", "uosmox"), "1500000 uosmox");
+}

--- a/unittests/firmware/osmosis.cpp
+++ b/unittests/firmware/osmosis.cpp
@@ -5,6 +5,7 @@ extern "C" {
 #include "keepkey/board/util.h"
 #include "keepkey/firmware/app_confirm.h"
 #include "keepkey/firmware/osmosis.h"
+#include "trezor/crypto/curves.h"
 }
 
 #include "gtest/gtest.h"

--- a/unittests/firmware/osmosis.cpp
+++ b/unittests/firmware/osmosis.cpp
@@ -2,6 +2,8 @@ extern "C" {
 // interface.h first: it is what neutralises the `delete` field in
 // messages.pb.h, which is a keyword in C++.
 #include "keepkey/transport/interface.h"
+#include "keepkey/board/util.h"
+#include "keepkey/firmware/app_confirm.h"
 #include "keepkey/firmware/osmosis.h"
 }
 
@@ -9,9 +11,12 @@ extern "C" {
 
 #include <string>
 
+bool kkconfirm_preload(int nYes, int nNo);
+int kkconfirm_drain(void);
+
 static std::string fmt(const char *value, const char *denom) {
   char out[OSMOSIS_AMOUNT_STR_LEN] = {0};
-  osmosis_formatAmount(out, sizeof(out), value, denom);
+  EXPECT_TRUE(osmosis_formatAmount(out, sizeof(out), value, denom));
   return std::string(out);
 }
 
@@ -40,8 +45,81 @@ TEST(Osmosis, FormatAmountLeavesUnknownDenomsAlone) {
   // The device does not know the precision of an arbitrary denom, so the
   // base-unit integer is shown verbatim — never scaled by a guess.
   EXPECT_EQ(fmt("1500000", "uatom"), "1500000 uatom");
-  EXPECT_EQ(fmt("42", "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA6"),
-            "42 ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA6");
+  EXPECT_EQ(
+      fmt("42", "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA6"),
+      "42 ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA6");
   // "uosmo" must match exactly — a lookalike denom is not OSMO.
   EXPECT_EQ(fmt("1500000", "uosmox"), "1500000 uosmox");
+}
+
+TEST(Osmosis, FormatAmountRejectsNoncanonicalOrOutOfSchemaValues) {
+  const char *invalid[] = {"",
+                           "01",
+                           "+1",
+                           "-1",
+                           " 1",
+                           "1 ",
+                           "0x1",
+                           "1a",
+                           "18446744073709551616",
+                           "123456789012345678901234567890123"};
+  for (const char *value : invalid) {
+    char out[OSMOSIS_AMOUNT_STR_LEN] = "unchanged";
+    EXPECT_FALSE(osmosis_formatAmount(out, sizeof(out), value, "uosmo"));
+    EXPECT_STREQ(out, "");
+  }
+
+  char out[OSMOSIS_AMOUNT_STR_LEN] = {0};
+  EXPECT_FALSE(osmosis_formatAmount(out, sizeof(out), "1", "bad denom"));
+  EXPECT_FALSE(osmosis_formatAmount(out, sizeof(out), "1", "bad\"denom"));
+  EXPECT_FALSE(osmosis_formatAmount(
+      out, sizeof(out), "1",
+      "ibc/12345678901234567890123456789012345678901234567890123456789012345"));
+  EXPECT_FALSE(osmosis_formatAmount(out, 4, "1", "uosmo"));
+}
+
+TEST(Osmosis, BaseToPrecisionPreservesMaxLpAmountAndCanary) {
+  struct {
+    uint8_t out[34];
+    uint8_t canary;
+  } guarded = {{0}, 0xa5};
+  const char value[] = "12345678901234567890123456789012";
+
+  ASSERT_EQ(0, base_to_precision(guarded.out, (const uint8_t *)value,
+                                 sizeof(guarded.out), strlen(value), 18));
+  EXPECT_STREQ((const char *)guarded.out, "12345678901234.567890123456789012");
+  EXPECT_EQ(guarded.canary, 0xa5);
+}
+
+TEST(Osmosis, BaseToPrecisionRejectsTruncationAndNoncanonicalValues) {
+  uint8_t out[34] = {0};
+  const char max_value[] = "12345678901234567890123456789012";
+  EXPECT_LT(base_to_precision(out, (const uint8_t *)max_value, sizeof(out) - 1,
+                              strlen(max_value), 18),
+            0);
+  EXPECT_LT(base_to_precision(out, (const uint8_t *)"01", sizeof(out), 2, 18),
+            0);
+  EXPECT_LT(base_to_precision(out, (const uint8_t *)"1x", sizeof(out), 2, 18),
+            0);
+}
+
+TEST(Osmosis, MaxSwapAssetsAreRendererPagedCompletely) {
+  const char denom[] =
+      "ibc/1234567890123456789012345678901234567890123456789012345678901234";
+  static_assert(sizeof(denom) - 1 == OSMOSIS_MAX_DENOM_LEN,
+                "fixture must exercise the schema maximum");
+  char token[OSMOSIS_AMOUNT_STR_LEN] = {0};
+  ASSERT_TRUE(osmosis_formatAmount(token, sizeof(token),
+                                   "12345678901234567890123456789012", denom));
+
+  // The old combined sentence required more than the OLED's three rows. Each
+  // 101-character asset now gets its own measured page, so both signed values
+  // are fully accepted in exactly two independent confirmations.
+  ASSERT_TRUE(kkconfirm_preload(2, 0));
+  EXPECT_TRUE(confirm_bytes(ButtonRequestType_ButtonRequest_Other, "Swap Input",
+                            (const uint8_t *)token, strlen(token)));
+  EXPECT_TRUE(confirm_bytes(ButtonRequestType_ButtonRequest_Other,
+                            "Minimum Output", (const uint8_t *)token,
+                            strlen(token)));
+  EXPECT_EQ(0, kkconfirm_drain());
 }

--- a/unittests/firmware/osmosis.cpp
+++ b/unittests/firmware/osmosis.cpp
@@ -5,7 +5,7 @@ extern "C" {
 #include "keepkey/board/util.h"
 #include "keepkey/firmware/app_confirm.h"
 #include "keepkey/firmware/osmosis.h"
-#include "trezor/crypto/curves.h"
+#include "trezor/crypto/secp256k1.h"
 }
 
 #include "gtest/gtest.h"

--- a/unittests/firmware/osmosis.cpp
+++ b/unittests/firmware/osmosis.cpp
@@ -123,3 +123,35 @@ TEST(Osmosis, MaxSwapAssetsAreRendererPagedCompletely) {
                             strlen(token)));
   EXPECT_EQ(0, kkconfirm_drain());
 }
+
+TEST(Osmosis, MsgSendSignsCanonicalNonNativeDenomination) {
+  HDNode node = {
+      0,
+      0,
+      {0},
+      {0xb9, 0x9a, 0x39, 0x3a, 0x5a, 0x53, 0x0d, 0x90, 0xef, 0x6e, 0x46,
+       0x4e, 0x8e, 0x2f, 0x2b, 0x8b, 0x5c, 0x64, 0xa7, 0x97, 0x29, 0xcd,
+       0x8b, 0x6c, 0x69, 0x5c, 0x71, 0x72, 0x03, 0x02, 0xf1, 0x76},
+      {0},
+      {0},
+      &secp256k1_info};
+  hdnode_fill_public_key(&node);
+
+  OsmosisSignTx msg = {};
+  msg.account_number = 0;
+  msg.has_chain_id = true;
+  strlcpy(msg.chain_id, "osmosis-1", sizeof(msg.chain_id));
+  msg.fee_amount = 800;
+  msg.gas = 290000;
+  msg.has_memo = true;
+  msg.sequence = 0;
+  msg.msg_count = 1;
+  ASSERT_TRUE(osmosis_signTxInit(&node, &msg));
+
+  const char denom[] =
+      "ibc/1234567890123456789012345678901234567890123456789012345678901234";
+  static_assert(sizeof(denom) - 1 == OSMOSIS_MAX_DENOM_LEN,
+                "fixture must exercise the schema maximum");
+  EXPECT_TRUE(osmosis_signTxUpdateMsgSend(
+      "7", "osmo1rs7fckgznkaxs4sq02pexwjgar43p5wnkx9s92", denom));
+}

--- a/unittests/firmware/thorchain.cpp
+++ b/unittests/firmware/thorchain.cpp
@@ -2,6 +2,7 @@ extern "C" {
 #include "keepkey/board/messages.h"
 #include "keepkey/board/usb.h"
 #include "keepkey/firmware/coins.h"
+#include "keepkey/firmware/app_confirm.h"
 #include "keepkey/firmware/ethereum_contracts/thortx.h"
 #include "keepkey/firmware/fsm.h"
 #include "keepkey/firmware/thorchain.h"
@@ -408,29 +409,30 @@ TEST(Thorchain, FullMemoShortAsciiIsOnePage) {
   EXPECT_EQ(0, kkconfirm_drain());
 }
 
-// A long memo (up to THORChain's 250-byte limit) pages in full instead of
-// truncating in one confirm: 150 ASCII bytes / 72 per page = 3 pages.
+// Page breaks use measured rendered rows, including word-wrap behavior.
 TEST(Thorchain, FullMemoLongAsciiPagesAll) {
-  std::string memo(150, 'a');
-  ASSERT_TRUE(kkconfirm_preload(3, 0));
-  EXPECT_TRUE(thorchain_confirm_full_memo("Memo", memo.c_str(), memo.size()));
+  const char memo[] =
+      "%%%%%%%%%%%%%%%% %%%%%%%%%%%%%%%% %%%%%%%%%%%%%%%% %%%%%%%%%%%%%%%%";
+  ASSERT_TRUE(kkconfirm_preload(2, 0));
+  EXPECT_TRUE(thorchain_confirm_full_memo("Memo", memo, strlen(memo)));
   EXPECT_EQ(0, kkconfirm_drain());
 }
 
 // Rejecting any page aborts the whole disclosure (so the handler aborts
 // signing).
 TEST(Thorchain, FullMemoRejectPropagates) {
-  std::string memo(150, 'a');
+  const char memo[] =
+      "%%%%%%%%%%%%%%%% %%%%%%%%%%%%%%%% %%%%%%%%%%%%%%%% %%%%%%%%%%%%%%%%";
   ASSERT_TRUE(kkconfirm_preload(1, 1));  // approve page 1, reject page 2
-  EXPECT_FALSE(thorchain_confirm_full_memo("Memo", memo.c_str(), memo.size()));
+  EXPECT_FALSE(thorchain_confirm_full_memo("Memo", memo, strlen(memo)));
   EXPECT_EQ(0, kkconfirm_drain());
 }
 
-// Non-printable memo bytes are disclosed as hex pages (40 bytes/page), never
-// hidden behind a byte-count summary.
+// Non-printable memo bytes are disclosed in complete renderer-measured hex
+// pages, never hidden behind a byte-count summary.
 TEST(Thorchain, FullMemoBinaryPagesAsHex) {
-  char memo[50];
-  memset(memo, 0x01, sizeof(memo));  // 50 non-printable bytes -> 2 hex pages
+  char memo[100];
+  memset(memo, 0x01, sizeof(memo));
   ASSERT_TRUE(kkconfirm_preload(2, 0));
   EXPECT_TRUE(thorchain_confirm_full_memo("Memo", memo, sizeof(memo)));
   EXPECT_EQ(0, kkconfirm_drain());
@@ -441,6 +443,29 @@ TEST(Thorchain, FullMemoBinaryPagesAsHex) {
 TEST(Thorchain, FullMemoEmptyShowsEmpty) {
   ASSERT_TRUE(kkconfirm_preload(1, 0));
   EXPECT_TRUE(thorchain_confirm_full_memo("Memo", "", 0));
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+// Renderer-aware paging must split the exact 69-byte word-wrap exploit from
+// the second-pass audit. A byte-count pager treated this as one screen even
+// though the OLED renderer placed the final signed word on a fourth row.
+TEST(Confirmation, ExactLengthPagerMeasuresRenderedRows) {
+  const char payload[] =
+      "%%%%%%%%%%%%%%%% %%%%%%%%%%%%%%%% %%%%%%%%%%%%%%%% %%%%%%%%%%%%%%%%";
+  ASSERT_TRUE(kkconfirm_preload(2, 0));
+  EXPECT_TRUE(confirm_bytes(ButtonRequestType_ButtonRequest_SignMessage,
+                            "Signed Message", (const uint8_t*)payload,
+                            strlen(payload)));
+  EXPECT_EQ(0, kkconfirm_drain());
+}
+
+TEST(Confirmation, ExactLengthPagerRejectPropagates) {
+  const char payload[] =
+      "%%%%%%%%%%%%%%%% %%%%%%%%%%%%%%%% %%%%%%%%%%%%%%%% %%%%%%%%%%%%%%%%";
+  ASSERT_TRUE(kkconfirm_preload(1, 1));
+  EXPECT_FALSE(confirm_bytes(ButtonRequestType_ButtonRequest_SignMessage,
+                             "Signed Message", (const uint8_t*)payload,
+                             strlen(payload)));
   EXPECT_EQ(0, kkconfirm_drain());
 }
 


### PR DESCRIPTION
## Summary

Integrate the accumulated RC15-RC17 security hardening into the 7.15.0 release
line and establish the final RC18 release shape.

RC18 has exactly two products:

- **regular/full** — every supported chain, including Zcash
  shielded/Orchard;
- **bitcoin-only** — Bitcoin only, with non-Bitcoin and Zcash privacy code
  compiled out.

The separate `zcash-privacy` artifact and its CI, unit-test, SRAM, release, and
emulator-publish matrix legs are removed. Zcash privacy is now an invariant of
the regular build rather than an optional third release gate.

## Impact

- Unflagged device and emulator builds set `ZCASH_PRIVACY=1`.
- `-DKK_BITCOIN_ONLY=ON` sets `ZCASH_PRIVACY=0`.
- The regular image uses `AES_SMALL_TABLES` to retain the proven flash
  headroom of the former privacy build.
- Tagged releases and reproducible-build instructions emit only `full` and
  `bitcoin-only`.
- The published emulator is the regular/full image.
- Merging this PR updates the head of #450 without replacing its consolidated
  release review.

## Validation

- Regular ARM build: pass; Zcash object present; `ZCASH_PRIVACY=1`.
- Bitcoin-only ARM build: pass; Zcash object absent; `ZCASH_PRIVACY=0`.
- Regular emulator suites: 363/363 firmware, 2/2 board, 4/4 crypto.
- Bitcoin-only emulator suites: 28/28 firmware, 2/2 board, 4/4 crypto.
- SRAM gate:
  - regular: 19,064 B reserve; 7,664 B largest frame; 11,400 B margin;
  - bitcoin-only: 32,908 B reserve; 7,664 B largest frame; 25,244 B margin.
- Workflow YAML, SRAM-budget JSON, Python syntax, and `git diff --check`: pass.

The exact RC18 release contract and evidence are recorded in
`docs/security/7.15.0-rc18-release-shape.md`.
