### PR TITLE
fix(signing): reject empty message sessions

### DIFF
--- a/lib/board/messages.c
+++ b/lib/board/messages.c
@@ -23,6 +23,7 @@
 #include "keepkey/board/timer.h"
 #include "keepkey/board/layout.h"
 #include "keepkey/board/util.h"
+#include "trezor/crypto/memzero.h"
 
 #include <nanopb.h>
 
@@ -122,20 +123,26 @@ static bool pb_parse(const MessagesMap_t* entry, const uint8_t* msg,
 static void dispatch(const MessagesMap_t* entry, const uint8_t* msg,
                      uint32_t msg_size) {
   static uint8_t decode_buffer[MAX_DECODE_SIZE] __attribute__((aligned(4)));
-  memset(decode_buffer, 0, sizeof(decode_buffer));
+  memzero(decode_buffer, sizeof(decode_buffer));
 
   if (!pb_parse(entry, msg, msg_size, decode_buffer)) {
     (*msg_failure)(FailureType_Failure_UnexpectedMessage,
                    "Could not parse protocol buffer message");
-    return;
+    goto cleanup;
   }
 
   if (!entry->process_func) {
     (*msg_failure)(FailureType_Failure_UnexpectedMessage, "Unexpected message");
-    return;
+    goto cleanup;
   }
 
   entry->process_func(decode_buffer);
+
+cleanup:
+  /* Parsed protobufs can contain PINs, passphrases, authenticator seeds, and
+   * other credentials.  Handlers must copy any state they retain; do not keep
+   * the source message resident until the next dispatch. */
+  memzero(decode_buffer, sizeof(decode_buffer));
 }
 
 /*

--- a/lib/firmware/authenticator.c
+++ b/lib/firmware/authenticator.c
@@ -97,7 +97,14 @@ unsigned wipeAuthData(void) {
 }
 
 unsigned addAuthAccount(char* accountWithSeed) {
-  char *domain, *account, *seedStr = NULL;
+  if (accountWithSeed == NULL) return TOKERR;
+
+  /* strtok() inserts NULs into the caller's protobuf string, so retain the
+   * original extent before parsing.  Every exit wipes that whole credential
+   * suffix, including the Base32 source, rather than leaving it in the static
+   * message decode buffer until another USB message arrives. */
+  const size_t sourceLen = strlen(accountWithSeed);
+  char *domain, *account, *seedStr;
   unsigned slot;
   char authSecret[AUTHSECRET_SIZE_MAX] = {
       0};  // 128-bit key len is the recommended minimum, this is room for
@@ -108,20 +115,24 @@ unsigned addAuthAccount(char* accountWithSeed) {
   // accountWithSeed should be of the form "domain:account:seedStr"
   domain = strtok(accountWithSeed, ":");  // get the domain string token
   if (NULL == domain) {
-    return TOKERR;
+    result = TOKERR;
+    goto cleanup;
   }
 
   account = strtok(NULL, ":");  // get the account string token
   if (NULL == account) {
-    return TOKERR;
+    result = TOKERR;
+    goto cleanup;
   }
   if (0 == strlen(account)) {
-    return TOKERR;
+    result = TOKERR;
+    goto cleanup;
   }
 
   seedStr = strtok(NULL, "");  // get the seed string string token
   if (NULL == seedStr) {
-    return TOKERR;
+    result = TOKERR;
+    goto cleanup;
   }
   if (0 == strlen(seedStr)) {
     result = TOKERR;
@@ -173,10 +184,8 @@ unsigned addAuthAccount(char* accountWithSeed) {
   result = NOERR;
 
 cleanup:
-  if (seedStr != NULL) {
-    memzero(seedStr, strlen(seedStr));
-  }
   memzero(authSecret, sizeof(authSecret));
+  memzero(accountWithSeed, sourceLen);
   return result;
 }
 

--- a/lib/firmware/fsm_msg_mayachain.h
+++ b/lib/firmware/fsm_msg_mayachain.h
@@ -80,16 +80,19 @@ void fsm_msgMayachainGetAddress(const MayachainGetAddress* msg) {
 
 void fsm_msgMayachainSignTx(const MayachainSignTx* msg) {
   CHECK_INITIALIZED
-  CHECK_PIN
 
   if (!msg->has_account_number || !msg->has_chain_id || !msg->has_fee_amount ||
-      !msg->has_gas || !msg->has_sequence) {
+      !msg->has_gas || !msg->has_sequence || !msg->has_msg_count ||
+      msg->msg_count == 0) {
     mayachain_signAbort();
     fsm_sendFailure(FailureType_Failure_SyntaxError,
-                    "Missing Fields On Message");
+                    "Missing or Invalid Fields On Message");
     layoutHome();
     return;
   }
+
+  /* Reject malformed envelopes before authentication or key derivation. */
+  CHECK_PIN
 
   HDNode* node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
                                     msg->address_n_count, NULL);

--- a/lib/firmware/fsm_msg_osmosis.h
+++ b/lib/firmware/fsm_msg_osmosis.h
@@ -125,16 +125,19 @@ void fsm_msgOsmosisGetAddress(const OsmosisGetAddress* msg) {
 
 void fsm_msgOsmosisSignTx(const OsmosisSignTx* msg) {
   CHECK_INITIALIZED
-  CHECK_PIN
 
   if (!msg->has_account_number || !msg->has_chain_id || !msg->has_fee_amount ||
-      !msg->has_gas || !msg->has_sequence) {
+      !msg->has_gas || !msg->has_sequence || !msg->has_msg_count ||
+      msg->msg_count == 0) {
     osmosis_signAbort();
     fsm_sendFailure(FailureType_Failure_SyntaxError,
-                    "Missing Fields On Message");
+                    "Missing or Invalid Fields On Message");
     layoutHome();
     return;
   }
+
+  /* Reject malformed envelopes before authentication or key derivation. */
+  CHECK_PIN
 
   HDNode* node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
                                     msg->address_n_count, NULL);

--- a/lib/firmware/fsm_msg_thorchain.h
+++ b/lib/firmware/fsm_msg_thorchain.h
@@ -79,16 +79,19 @@ void fsm_msgThorchainGetAddress(const ThorchainGetAddress* msg) {
 
 void fsm_msgThorchainSignTx(const ThorchainSignTx* msg) {
   CHECK_INITIALIZED
-  CHECK_PIN
 
   if (!msg->has_account_number || !msg->has_chain_id || !msg->has_fee_amount ||
-      !msg->has_gas || !msg->has_sequence) {
+      !msg->has_gas || !msg->has_sequence || !msg->has_msg_count ||
+      msg->msg_count == 0) {
     thorchain_signAbort();
     fsm_sendFailure(FailureType_Failure_SyntaxError,
-                    "Missing Fields On Message");
+                    "Missing or Invalid Fields On Message");
     layoutHome();
     return;
   }
+
+  /* Reject malformed envelopes before authentication or key derivation. */
+  CHECK_PIN
 
   HDNode* node = fsm_getDerivedNode(SECP256K1_NAME, msg->address_n,
                                     msg->address_n_count, NULL);

--- a/lib/firmware/mayachain.c
+++ b/lib/firmware/mayachain.c
@@ -57,11 +57,11 @@ bool mayachain_formatAmount(uint64_t amount, const char* denom, char* out,
 }
 
 bool mayachain_signTxInit(const HDNode* _node, const MayachainSignTx* _msg) {
-  initialized = true;
-  /* A previous session's has_message must not leak into this one: a stale
-   * true writes a comma BEFORE the first message. signAbort() also clears
-   * it, but init cannot depend on the host having aborted. */
-  has_message = false;
+  mayachain_signAbort();
+  if (!_node || !_msg || !_msg->has_msg_count || _msg->msg_count == 0) {
+    return false;
+  }
+
   msgs_remaining = _msg->msg_count;
   testnet = false;
 
@@ -111,11 +111,18 @@ bool mayachain_signTxInit(const HDNode* _node, const MayachainSignTx* _msg) {
   // 10
   sha256_Update(&ctx, (uint8_t*)"\",\"msgs\":[", 10);
 
-  return success;
+  if (!success) {
+    mayachain_signAbort();
+    return false;
+  }
+  initialized = true;
+  return true;
 }
 
 bool mayachain_signTxUpdateMsgSend(const uint64_t amount,
                                    const char* to_address, const char* denom) {
+  if (!initialized || msgs_remaining == 0) return false;
+
   const char mainnetp[] = "maya";
   const char testnetp[] = "smaya";
   const char* pfix;
@@ -170,6 +177,8 @@ bool mayachain_signTxUpdateMsgSend(const uint64_t amount,
 }
 
 bool mayachain_signTxUpdateMsgDeposit(const MayachainMsgDeposit* depmsg) {
+  if (!initialized || msgs_remaining == 0) return false;
+
   char buffer[64 + 1];
 
   if (has_message) {

--- a/lib/firmware/osmosis.c
+++ b/lib/firmware/osmosis.c
@@ -54,11 +54,11 @@ bool osmosis_validate_amount(bool has_value, const char* value) {
 }
 
 bool osmosis_signTxInit(const HDNode* _node, const OsmosisSignTx* _msg) {
-  initialized = true;
-  /* A previous session's has_message must not leak into this one: a stale
-   * true writes a comma BEFORE the first message. signAbort() also clears
-   * it, but init cannot depend on the host having aborted. */
-  has_message = false;
+  osmosis_signAbort();
+  if (!_node || !_msg || !_msg->has_msg_count || _msg->msg_count == 0) {
+    return false;
+  }
+
   msgs_remaining = _msg->msg_count;
   testnet = false;
 
@@ -110,11 +110,18 @@ bool osmosis_signTxInit(const HDNode* _node, const OsmosisSignTx* _msg) {
   // 10
   sha256_Update(&ctx, (uint8_t*)"\",\"msgs\":[", 10);
 
-  return success;
+  if (!success) {
+    osmosis_signAbort();
+    return false;
+  }
+  initialized = true;
+  return true;
 }
 
 bool osmosis_signTxUpdateMsgSend(const char* amount, const char* to_address,
                                  const char* denom) {
+  if (!initialized || msgs_remaining == 0) return false;
+
   const char mainnetp[] = "osmo";
   const char testnetp[] = "tosmo";
   const char* pfix;
@@ -181,6 +188,8 @@ bool osmosis_signTxUpdateMsgDelegate(const char* amount,
                                      const char* delegator_address,
                                      const char* validator_address,
                                      const char* denom) {
+  if (!initialized || msgs_remaining == 0) return false;
+
   const char mainnetp[] = "osmo";
   const char testnetp[] = "tosmo";
   const char* pfix;
@@ -249,6 +258,8 @@ bool osmosis_signTxUpdateMsgUndelegate(const char* amount,
                                        const char* delegator_address,
                                        const char* validator_address,
                                        const char* denom) {
+  if (!initialized || msgs_remaining == 0) return false;
+
   const char mainnetp[] = "osmo";
   const char testnetp[] = "tosmo";
   const char* pfix;
@@ -317,6 +328,8 @@ bool osmosis_signTxUpdateMsgRedelegate(const char* amount,
                                        const char* validator_src_address,
                                        const char* validator_dst_address,
                                        const char* denom) {
+  if (!initialized || msgs_remaining == 0) return false;
+
   const char mainnetp[] = "osmo";
   const char testnetp[] = "tosmo";
   const char* pfix;
@@ -393,6 +406,8 @@ bool osmosis_signTxUpdateMsgLPAdd(const uint64_t pool_id, const char* sender,
                                   const char* denom_in_max_a,
                                   const char* amount_in_max_b,
                                   const char* denom_in_max_b) {
+  if (!initialized || msgs_remaining == 0) return false;
+
   char buffer[96 + 1] = {0};
 
   if (has_message) {
@@ -447,6 +462,8 @@ bool osmosis_signTxUpdateMsgLPRemove(const uint64_t pool_id, const char* sender,
                                      const char* denom_out_min_a,
                                      const char* amount_out_min_b,
                                      const char* denom_out_min_b) {
+  if (!initialized || msgs_remaining == 0) return false;
+
   char buffer[96 + 1] = {0};
 
   if (has_message) {
@@ -497,6 +514,8 @@ bool osmosis_signTxUpdateMsgLPRemove(const uint64_t pool_id, const char* sender,
 
 bool osmosis_signTxUpdateMsgRewards(const char* delegator_address,
                                     const char* validator_address) {
+  if (!initialized || msgs_remaining == 0) return false;
+
   const char mainnetp[] = "osmo";
   const char testnetp[] = "tosmo";
   const char* pfix;
@@ -562,6 +581,8 @@ bool osmosis_signTxUpdateMsgIBCTransfer(const char* amount, const char* sender,
                                         const char* revision_number,
                                         const char* revision_height,
                                         const char* denom) {
+  if (!initialized || msgs_remaining == 0) return false;
+
   const char mainnetp[] = "osmo";
   const char testnetp[] = "tosmo";
   const char* pfix;
@@ -648,6 +669,8 @@ bool osmosis_signTxUpdateMsgSwap(const uint64_t pool_id,
                                  const char* token_in_amount,
                                  const char* token_in_denom,
                                  const char* token_out_min_amount) {
+  if (!initialized || msgs_remaining == 0) return false;
+
   char buffer[96 + 1] = {0};
 
   // TODO: add testnet support

--- a/lib/firmware/thorchain.c
+++ b/lib/firmware/thorchain.c
@@ -53,8 +53,11 @@ bool thorchain_formatAmount(uint64_t amount, const char* asset, char* out,
 }
 
 bool thorchain_signTxInit(const HDNode* _node, const ThorchainSignTx* _msg) {
-  initialized = true;
-  has_message = false;
+  thorchain_signAbort();
+  if (!_node || !_msg || !_msg->has_msg_count || _msg->msg_count == 0) {
+    return false;
+  }
+
   msgs_remaining = _msg->msg_count;
   testnet = false;
 
@@ -104,12 +107,17 @@ bool thorchain_signTxInit(const HDNode* _node, const ThorchainSignTx* _msg) {
   // 10
   sha256_Update(&ctx, (uint8_t*)"\",\"msgs\":[", 10);
 
-  return success;
+  if (!success) {
+    thorchain_signAbort();
+    return false;
+  }
+  initialized = true;
+  return true;
 }
 
 bool thorchain_signTxUpdateMsgSend(const uint64_t amount,
                                    const char* to_address) {
-  if (msgs_remaining == 0) return false;
+  if (!initialized || msgs_remaining == 0) return false;
 
   const char mainnetp[] = "thor";
   const char testnetp[] = "tthor";
@@ -162,7 +170,7 @@ bool thorchain_signTxUpdateMsgSend(const uint64_t amount,
 }
 
 bool thorchain_signTxUpdateMsgDeposit(const ThorchainMsgDeposit* depmsg) {
-  if (msgs_remaining == 0) return false;
+  if (!initialized || msgs_remaining == 0) return false;
 
   char buffer[64 + 1];
 

--- a/unittests/firmware/fsm.cpp
+++ b/unittests/firmware/fsm.cpp
@@ -1,5 +1,7 @@
 extern "C" {
 #include "keepkey/transport/interface.h"
+#include "trezor/crypto/sha2.h"
+#include "keepkey/firmware/authenticator.h"
 #include "keepkey/firmware/binance.h"
 #include "keepkey/firmware/eos.h"
 #include "keepkey/firmware/fsm.h"
@@ -13,6 +15,15 @@ extern "C" {
 #include "gtest/gtest.h"
 
 #include <cstring>
+
+TEST(Fsm, AuthenticatorCredentialSourceIsWipedOnEveryExit) {
+  char credential[] = "site:user:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+  ASSERT_EQ(LARGESEED, addAuthAccount(credential));
+
+  for (size_t i = 0; i < sizeof(credential); ++i) {
+    EXPECT_EQ('\0', credential[i]);
+  }
+}
 
 TEST(Fsm, AbortWorkflowsClearsEveryObservableSigningSession) {
   HDNode node = {};
@@ -36,16 +47,19 @@ TEST(Fsm, AbortWorkflowsClearsEveryObservableSigningSession) {
                                     "uatom", TENDERMINT_SIGNING_GENERIC));
 
   OsmosisSignTx osmosis = {};
+  osmosis.has_msg_count = true;
   osmosis.msg_count = 1;
   std::strcpy(osmosis.chain_id, "osmosis-1");
   ASSERT_TRUE(osmosis_signTxInit(&node, &osmosis));
 
   ThorchainSignTx thorchain = {};
+  thorchain.has_msg_count = true;
   thorchain.msg_count = 1;
   std::strcpy(thorchain.chain_id, "thorchain-1");
   ASSERT_TRUE(thorchain_signTxInit(&node, &thorchain));
 
   MayachainSignTx mayachain = {};
+  mayachain.has_msg_count = true;
   mayachain.msg_count = 1;
   std::strcpy(mayachain.chain_id, "mayachain-mainnet-v1");
   ASSERT_TRUE(mayachain_signTxInit(&node, &mayachain));

--- a/unittests/firmware/mayachain.cpp
+++ b/unittests/firmware/mayachain.cpp
@@ -230,9 +230,7 @@ TEST(Mayachain, MultiMessageSignTxSeparatesMsgsWithComma) {
   mayachain_signAbort();
 }
 
-TEST(Mayachain, ZeroMessagesNeverFinishes) {
-  /* msg_count:0 used to "finish" trivially (msgs_remaining==0 from the start),
-     signing a document whose msgs array was never populated. */
+TEST(Mayachain, ZeroOrOmittedMessagesFailInitialization) {
   HDNode node = {
       0,
       0,
@@ -258,7 +256,13 @@ TEST(Mayachain, ZeroMessagesNeverFinishes) {
       true, 19,
       true, 0  // msg_count
   };
-  ASSERT_TRUE(mayachain_signTxInit(&node, &msg));
+  EXPECT_FALSE(mayachain_signTxInit(&node, &msg));
+  EXPECT_FALSE(mayachain_signingIsInited());
   EXPECT_FALSE(mayachain_signingIsFinished());
-  mayachain_signAbort();
+  EXPECT_FALSE(mayachain_signTxUpdateMsgSend(1, "ignored", "cacao"));
+
+  msg.has_msg_count = false;
+  msg.msg_count = 1;
+  EXPECT_FALSE(mayachain_signTxInit(&node, &msg));
+  EXPECT_FALSE(mayachain_signingIsInited());
 }

--- a/unittests/firmware/osmosis.cpp
+++ b/unittests/firmware/osmosis.cpp
@@ -91,12 +91,10 @@ TEST(Osmosis, MultiMessageSignTxSeparatesMsgsWithComma) {
   osmosis_signAbort();
 }
 
-TEST(Osmosis, ZeroMessagesNeverFinishes) {
-  /* msg_count:0 used to "finish" trivially (msgs_remaining==0 from the start),
-     signing a document whose msgs array was never populated. */
+TEST(Osmosis, ZeroOrOmittedMessagesFailInitialization) {
   HDNode node = testNode();
 
-  const OsmosisSignTx msg = {
+  OsmosisSignTx msg = {
       5,    {0x80000000 | 44, 0x80000000 | 118, 0x80000000, 0, 0},
       true, 251252,
       true, "osmosis-1",
@@ -106,9 +104,15 @@ TEST(Osmosis, ZeroMessagesNeverFinishes) {
       true, 4,
       true, 0  // msg_count
   };
-  ASSERT_TRUE(osmosis_signTxInit(&node, &msg));
+  EXPECT_FALSE(osmosis_signTxInit(&node, &msg));
+  EXPECT_FALSE(osmosis_signingIsInited());
   EXPECT_FALSE(osmosis_signingIsFinished());
-  osmosis_signAbort();
+  EXPECT_FALSE(osmosis_signTxUpdateMsgSend("1", "ignored", "uosmo"));
+
+  msg.has_msg_count = false;
+  msg.msg_count = 1;
+  EXPECT_FALSE(osmosis_signTxInit(&node, &msg));
+  EXPECT_FALSE(osmosis_signingIsInited());
 }
 
 TEST(Osmosis, RequiredValuesRejectEmptyAndNonDecimalAmounts) {

--- a/unittests/firmware/thorchain.cpp
+++ b/unittests/firmware/thorchain.cpp
@@ -248,11 +248,17 @@ TEST(Thorchain, MultiMessageSignTxSeparatesMsgsWithComma) {
   thorchain_signAbort();
 }
 
-TEST(Thorchain, ZeroMessagesNeverFinishes) {
+TEST(Thorchain, ZeroOrOmittedMessagesFailInitialization) {
   HDNode node = {};
-  const ThorchainSignTx msg = {0,    {}, true, 0,  true, "thorchain", true, 0,
-                               true, 0,  true, "", true, 0,           true, 0};
-  ASSERT_TRUE(thorchain_signTxInit(&node, &msg));
+  ThorchainSignTx msg = {0,    {}, true, 0,  true, "thorchain", true, 0,
+                         true, 0,  true, "", true, 0,           true, 0};
+  EXPECT_FALSE(thorchain_signTxInit(&node, &msg));
+  EXPECT_FALSE(thorchain_signingIsInited());
   EXPECT_FALSE(thorchain_signingIsFinished());
-  thorchain_signAbort();
+  EXPECT_FALSE(thorchain_signTxUpdateMsgSend(1, "ignored"));
+
+  msg.has_msg_count = false;
+  msg.msg_count = 1;
+  EXPECT_FALSE(thorchain_signTxInit(&node, &msg));
+  EXPECT_FALSE(thorchain_signingIsInited());
 }


### PR DESCRIPTION
## Summary

This is a focused pre-signing hardening follow-up for 7.14.2. It targets `release/7.14.2-rc31` through a feature PR; it does not merge, tag, or sign the release.

- reject missing or zero `msg_count` during Osmosis, THORChain, and MAYAChain signing initialization, before any confirmation or message request
- validate the complete signing envelope in each FSM before `CHECK_PIN` or private-node derivation, returning `Failure_SyntaxError` for malformed input
- leave failed initialization fully aborted and reject update calls outside an active session or after the declared message count is exhausted
- wipe authenticator credential source strings on every `addAuthAccount()` exit, including early validation failures
- wipe the shared protobuf decode buffer immediately after dispatch, including parse and missing-handler failures
- add exact zero/omitted-count regressions and an authenticator source-wipe regression

## Findings addressed

1. Osmosis and MAYAChain accepted zero/omitted counts and could decrement zero to `UINT32_MAX` on an update.
2. THORChain accepted zero/omitted counts, allowing confirmation UI before its update rejected the invalid session.
3. Authenticator cleanup wiped decoded key bytes but retained the Base32 credential source in the static protobuf decode buffer until a later dispatch.

## Verification

- firmware unit tests: **121 passed, 0 failed**
- board unit tests: **14 passed, 0 failed**
- full Python/emulator suite against the exact feature-branch firmware image: **432 passed, 47 skipped, 0 failed**
- focused regressions: **4 passed, 0 failed**
- exact protobuf/USB FSM regression on a PIN-protected, uncached device: **6/6 malformed envelopes returned `Failure_SyntaxError`; PIN remained uncached** (zero and omitted count for all three chains)
- `clang-format --dry-run --Werror`: clean for all changed files
- `git diff --check`: clean

The pre-existing `deps/crypto/trezor-firmware` worktree change was not staged or committed.

## Release control

This PR is intentionally rebased on firmware release head `39fdc885e`. That head's authenticator-only patch wipes a parsed seed suffix; this PR completes the cleanup by wiping the original full credential extent on every exit and clearing the shared dispatch buffer after processing. Please review and merge it into `release/7.14.2-rc31` before regenerating final evidence. No merge, tag, firmware signature, or release publication is authorized by this PR.
