### PR TITLE
fix(security): consolidate 7.14.2 audit remediation

### DIFF
--- a/include/keepkey/firmware/app_confirm.h
+++ b/include/keepkey/firmware/app_confirm.h
@@ -28,6 +28,7 @@
 
 #define CONFIRM_SIGN_IDENTITY_TITLE 32
 #define CONFIRM_SIGN_IDENTITY_BODY 416
+#define CONFIRM_SIGN_IDENTITY_KEY 96
 
 bool confirm_cipher(bool encrypt, const char* key);
 bool confirm_encrypt_msg(const char* msg, bool signing);
@@ -46,7 +47,11 @@ bool confirm_transaction(const char* total_amount, const char* fee);
 bool confirm_load_device(bool is_node);
 bool confirm_address(const char* desc, const char* address);
 bool confirm_xpub(const char* node_str, const char* xpub);
-bool confirm_sign_identity(const IdentityType* identity, const char* challenge);
+bool format_sign_identity_key_selection(const IdentityType* identity,
+                                        const char* curve, char* out,
+                                        size_t out_len);
+bool confirm_sign_identity(const IdentityType* identity, const char* challenge,
+                           const char* curve);
 
 /**
  * Render the largest screen-sized prefix of a byte string.

--- a/include/keepkey/firmware/signing.h
+++ b/include/keepkey/firmware/signing.h
@@ -28,6 +28,7 @@
 void signing_init(const SignTx* msg, const CoinType* _coin,
                   const HDNode* _root);
 void signing_abort(void);
+bool signing_is_active(void);
 void signing_txack(TransactionType* tx);
 void send_fsm_co_error_message(int co_error);
 

--- a/lib/board/confirm_sm.c
+++ b/lib/board/confirm_sm.c
@@ -52,19 +52,18 @@ extern bool reset_msg_stack;
 
 static CONFIDENTIAL char strbuf[BODY_CHAR_MAX];
 
-/* Set by format_body() when the formatted body did not fit strbuf, i.e. when
- * characters were lost before any screen existed to show them. Read and
- * cleared by confirm_helper(). Truncation here is invisible to every later
- * check: what reaches the renderer is a complete, well-formed, shorter string,
- * so the screen looks correct and is not. */
-static bool body_truncated = false;
+/* vsnprintf() returns the length it WOULD have written. Treat anything that
+ * did not fit as a refusal: once characters are lost, no renderer or pager can
+ * recover them and there is no complete body the user can approve. */
+static bool format_body_into(char* out, size_t out_len,
+                             const char* request_body, va_list vl) {
+  if (!out || out_len == 0 || !request_body) return false;
+  const int needed = vsnprintf(out, out_len, request_body, vl);
+  return needed >= 0 && (size_t)needed < out_len;
+}
 
-/* The single place a host-supplied body is formatted. vsnprintf() returns the
- * length it WOULD have written, which is the only chance to notice that
- * strbuf was too small -- after this, the evidence is gone. */
-static void format_body(const char* request_body, va_list vl) {
-  const int needed = vsnprintf(strbuf, sizeof(strbuf), request_body, vl);
-  body_truncated = (needed < 0) || ((size_t)needed >= sizeof(strbuf));
+static bool format_body(const char* request_body, va_list vl) {
+  return format_body_into(strbuf, sizeof(strbuf), request_body, vl);
 }
 
 /// Handler for push button being pressed.
@@ -511,19 +510,14 @@ done:
   return ok;
 }
 
-/// Show a confirmation, warning first when its body will not fit the screen.
+/// Show a confirmation, paging when its complete body will not fit the screen.
 ///
 /// draw_string() draws until a glyph no longer fits the canvas and then simply
 /// stops: a body taller than BODY_ROWS is drawn in part, with no ellipsis and
 /// nothing to tell the user that the tail of an address, an amount or a
-/// warning was dropped. The vsnprintf() into strbuf[BODY_CHAR_MAX] below cuts
-/// long host strings a second time, just as quietly.
-///
-/// So when the body will not fit, put an explicit screen in front of it. That
-/// screen costs its own hold, and the hold is a real consent signal: a host
-/// Cancel breaks it and the caller reports ActionCancelled, exactly as it
-/// would for the body screen. A body that is only partly shown is now never
-/// shown without saying so.
+/// warning was dropped. Complete formatted bodies are therefore paged here.
+/// Source formatting overflow is refused by every public entry point before a
+/// ButtonRequest is emitted, because lost source cannot be paged.
 ///
 /// Bodies that fit take exactly the path they took before: one screen, one
 /// ButtonRequest, one hold.
@@ -534,69 +528,14 @@ static bool confirm_helper(const char* request_title, const char* request_body,
   const uint16_t body_width =
       (uint16_t)((iconNum == NO_ICON) ? BODY_WIDTH : BODY_WIDTH_WITH_ICON);
 
-  /* Consume the source-completeness latch exactly once, whatever happens
-   * below: leaving it set would make the NEXT confirmation warn for this
-   * one's reason. */
-  const bool truncated = body_truncated;
-  body_truncated = false;
-
-  /* Two independent ways the user can be shown less than what is being
-   * approved, and they need separate measurements because they happen at
-   * different times:
-   *
-   *   SOURCE       the formatted body did not fit strbuf. Characters were lost
-   *                before the renderer ever saw them, so no amount of looking
-   *                at the screen can detect it -- only vsnprintf()'s return
-   *                value could, and format_body() kept it.
-   *   RENDER       the body reached the renderer intact but did not fit the
-   *                canvas. draw_string_fits() replays the real placement and
-   *                reports whether the last character landed.
-   *
-   * Only layout_standard_notification is known to wrap the body at BODY_WIDTH
+  /* Only layout_standard_notification is known to wrap the body at BODY_WIDTH
    * over BODY_ROWS rows. Custom layouts place and size their own body, and
    * layout_constant_power_notification draws from x = 128 + LEFT_MARGIN where
    * the canvas edge, not BODY_WIDTH, is the limit. Measuring either of those
-   * against BODY_WIDTH would be wrong, so leave them exactly as they were --
-   * but a SOURCE truncation is layout-independent and must warn regardless.  */
+   * against BODY_WIDTH would be wrong, so leave them exactly as they were. */
   const bool render_incomplete =
       (layout_notification_func == &layout_standard_notification) &&
       !confirm_body_fits(request_body, body_width);
-
-  if (truncated) {
-    /* SOURCE truncation: characters were lost in vsnprintf() before the
-     * renderer ever saw them. They cannot be paged, because they do not
-     * exist any more. Say exactly that -- the old copy promised to show the
-     * rest on the next hold and then redrew the same clipped body, which is
-     * worse than not warning at all: a user who read it carefully was
-     * misled about what they had seen. */
-    if (!confirm_screen("Cut Off",
-                        "This text is too long to show in full. The rest "
-                        "cannot be displayed. Hold to continue anyway.",
-                        &layout_standard_notification, constant_power, NO_ICON,
-                        immediate)) {
-      return false;
-    }
-    /* The warning CONSUMED the caller's ButtonRequest, so the body screen that
-     * follows needs one of its own -- otherwise it is a required press the
-     * host was never told about, and the invariant above is broken on exactly
-     * the path that added a screen. An interactive user would get through it
-     * (button_request_acked is still set from the warning's ack), but a
-     * ButtonRequest-driven client waits forever for a message that never
-     * comes. Reachable today: confirm_sign_identity() formats into a 416-byte
-     * body and strbuf is BODY_CHAR_MAX == 352, so a long identity truncates
-     * and lands here. See #482. */
-    if (notify_host) {
-      ButtonRequest body_req;
-      memset(&body_req, 0, sizeof(body_req));
-      body_req.has_code = true;
-      body_req.code = ButtonRequestType_ButtonRequest_Other;
-      button_request_acked = false;
-      msg_write(MessageType_MessageType_ButtonRequest, &body_req);
-    }
-    return page_body_confirm(request_title, request_body,
-                             layout_notification_func, constant_power, iconNum,
-                             immediate, body_width, notify_host);
-  }
 
   if (render_incomplete) {
     /* RENDER overflow: the body reached the renderer intact, so every
@@ -617,8 +556,12 @@ bool confirm(ButtonRequestType type, const char* request_title,
 
   va_list vl;
   va_start(vl, request_body);
-  format_body(request_body, vl);
+  const bool formatted = format_body(request_body, vl);
   va_end(vl);
+  if (!formatted) {
+    memzero(strbuf, sizeof(strbuf));
+    return false;
+  }
 
   /* Send button request */
   ButtonRequest resp;
@@ -716,8 +659,12 @@ bool confirm_constant_power(ButtonRequestType type, const char* request_title,
 
   va_list vl;
   va_start(vl, request_body);
-  format_body(request_body, vl);
+  const bool formatted = format_body(request_body, vl);
   va_end(vl);
+  if (!formatted) {
+    memzero(strbuf, sizeof(strbuf));
+    return false;
+  }
 
   /* Send button request */
   ButtonRequest resp;
@@ -740,8 +687,12 @@ bool confirm_with_custom_button_request(const ButtonRequest* button_request,
 
   va_list vl;
   va_start(vl, request_body);
-  format_body(request_body, vl);
+  const bool formatted = format_body(request_body, vl);
   va_end(vl);
+  if (!formatted) {
+    memzero(strbuf, sizeof(strbuf));
+    return false;
+  }
 
   /* Send button request */
   msg_write(MessageType_MessageType_ButtonRequest, button_request);
@@ -766,8 +717,12 @@ bool confirm_with_custom_layout(layout_notification_t layout_notification_func,
 
   va_list vl;
   va_start(vl, request_body);
-  format_body(request_body, vl);
+  const bool formatted = format_body(request_body, vl);
   va_end(vl);
+  if (!formatted) {
+    memzero(strbuf, sizeof(strbuf));
+    return false;
+  }
 
   /* Send button request */
   ButtonRequest resp;
@@ -789,8 +744,12 @@ bool confirm_without_button_request(const char* request_title,
 
   va_list vl;
   va_start(vl, request_body);
-  format_body(request_body, vl);
+  const bool formatted = format_body(request_body, vl);
   va_end(vl);
+  if (!formatted) {
+    memzero(strbuf, sizeof(strbuf));
+    return false;
+  }
 
   bool ret =
       confirm_helper(request_title, strbuf, &layout_standard_notification,
@@ -806,8 +765,12 @@ bool confirm_with_icon(ButtonRequestType type, IconType iconNum,
 
   va_list vl;
   va_start(vl, request_body);
-  format_body(request_body, vl);
+  const bool formatted = format_body(request_body, vl);
   va_end(vl);
+  if (!formatted) {
+    memzero(strbuf, sizeof(strbuf));
+    return false;
+  }
 
   /* Send button request */
   ButtonRequest resp;
@@ -829,8 +792,12 @@ bool review(ButtonRequestType type, const char* request_title,
 
   va_list vl;
   va_start(vl, request_body);
-  format_body(request_body, vl);
+  const bool formatted = format_body(request_body, vl);
   va_end(vl);
+  if (!formatted) {
+    memzero(strbuf, sizeof(strbuf));
+    return false;
+  }
 
   /* Send button request */
   ButtonRequest resp;
@@ -852,8 +819,12 @@ bool review_without_button_request(const char* request_title,
 
   va_list vl;
   va_start(vl, request_body);
-  format_body(request_body, vl);
+  const bool formatted = format_body(request_body, vl);
   va_end(vl);
+  if (!formatted) {
+    memzero(strbuf, sizeof(strbuf));
+    return false;
+  }
 
   const bool shown =
       confirm_helper(request_title, strbuf, &layout_standard_notification,
@@ -869,8 +840,12 @@ bool review_with_icon(ButtonRequestType type, IconType iconNum,
 
   va_list vl;
   va_start(vl, request_body);
-  format_body(request_body, vl);
+  const bool formatted = format_body(request_body, vl);
   va_end(vl);
+  if (!formatted) {
+    memzero(strbuf, sizeof(strbuf));
+    return false;
+  }
 
   /* Send button request */
   ButtonRequest resp;
@@ -892,8 +867,12 @@ bool review_immediate(ButtonRequestType type, const char* request_title,
 
   va_list vl;
   va_start(vl, request_body);
-  format_body(request_body, vl);
+  const bool formatted = format_body(request_body, vl);
   va_end(vl);
+  if (!formatted) {
+    memzero(strbuf, sizeof(strbuf));
+    return false;
+  }
 
   /* Send button request */
   ButtonRequest resp;

--- a/lib/firmware/app_confirm.c
+++ b/lib/firmware/app_confirm.c
@@ -349,9 +349,41 @@ bool confirm_address(const char* desc, const char* address) {
  *     true/false of confirmation
  *
  */
-bool confirm_sign_identity(const IdentityType* identity,
-                           const char* challenge) {
+bool format_sign_identity_key_selection(const IdentityType* identity,
+                                        const char* curve, char* out,
+                                        size_t out_len) {
+  if (!identity || !curve || !out || out_len == 0) return false;
+  const int needed = snprintf(
+      out, out_len, "Index: %" PRIu32 "\nCurve: %s\nPath: %s", identity->index,
+      curve, (identity->has_path && identity->path[0]) ? "shown next" : "none");
+  return needed >= 0 && (size_t)needed < out_len;
+}
+
+bool confirm_sign_identity(const IdentityType* identity, const char* challenge,
+                           const char* curve) {
   char title[CONFIRM_SIGN_IDENTITY_TITLE], body[CONFIRM_SIGN_IDENTITY_BODY];
+
+  if (!identity || !curve) return false;
+
+  /* These values select the key and signing algorithm. Keep them out of the
+   * free-form identity body so the maximum-size path can be reviewed by the
+   * exact-byte pager instead of being shortened by a printf buffer. */
+  char key_selection[CONFIRM_SIGN_IDENTITY_KEY];
+  if (!format_sign_identity_key_selection(identity, curve, key_selection,
+                                          sizeof(key_selection)) ||
+      !confirm(ButtonRequestType_ButtonRequest_SignIdentity, "Identity Key",
+               "%s", key_selection)) {
+    memzero(key_selection, sizeof(key_selection));
+    return false;
+  }
+  memzero(key_selection, sizeof(key_selection));
+
+  if (identity->has_path && identity->path[0] &&
+      !confirm_bytes(ButtonRequestType_ButtonRequest_SignIdentity,
+                     "Identity Path", (const uint8_t*)identity->path,
+                     strlen(identity->path))) {
+    return false;
+  }
 
   /* Format protocol */
   if (identity->has_proto && identity->proto[0]) {
@@ -384,9 +416,26 @@ bool confirm_sign_identity(const IdentityType* identity,
     strlcat(body, "\n", sizeof(body));
   }
 
-  /* Format challenge */
-  if (challenge && strlen(challenge) != 0) {
-    strlcat(body, challenge, sizeof(body));
+  /* Preserve the established single identity/challenge screen when it can be
+   * formatted without loss. A maximum-size challenge does not fit the shared
+   * confirmation buffer after host and user metadata; in that case confirm the
+   * metadata first and page every challenge byte separately. */
+  if (challenge && challenge[0]) {
+    const size_t body_len = strlen(body);
+    const size_t challenge_len = strlen(challenge);
+    if (body_len + challenge_len < BODY_CHAR_MAX) {
+      strlcat(body, challenge, sizeof(body));
+      return confirm(ButtonRequestType_ButtonRequest_SignIdentity, title, "%s",
+                     body);
+    }
+
+    if (body_len != 0 && !confirm(ButtonRequestType_ButtonRequest_SignIdentity,
+                                  title, "%s", body)) {
+      return false;
+    }
+    return confirm_bytes(ButtonRequestType_ButtonRequest_SignIdentity,
+                         "Visual Challenge", (const uint8_t*)challenge,
+                         challenge_len);
   }
 
   return confirm(ButtonRequestType_ButtonRequest_SignIdentity, title, "%s",

--- a/lib/firmware/authenticator.c
+++ b/lib/firmware/authenticator.c
@@ -62,6 +62,13 @@ void authenticator_clear_cache(void) {
   localAuthdataUpdate = true;
 }
 
+static unsigned authenticator_cancel(void) {
+  /* A nested confirmation refusal does not pass through fsm_msgCancel(), so it
+   * must revoke the decrypted authenticator cache itself. */
+  authenticator_clear_cache();
+  return CANCELED;
+}
+
 #if DEBUG_LINK
 static unsigned _otpSlot = 0;
 void getAuthSlot(char* authSlotData) {
@@ -86,7 +93,7 @@ unsigned wipeAuthData(void) {
   if (!confirm(ButtonRequestType_ButtonRequest_Other, "Confirm Wipe Authdata",
                "Do you want to PERMANENTLY delete all authenticator "
                "accounts?")) {
-    return CANCELED;
+    return authenticator_cancel();
   }
 
   // wipe storage and reset authdata encryption flag
@@ -186,6 +193,7 @@ unsigned addAuthAccount(char* accountWithSeed) {
 cleanup:
   memzero(authSecret, sizeof(authSecret));
   memzero(accountWithSeed, sourceLen);
+  if (result == CANCELED) authenticator_clear_cache();
   return result;
 }
 
@@ -281,15 +289,25 @@ unsigned generateOTP(char* accountWithMsg, char otpStr[]) {
   char otpStrLarge[10] = {0};
   // snprintf(otpStrLarge, 9, "\x19%06u", otp);
   snprintf(otpStrLarge, 9, "%06u", otp);
-  (void)review_immediate(ButtonRequestType_ButtonRequest_Other, "display OTP",
-                         "Press button to display OTP");
+  if (!review_immediate(ButtonRequestType_ButtonRequest_Other, "display OTP",
+                        "Press button to display OTP")) {
+    memzero(hmac, sizeof(hmac));
+    memzero(otpStrLarge, sizeof(otpStrLarge));
+    memzero(otpStr, 9);
+    return authenticator_cancel();
+  }
 
   // Check to see if user needs to regenerate OTP
   tRemainVal -=
       (getSysTime() - t0) / 1000;  // time since kk received time value
   if (tRemainVal < 4) {
-    (void)review_immediate(ButtonRequestType_ButtonRequest_Other, "OTP Timeout",
-                           "OTP time slice timed out, regenerate OTP");
+    if (!review_immediate(ButtonRequestType_ButtonRequest_Other, "OTP Timeout",
+                          "OTP time slice timed out, regenerate OTP")) {
+      memzero(hmac, sizeof(hmac));
+      memzero(otpStrLarge, sizeof(otpStrLarge));
+      memzero(otpStr, 9);
+      return authenticator_cancel();
+    }
   } else {
     char accStr[DOMAIN_SIZE + ACCOUNT_SIZE + 2] = {0};
     strncpy(accStr, authData[slot].domain, DOMAIN_SIZE);
@@ -302,6 +320,8 @@ unsigned generateOTP(char* accountWithMsg, char otpStr[]) {
       layoutProgressForAuth(otpStrLarge, accStr, (1000 * remainingdmSec) / 300);
     }
   }
+  memzero(hmac, sizeof(hmac));
+  memzero(otpStrLarge, sizeof(otpStrLarge));
   return NOERR;
 }
 
@@ -362,7 +382,7 @@ unsigned removeAuthAccount(char* domAcc) {
   if (!confirm(ButtonRequestType_ButtonRequest_Other, "Confirm Delete Account",
                "Do you want to PERMANENTLY delete account %.*s:%.*s?",
                DOMAIN_SIZE - 1, domain, ACCOUNT_SIZE - 1, account)) {
-    return CANCELED;
+    return authenticator_cancel();
   }
 
   memzero((void*)&authData[slot], sizeof(authType));

--- a/lib/firmware/ethereum_contracts.c
+++ b/lib/firmware/ethereum_contracts.c
@@ -26,7 +26,6 @@
 #include "keepkey/firmware/ethereum_contracts/zxappliquid.h"
 #include "keepkey/firmware/ethereum_contracts/zxliquidtx.h"
 #include "keepkey/firmware/ethereum_contracts/zxswap.h"
-#include "keepkey/firmware/ethereum_contracts/makerdao.h"
 
 bool zx_isExchangeProxyChain(uint32_t chain_id) {
   /* Optimism is deliberately absent: 0x deploys a DIFFERENT Exchange Proxy
@@ -81,8 +80,6 @@ bool ethereum_contractHandled(uint32_t data_total, const EthereumSignTx* msg,
 
   if (thor_isThorchainTx(msg)) return true;
 
-  if (makerdao_isMakerDAO(data_total, msg)) return true;
-
   return false;
 }
 
@@ -105,9 +102,6 @@ bool ethereum_contractConfirmed(uint32_t data_total, const EthereumSignTx* msg,
     return zx_confirmApproveLiquidity(data_total, msg);
 
   if (thor_isThorchainTx(msg)) return thor_confirmThorTx(data_total, msg);
-
-  if (makerdao_isMakerDAO(data_total, msg))
-    return makerdao_confirmMakerDAO(data_total, msg);
 
   return false;
 }

--- a/lib/firmware/fsm_msg_coin.h
+++ b/lib/firmware/fsm_msg_coin.h
@@ -81,6 +81,11 @@ void fsm_msgGetPublicKey(GetPublicKey* msg) {
 }
 
 void fsm_msgSignTx(SignTx* msg) {
+  /* A new start supersedes any prior Bitcoin stream even when this request is
+   * malformed.  Otherwise its Failure can be followed by an ACK that resumes
+   * the old, already-approved transaction. */
+  signing_abort();
+
   CHECK_INITIALIZED
 
   CHECK_PARAM(msg->inputs_count > 0,
@@ -107,7 +112,12 @@ void fsm_msgSignTx(SignTx* msg) {
 }
 
 void fsm_msgTxAck(TxAck* msg) {
-  CHECK_PARAM(msg->has_tx, _("No transaction provided"));
+  if (!msg->has_tx) {
+    signing_abort();
+    fsm_sendFailure(FailureType_Failure_Other, _("No transaction provided"));
+    layoutHome();
+    return;
+  }
 
   signing_txack(&(msg->tx));
 }

--- a/lib/firmware/fsm_msg_crypto.h
+++ b/lib/firmware/fsm_msg_crypto.h
@@ -63,9 +63,11 @@ void fsm_msgSignIdentity(SignIdentity* msg) {
 
   CHECK_INITIALIZED
 
-  if (!confirm_sign_identity(&(msg->identity), msg->has_challenge_visual
-                                                   ? msg->challenge_visual
-                                                   : 0)) {
+  const char* curve =
+      msg->has_ecdsa_curve_name ? msg->ecdsa_curve_name : SECP256K1_NAME;
+  if (!confirm_sign_identity(
+          &(msg->identity),
+          msg->has_challenge_visual ? msg->challenge_visual : 0, curve)) {
     fsm_sendFailure(FailureType_Failure_ActionCancelled,
                     "Sign identity cancelled");
     layoutHome();
@@ -93,10 +95,6 @@ void fsm_msgSignIdentity(SignIdentity* msg) {
   address_n[4] = 0x80000000 | hash[12] | (hash[13] << 8) | (hash[14] << 16) |
                  ((uint32_t)hash[15] << 24);
 
-  const char* curve = SECP256K1_NAME;
-  if (msg->has_ecdsa_curve_name) {
-    curve = msg->ecdsa_curve_name;
-  }
   HDNode* node = fsm_getDerivedNode(curve, address_n, 5, NULL);
   if (!node) {
     return;

--- a/lib/firmware/fsm_msg_eos.h
+++ b/lib/firmware/fsm_msg_eos.h
@@ -77,6 +77,9 @@ void fsm_msgEosGetPublicKey(const EosGetPublicKey* msg) {
 }
 
 void fsm_msgEosSignTx(const EosSignTx* msg) {
+  /* A second start is a boundary, including when its envelope is invalid. */
+  eos_signingAbort();
+
   CHECK_PARAM(msg->chain_id.size == 32, "Wrong chain_id size");
   CHECK_PARAM(msg->has_header, "Must have transaction header");
   CHECK_PARAM(msg->has_num_actions && 0 < msg->num_actions,
@@ -103,7 +106,12 @@ void fsm_msgEosSignTx(const EosSignTx* msg) {
 
 void fsm_msgEosTxActionAck(const EosTxActionAck* msg) {
   CHECK_PARAM(eos_signingIsInited(), "Must call EosSignTx to initiate signing");
-  CHECK_PARAM(msg->has_common, "Must have common");
+  if (!msg->has_common) {
+    eos_signingAbort();
+    fsm_sendFailure(FailureType_Failure_Other, "Must have common");
+    layoutHome();
+    return;
+  }
 
   int action_count = (int)msg->has_transfer + (int)msg->has_delegate +
                      (int)msg->has_undelegate + (int)msg->has_refund +
@@ -112,8 +120,13 @@ void fsm_msgEosTxActionAck(const EosTxActionAck* msg) {
                      (int)msg->has_update_auth + (int)msg->has_delete_auth +
                      (int)msg->has_link_auth + (int)msg->has_unlink_auth +
                      (int)msg->has_new_account + (int)msg->has_unknown + 0;
-  CHECK_PARAM(action_count == 1,
-              "Eos signing can only handle one action at a time");
+  if (action_count != 1) {
+    eos_signingAbort();
+    fsm_sendFailure(FailureType_Failure_Other,
+                    "Eos signing can only handle one action at a time");
+    layoutHome();
+    return;
+  }
 
   if (eos_hasActionUnknownDataRemaining()) {
     if (!msg->has_unknown) {

--- a/lib/firmware/fsm_msg_ethereum.h
+++ b/lib/firmware/fsm_msg_ethereum.h
@@ -76,6 +76,9 @@ static int process_ethereum_msg(EthereumSignTx* msg, bool* needs_confirm) {
 }
 
 void fsm_msgEthereumSignTx(EthereumSignTx* msg) {
+  /* A new start supersedes any old Ethereum stream before validation. */
+  ethereum_signing_abort();
+
   CHECK_INITIALIZED
 
   CHECK_PIN

--- a/lib/firmware/fsm_msg_osmosis.h
+++ b/lib/firmware/fsm_msg_osmosis.h
@@ -684,10 +684,10 @@ void fsm_msgOsmosisMsgAck(const OsmosisMsgAck* msg) {
                                         msg->ibc_transfer.source_channel) ||
         !osmosis_validate_required_text(msg->ibc_transfer.has_source_port,
                                         msg->ibc_transfer.source_port) ||
-        !osmosis_validate_required_text(msg->ibc_transfer.has_revision_height,
-                                        msg->ibc_transfer.revision_height) ||
-        !osmosis_validate_required_text(msg->ibc_transfer.has_revision_number,
-                                        msg->ibc_transfer.revision_number) ||
+        !osmosis_validate_amount(msg->ibc_transfer.has_revision_height,
+                                 msg->ibc_transfer.revision_height) ||
+        !osmosis_validate_amount(msg->ibc_transfer.has_revision_number,
+                                 msg->ibc_transfer.revision_number) ||
         !osmosis_validate_required_text(msg->ibc_transfer.has_denom,
                                         msg->ibc_transfer.denom) ||
         !osmosis_validate_amount(msg->ibc_transfer.has_amount,

--- a/lib/firmware/home_sm.c
+++ b/lib/firmware/home_sm.c
@@ -118,15 +118,20 @@ void leave_home(void) {
  *     none
  */
 void toggle_screensaver(void) {
+  /* Auto-lock is a session boundary even while the device is waiting for the
+   * host between streamed signing messages.  Confirmation handlers block the
+   * main loop, so this check cannot interrupt a button hold; AWAY_FROM_HOME
+   * here means firmware has returned to the main loop and is idle. */
+  if (home_state != SCREENSAVER && idle_time >= storage_getAutoLockDelayMs()) {
+    fsm_abort_workflows();
+    session_clear(/*clear_pin=*/true);
+    layout_screensaver();
+    home_state = SCREENSAVER;
+    return;
+  }
+
   switch (home_state) {
     case AT_HOME:
-      if (idle_time >= storage_getAutoLockDelayMs()) {
-        fsm_abort_workflows();
-        session_clear(/*clear_pin=*/true);
-        layout_screensaver();
-        home_state = SCREENSAVER;
-      }
-
       break;
 
     case SCREENSAVER:

--- a/lib/firmware/mayachain.c
+++ b/lib/firmware/mayachain.c
@@ -275,6 +275,32 @@ static bool mayachain_memo_has_empty_component(const char* memo, size_t size) {
   return false;
 }
 
+static bool mayachain_memo_is_structured_text(const char* memo, size_t size) {
+  if (!memo || size == 0) return false;
+
+  for (size_t i = 0; i < size; i++) {
+    const unsigned char c = (unsigned char)memo[i];
+    if (c < 0x21 || c > 0x7e) return false;
+  }
+  return true;
+}
+
+static bool mayachain_parse_bps(const char* text, uint16_t* bps) {
+  if (!text || !bps || text[0] == '\0') return false;
+  if (text[0] == '0' && text[1] != '\0') return false;
+
+  uint32_t value = 0;
+  for (const char* p = text; *p; p++) {
+    if (*p < '0' || *p > '9') return false;
+    const uint32_t digit = (uint32_t)(*p - '0');
+    if (value > (10000u - digit) / 10u) return false;
+    value = value * 10u + digit;
+  }
+
+  *bps = (uint16_t)value;
+  return true;
+}
+
 MayachainMemoResult mayachain_parseConfirmMemo(const char* swapStr,
                                                size_t size) {
   /*
@@ -306,7 +332,8 @@ MayachainMemoResult mayachain_parseConfirmMemo(const char* swapStr,
   /* One byte short of the buffer, so a full-length memo is still terminated by
      the memzero below. */
   if (size >= sizeof(memoBuf) ||
-      mayachain_memo_has_empty_component(swapStr, size)) {
+      mayachain_memo_has_empty_component(swapStr, size) ||
+      !mayachain_memo_is_structured_text(swapStr, size)) {
     return MAYACHAIN_MEMO_UNPARSED;
   }
   memzero(memoBuf, sizeof(memoBuf));
@@ -363,8 +390,8 @@ MayachainMemoResult mayachain_parseConfirmMemo(const char* swapStr,
   }
 
   // Check for swap
-  if (strncmp(parseTokPtrs[0], "SWAP", 4) == 0 || *parseTokPtrs[0] == 's' ||
-      *parseTokPtrs[0] == '=') {
+  if (strcmp(parseTokPtrs[0], "SWAP") == 0 ||
+      strcmp(parseTokPtrs[0], "s") == 0 || strcmp(parseTokPtrs[0], "=") == 0) {
     // This is a swap, set up destination and limit
     // This is the dest, may be blank which means swap to self
     parseTokPtrs[3] = "self";
@@ -409,8 +436,9 @@ MayachainMemoResult mayachain_parseConfirmMemo(const char* swapStr,
   }
 
   // Check for add liquidity
-  else if (strncmp(parseTokPtrs[0], "ADD", 3) == 0 || *parseTokPtrs[0] == 'a' ||
-           *parseTokPtrs[0] == '+') {
+  else if (strcmp(parseTokPtrs[0], "ADD") == 0 ||
+           strcmp(parseTokPtrs[0], "a") == 0 ||
+           strcmp(parseTokPtrs[0], "+") == 0) {
     if (tok != NULL) {
       // add liquidity pool address
       parseTokPtrs[3] = tok;
@@ -442,8 +470,9 @@ MayachainMemoResult mayachain_parseConfirmMemo(const char* swapStr,
   }
 
   // Check for withdraw liquidity
-  else if (strncmp(parseTokPtrs[0], "WITHDRAW", 8) == 0 ||
-           strncmp(parseTokPtrs[0], "wd", 2) == 0 || *parseTokPtrs[0] == '-') {
+  else if (strcmp(parseTokPtrs[0], "WITHDRAW") == 0 ||
+           strcmp(parseTokPtrs[0], "wd") == 0 ||
+           strcmp(parseTokPtrs[0], "-") == 0) {
     if (tok != NULL) {
       // add liquidity pool address
       parseTokPtrs[3] = tok;
@@ -451,10 +480,14 @@ MayachainMemoResult mayachain_parseConfirmMemo(const char* swapStr,
       return MAYACHAIN_MEMO_UNPARSED;  // malformed memo
     }
 
-    float percent = (float)(atoi(parseTokPtrs[3])) / 100;
+    uint16_t bps = 0;
+    if (!mayachain_parse_bps(parseTokPtrs[3], &bps)) {
+      return MAYACHAIN_MEMO_UNPARSED;
+    }
     if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
                  "Mayachain withdraw liquidity",
-                 "Confirm withdraw %3.2f%% of asset %s on chain %s", percent,
+                 "Confirm withdraw %u.%02u%% of asset %s on chain %s",
+                 (unsigned)(bps / 100u), (unsigned)(bps % 100u),
                  parseTokPtrs[2], parseTokPtrs[1])) {
       return MAYACHAIN_MEMO_CANCELLED;
     }

--- a/lib/firmware/osmosis.c
+++ b/lib/firmware/osmosis.c
@@ -42,7 +42,7 @@ static bool testnet;
 const OsmosisSignTx* osmosis_getOsmosisSignTx(void) { return &msg; }
 
 bool osmosis_validate_required_text(bool has_value, const char* value) {
-  return has_value && value && value[0] != '\0';
+  return has_value && tendermint_validateSafeText(value);
 }
 
 bool osmosis_validate_amount(bool has_value, const char* value) {

--- a/lib/firmware/reset.c
+++ b/lib/firmware/reset.c
@@ -81,6 +81,10 @@ void setup_abort(void) {
   memzero(&setup, sizeof(setup));
   memzero(int_entropy, sizeof(int_entropy));
   memzero(current_words, sizeof(current_words));
+  /* reset_entropy() receives its generated sentence from bip39.c's static
+   * `mnemo` buffer.  A cancelled/error ceremony has no owner for that secret,
+   * so the common abort path must clear it along with the setup scratch. */
+  mnemonic_clear();
   strength = 0;
 }
 

--- a/lib/firmware/signing.c
+++ b/lib/firmware/signing.c
@@ -1974,3 +1974,5 @@ void signing_abort(void) {
   coin = NULL;
   curve = NULL;
 }
+
+bool signing_is_active(void) { return signing; }

--- a/lib/firmware/thorchain.c
+++ b/lib/firmware/thorchain.c
@@ -271,6 +271,32 @@ static bool thorchain_memo_has_empty_component(const char* memo, size_t size) {
   return false;
 }
 
+static bool thorchain_memo_is_structured_text(const char* memo, size_t size) {
+  if (!memo || size == 0) return false;
+
+  for (size_t i = 0; i < size; i++) {
+    const unsigned char c = (unsigned char)memo[i];
+    if (c < 0x21 || c > 0x7e) return false;
+  }
+  return true;
+}
+
+static bool thorchain_parse_bps(const char* text, uint16_t* bps) {
+  if (!text || !bps || text[0] == '\0') return false;
+  if (text[0] == '0' && text[1] != '\0') return false;
+
+  uint32_t value = 0;
+  for (const char* p = text; *p; p++) {
+    if (*p < '0' || *p > '9') return false;
+    const uint32_t digit = (uint32_t)(*p - '0');
+    if (value > (10000u - digit) / 10u) return false;
+    value = value * 10u + digit;
+  }
+
+  *bps = (uint16_t)value;
+  return true;
+}
+
 ThorchainMemoResult thorchain_parseConfirmMemo(const char* swapStr,
                                                size_t size) {
   /*
@@ -304,7 +330,8 @@ ThorchainMemoResult thorchain_parseConfirmMemo(const char* swapStr,
   // check if memo data is recognized
 
   if (size > THORCHAIN_MEMO_MAX ||
-      thorchain_memo_has_empty_component(swapStr, size)) {
+      thorchain_memo_has_empty_component(swapStr, size) ||
+      !thorchain_memo_is_structured_text(swapStr, size)) {
     return THORCHAIN_MEMO_UNPARSED;
   }
   memzero(memoBuf, sizeof(memoBuf));
@@ -360,8 +387,8 @@ ThorchainMemoResult thorchain_parseConfirmMemo(const char* swapStr,
   }
 
   // Check for swap
-  if (strncmp(parseTokPtrs[0], "SWAP", 4) == 0 || *parseTokPtrs[0] == 's' ||
-      *parseTokPtrs[0] == '=') {
+  if (strcmp(parseTokPtrs[0], "SWAP") == 0 ||
+      strcmp(parseTokPtrs[0], "s") == 0 || strcmp(parseTokPtrs[0], "=") == 0) {
     // This is a swap, set up destination and limit
     // This is the dest, may be blank which means swap to self
     parseTokPtrs[3] = "self";
@@ -404,8 +431,9 @@ ThorchainMemoResult thorchain_parseConfirmMemo(const char* swapStr,
   }
 
   // Check for add liquidity
-  else if (strncmp(parseTokPtrs[0], "ADD", 3) == 0 || *parseTokPtrs[0] == 'a' ||
-           *parseTokPtrs[0] == '+') {
+  else if (strcmp(parseTokPtrs[0], "ADD") == 0 ||
+           strcmp(parseTokPtrs[0], "a") == 0 ||
+           strcmp(parseTokPtrs[0], "+") == 0) {
     if (tok != NULL) {
       // add liquidity pool address
       parseTokPtrs[3] = tok;
@@ -437,8 +465,9 @@ ThorchainMemoResult thorchain_parseConfirmMemo(const char* swapStr,
   }
 
   // Check for withdraw liquidity
-  else if (strncmp(parseTokPtrs[0], "WITHDRAW", 8) == 0 ||
-           strncmp(parseTokPtrs[0], "wd", 2) == 0 || *parseTokPtrs[0] == '-') {
+  else if (strcmp(parseTokPtrs[0], "WITHDRAW") == 0 ||
+           strcmp(parseTokPtrs[0], "wd") == 0 ||
+           strcmp(parseTokPtrs[0], "-") == 0) {
     if (tok != NULL) {
       // add liquidity pool address
       parseTokPtrs[3] = tok;
@@ -446,10 +475,14 @@ ThorchainMemoResult thorchain_parseConfirmMemo(const char* swapStr,
       return THORCHAIN_MEMO_UNPARSED;  // malformed memo
     }
 
-    float percent = (float)(atoi(parseTokPtrs[3])) / 100;
+    uint16_t bps = 0;
+    if (!thorchain_parse_bps(parseTokPtrs[3], &bps)) {
+      return THORCHAIN_MEMO_UNPARSED;
+    }
     if (!confirm(ButtonRequestType_ButtonRequest_ConfirmOutput,
                  "Thorchain withdraw liquidity",
-                 "Confirm withdraw %3.2f%% of asset %s on chain %s", percent,
+                 "Confirm withdraw %u.%02u%% of asset %s on chain %s",
+                 (unsigned)(bps / 100u), (unsigned)(bps % 100u),
                  parseTokPtrs[2], parseTokPtrs[1])) {
       return THORCHAIN_MEMO_CANCELLED;
     }

--- a/unittests/board/board.cpp
+++ b/unittests/board/board.cpp
@@ -92,6 +92,22 @@ TEST_F(BodyFits, ConfirmBodyFits) {
       << "a body overflowing by exactly one glyph must not report as fitting";
 }
 
+TEST(Board, ConfirmationFormattingRefusesAnySourceLoss) {
+  const std::string one_too_many(BODY_CHAR_MAX, 'A');
+
+  // Source overflow must return before confirm() sends a ButtonRequest or
+  // enters the interactive confirmation state machine.
+  EXPECT_FALSE(confirm(ButtonRequestType_ButtonRequest_Other, "Overflow", "%s",
+                       one_too_many.c_str()));
+
+  // Expansion is measured after formatting, not from the format string or any
+  // one argument. This is the shape used by multi-field confirmation bodies.
+  const std::string left(175, 'L');
+  const std::string right(175, 'R');
+  EXPECT_FALSE(confirm(ButtonRequestType_ButtonRequest_Other, "Overflow",
+                       "%s::%s", left.c_str(), right.c_str()));
+}
+
 TEST_F(BodyFits, ConstantPowerSeedRowsAreCompleteAndPagedAtRowBoundaries) {
   EXPECT_EQ(CONSTANT_POWER_BODY_WIDTH,
             KEEPKEY_DISPLAY_WIDTH - (128 + LEFT_MARGIN));
@@ -355,6 +371,33 @@ TEST(Board, PostPreviewMutationChangesExactByteReview) {
   EXPECT_GT(pages_a, 1u);
   EXPECT_NE(review_a, review_b)
       << "a byte after the old 32-byte Solana preview must change a page";
+}
+
+TEST(Board, IdentityKeySelectionDisclosesEveryKeySelector) {
+  IdentityType identity{};
+  identity.has_index = true;
+  identity.index = UINT32_MAX;
+  identity.has_path = true;
+  memset(identity.path, 'p', sizeof(identity.path) - 1);
+
+  char selection[CONFIRM_SIGN_IDENTITY_KEY];
+  ASSERT_TRUE(format_sign_identity_key_selection(&identity, "ed25519",
+                                                 selection, sizeof(selection)));
+  EXPECT_STREQ(selection,
+               "Index: 4294967295\nCurve: ed25519\nPath: shown next");
+
+  // The production path uses confirm_bytes(), whose page formatter must retain
+  // the complete maximum-size path rather than a BODY_CHAR_MAX prefix.
+  size_t pages = 0;
+  const std::string path(identity.path);
+  EXPECT_EQ(FormatEveryPage(path, &pages), path);
+  EXPECT_EQ(path.size(), sizeof(identity.path) - 1);
+  EXPECT_GT(pages, 1u);
+
+  identity.has_path = false;
+  ASSERT_TRUE(format_sign_identity_key_selection(&identity, "secp256k1",
+                                                 selection, sizeof(selection)));
+  EXPECT_STREQ(selection, "Index: 4294967295\nCurve: secp256k1\nPath: none");
 }
 
 // base_to_precision() previously used strlcpy(dst, src, n) to copy n DIGITS.

--- a/unittests/firmware/ethereum.cpp
+++ b/unittests/firmware/ethereum.cpp
@@ -324,6 +324,32 @@ TEST(Ethereum, TransformErc20AlwaysRequiresAdvancedMode) {
                                         nullptr));
 }
 
+TEST(Ethereum, MakerDaoSelectorsAreNotSpecializedForPointRelease) {
+  struct MakerCall {
+    const uint8_t selector[4];
+    size_t argument_count;
+  };
+  static const MakerCall kCalls[] = {
+      {{0xc7, 0x40, 0x73, 0xa1}, 1},  // open(address)
+      {{0x1b, 0x96, 0x81, 0x60}, 5},  // wipeAndFree(...,address)
+  };
+
+  for (const MakerCall& call : kCalls) {
+    EthereumSignTx msg = EthereumSignTx{};
+    msg.has_chain_id = true;
+    msg.chain_id = 1;
+    msg.has_to = true;
+    msg.to.size = 20;
+    msg.has_data_initial_chunk = true;
+    msg.data_initial_chunk.size = 4 + call.argument_count * 32;
+    std::memcpy(msg.data_initial_chunk.bytes, call.selector,
+                sizeof(call.selector));
+
+    EXPECT_FALSE(
+        ethereum_contractHandled(msg.data_initial_chunk.size, &msg, nullptr));
+  }
+}
+
 TEST(Ethereum, Eip712ChainIdRequiresCanonicalUint32) {
   uint32_t value = 0;
   EXPECT_TRUE(eip712_parse_canonical_u32("0", &value));

--- a/unittests/firmware/fsm.cpp
+++ b/unittests/firmware/fsm.cpp
@@ -1,13 +1,20 @@
 extern "C" {
+#include "keepkey/board/keepkey_board.h"
+#include "keepkey/board/layout.h"
+#include "keepkey/board/timer.h"
 #include "keepkey/transport/interface.h"
 #include "trezor/crypto/sha2.h"
 #include "keepkey/firmware/authenticator.h"
 #include "keepkey/firmware/binance.h"
+#include "keepkey/firmware/coins.h"
 #include "keepkey/firmware/eos.h"
 #include "keepkey/firmware/fsm.h"
+#include "keepkey/firmware/home_sm.h"
 #include "keepkey/firmware/mayachain.h"
 #include "keepkey/firmware/osmosis.h"
+#include "keepkey/firmware/signing.h"
 #include "keepkey/firmware/signtx_tendermint.h"
+#include "keepkey/firmware/storage.h"
 #include "keepkey/firmware/thorchain.h"
 #include "trezor/crypto/secp256k1.h"
 }
@@ -93,5 +100,109 @@ TEST(Fsm, AbortWorkflowsClearsEveryObservableSigningSession) {
   EXPECT_FALSE(osmosis_signingIsInited());
   EXPECT_FALSE(thorchain_signingIsInited());
   EXPECT_FALSE(mayachain_signingIsInited());
+  EXPECT_FALSE(eos_signingIsInited());
+}
+
+TEST(Fsm, MissingBitcoinAckPayloadTerminatesSigning) {
+  fsm_init();
+
+  SignTx start = {};
+  start.inputs_count = 1;
+  start.outputs_count = 1;
+  HDNode root = {};
+  const CoinType* coin = coinByName("Bitcoin");
+  ASSERT_NE(nullptr, coin);
+
+  signing_init(&start, coin, &root);
+  ASSERT_TRUE(signing_is_active());
+
+  TxAck missing = {};
+  fsm_msgTxAck(&missing);
+  EXPECT_FALSE(signing_is_active());
+
+  TxAck stale = {};
+  stale.has_tx = true;
+  fsm_msgTxAck(&stale);
+  EXPECT_FALSE(signing_is_active());
+}
+
+TEST(Fsm, AutoLockTerminatesSigningWhileWaitingAwayFromHome) {
+  /* Production initializes the OLED before the main loop can auto-lock. The
+   * firmware unit binary does not, so mirror that board precondition before
+   * toggle_screensaver() draws its terminal state. */
+  static bool display_ready = false;
+  if (!display_ready) {
+    timer_init();
+    layout_init(display_canvas_init());
+    display_ready = true;
+  }
+
+  fsm_init();
+  layoutHomeForced();
+  storage_setAutoLockDelayMs(STORAGE_MIN_SCREENSAVER_TIMEOUT);
+
+  SignTx start = {};
+  start.inputs_count = 1;
+  start.outputs_count = 1;
+  HDNode root = {};
+  const CoinType* coin = coinByName("Bitcoin");
+  ASSERT_NE(nullptr, coin);
+  signing_init(&start, coin, &root);
+  ASSERT_TRUE(signing_is_active());
+
+  leave_home();
+  increment_idle_time(STORAGE_MIN_SCREENSAVER_TIMEOUT - 1);
+  toggle_screensaver();
+  EXPECT_TRUE(signing_is_active());
+
+  increment_idle_time(1);
+  toggle_screensaver();
+  EXPECT_FALSE(signing_is_active());
+
+  /* Restore a deterministic home state for subsequent tests. */
+  layoutHomeForced();
+}
+
+TEST(Fsm, InvalidSecondBitcoinStartTerminatesOldSigning) {
+  fsm_init();
+
+  SignTx first = {};
+  first.inputs_count = 1;
+  first.outputs_count = 1;
+  HDNode root = {};
+  const CoinType* coin = coinByName("Bitcoin");
+  ASSERT_NE(nullptr, coin);
+
+  signing_init(&first, coin, &root);
+  ASSERT_TRUE(signing_is_active());
+
+  SignTx invalid = {};
+  fsm_msgSignTx(&invalid);
+  EXPECT_FALSE(signing_is_active());
+
+  TxAck stale = {};
+  stale.has_tx = true;
+  fsm_msgTxAck(&stale);
+  EXPECT_FALSE(signing_is_active());
+}
+
+TEST(Fsm, MissingEosCommonTerminatesSigning) {
+  fsm_init();
+
+  HDNode root = {};
+  uint8_t chain_id[32] = {};
+  EosTxHeader header = {};
+  uint32_t path[8] = {};
+  eos_signingInit(chain_id, 1, &header, &root, path, 0);
+  ASSERT_TRUE(eos_signingIsInited());
+
+  EosTxActionAck missing = {};
+  fsm_msgEosTxActionAck(&missing);
+  EXPECT_FALSE(eos_signingIsInited());
+
+  EosTxActionAck stale = {};
+  stale.has_common = true;
+  stale.has_transfer = true;
+  fsm_msgEosTxActionAck(&stale);
   EXPECT_FALSE(eos_signingIsInited());
 }

--- a/unittests/firmware/mayachain.cpp
+++ b/unittests/firmware/mayachain.cpp
@@ -80,6 +80,32 @@ TEST(Mayachain, MemoWithEmptyPositionalFieldIsNotStructured) {
             mayachain_parseConfirmMemo(kEmptyLimit, sizeof(kEmptyLimit) - 1));
 }
 
+TEST(Mayachain, StructuredMemoRequiresExactSafeTokensAndCanonicalBps) {
+  static const char* const kUnparsed[] = {
+      "SWAP-extra:ETH.ETH:destination:100",
+      "swap:ETH.ETH:destination:100",
+      "ADDITION:ETH.ETH:destination",
+      "WITHDRAWAL:ETH.ETH:100",
+      "WITHDRAW:ETH.ETH:01",
+      "WITHDRAW:ETH.ETH:100x",
+      "WITHDRAW:ETH.ETH:10001",
+      "WITHDRAW:ETH.ETH:4294967296",
+      "WITHDRAW:ETH.ETH:-1",
+      "SWAP:ETH.ETH:destination with space:100",
+      "SWAP:ETH.ETH:destination\nnext:100",
+  };
+
+  for (const char* memo : kUnparsed) {
+    EXPECT_EQ(MAYACHAIN_MEMO_UNPARSED,
+              mayachain_parseConfirmMemo(memo, std::strlen(memo)))
+        << memo;
+  }
+
+  static const char kNonAscii[] = "SWAP:ETH.ETH:dest\x80:100";
+  EXPECT_EQ(MAYACHAIN_MEMO_UNPARSED,
+            mayachain_parseConfirmMemo(kNonAscii, sizeof(kNonAscii) - 1));
+}
+
 TEST(Mayachain, MayachainGetAddress) {
   HDNode node = {
       0,

--- a/unittests/firmware/osmosis.cpp
+++ b/unittests/firmware/osmosis.cpp
@@ -128,11 +128,17 @@ TEST(Osmosis, RequiredValuesRejectEmptyAndNonDecimalAmounts) {
   EXPECT_FALSE(osmosis_validate_required_text(false, "uosmo"));
   EXPECT_FALSE(osmosis_validate_required_text(true, ""));
   EXPECT_TRUE(osmosis_validate_required_text(true, "uosmo"));
+  EXPECT_TRUE(osmosis_validate_required_text(true, "ibc/0123456789ABCDEF"));
+  EXPECT_FALSE(osmosis_validate_required_text(true, "u osmo"));
+  EXPECT_FALSE(osmosis_validate_required_text(true, "u\"osmo"));
+  EXPECT_FALSE(osmosis_validate_required_text(true, "u\\osmo"));
+  EXPECT_FALSE(osmosis_validate_required_text(true, "u\nosmo"));
 
   EXPECT_FALSE(osmosis_validate_amount(false, "1"));
   EXPECT_FALSE(osmosis_validate_amount(true, ""));
   EXPECT_FALSE(osmosis_validate_amount(true, "1.0"));
   EXPECT_FALSE(osmosis_validate_amount(true, "-1"));
+  EXPECT_FALSE(osmosis_validate_amount(true, "1e6"));
   EXPECT_TRUE(osmosis_validate_amount(true, "0"));
   EXPECT_TRUE(osmosis_validate_amount(true, "1000000"));
 }

--- a/unittests/firmware/setup_ceremony.cpp
+++ b/unittests/firmware/setup_ceremony.cpp
@@ -34,6 +34,7 @@ extern "C" {
 #include "keepkey/board/keepkey_board.h"
 #include "keepkey/firmware/fsm.h"
 #include "keepkey/firmware/reset.h"
+#include "trezor/crypto/bip39.h"
 }
 
 namespace {
@@ -52,9 +53,7 @@ class SetupCeremony : public ::testing::Test {
     setup_abort();
   }
 
-  void TearDown() override {
-    setup_abort();
-  }
+  void TearDown() override { setup_abort(); }
 };
 
 // #429 step 2, directly: a second ceremony cannot start on top of an armed one.
@@ -68,8 +67,6 @@ TEST_F(SetupCeremony, StageRefusesWhileArmed) {
   EXPECT_TRUE(setup_isArmedAs(SETUP_RESET))
       << "the refused stage must leave the original ceremony intact";
 }
-
-
 
 // Every abort path shares one implementation, so it must tolerate being
 // reached from any state, including twice.
@@ -90,7 +87,20 @@ TEST_F(SetupCeremony, AbortIsIdempotent) {
   EXPECT_FALSE(setup_isArmedAs(SETUP_RECOVERY));
 }
 
+// BIP39 owns a static output buffer.  Once setup is abandoned, retaining the
+// generated sentence there is retaining an otherwise unowned device seed.
+TEST_F(SetupCeremony, AbortScrubsGeneratedMnemonic) {
+  const uint8_t entropy[16] = {};
+  const char* generated = mnemonic_from_data(entropy, sizeof(entropy));
+  ASSERT_NE(nullptr, generated);
+  ASSERT_NE('\0', generated[0]);
 
+  setup_abort();
+
+  for (size_t i = 0; i < 24u * 10u; ++i) {
+    EXPECT_EQ('\0', generated[i]);
+  }
+}
 
 // setup_require() is the gate every continuation message uses. A mismatch must
 // abort rather than fall through.
@@ -143,7 +153,6 @@ TEST_F(SetupCeremony, MessagePermutationsLeaveNothingArmed) {
         setup_abort();
         EXPECT_FALSE(setup_isArmed());
       }
-
     }
   }
 }

--- a/unittests/firmware/thorchain.cpp
+++ b/unittests/firmware/thorchain.cpp
@@ -107,6 +107,32 @@ TEST(Thorchain, MemoWithEmptyPositionalFieldIsNotStructured) {
                                        sizeof(kSaversAffiliate) - 1));
 }
 
+TEST(Thorchain, StructuredMemoRequiresExactSafeTokensAndCanonicalBps) {
+  static const char* const kUnparsed[] = {
+      "SWAP-extra:ETH.ETH:destination:100",
+      "swap:ETH.ETH:destination:100",
+      "ADDITION:ETH.ETH:destination",
+      "WITHDRAWAL:ETH.ETH:100",
+      "WITHDRAW:ETH.ETH:01",
+      "WITHDRAW:ETH.ETH:100x",
+      "WITHDRAW:ETH.ETH:10001",
+      "WITHDRAW:ETH.ETH:4294967296",
+      "WITHDRAW:ETH.ETH:-1",
+      "SWAP:ETH.ETH:destination with space:100",
+      "SWAP:ETH.ETH:destination\nnext:100",
+  };
+
+  for (const char* memo : kUnparsed) {
+    EXPECT_EQ(THORCHAIN_MEMO_UNPARSED,
+              thorchain_parseConfirmMemo(memo, std::strlen(memo)))
+        << memo;
+  }
+
+  static const char kNonAscii[] = "SWAP:ETH.ETH:dest\x80:100";
+  EXPECT_EQ(THORCHAIN_MEMO_UNPARSED,
+            thorchain_parseConfirmMemo(kNonAscii, sizeof(kNonAscii) - 1));
+}
+
 TEST(Thorchain, ThorchainGetAddress) {
   HDNode node = {
       0,


### PR DESCRIPTION
## Summary

Consolidated remediation for the frozen 7.14.2 release head after the latest cross-cutting signing audit.

- fail closed before ButtonRequest when confirmation source formatting loses text
- disclose SignIdentity index, curve, full path, and long visual challenges
- remove legacy MakerDAO specialized clear-signing from the dispatcher
- validate Osmosis display/JSON fields and canonical IBC numeric fields
- tighten THORChain/MAYAChain structured memo tokens, byte grammar, and basis points
- scrub canceled reset mnemonics and authenticator secrets/cache
- make malformed continuations and second signing starts terminal
- apply auto-lock while workflows wait on the host
- add regression coverage for each failure class

The review also caught and fixed a new basis-point accumulator wrap case: 4294967296 could wrap to 0 and re-enter the accepted THOR/MAYA range.

## Scope

- Base: 2a430da0f96b99ef924cf747c8ac2853ee49fae2
- Remediation and companion-test pin: 25 files, +551/-155
- No documentation or report-infrastructure changes
- The pre-existing dirty crypto dependency submodule remains excluded
- The Python companion pin is intentional and points to keepkey/python-keepkey#221, based on the active 7.14.2 companion-test branch

This PR targets release/7.14.2-rc31, the head branch of parent PR #458.

## Validation

- clang-format 20: clean
- git diff --check: clean
- pinned container: kktech/firmware@sha256:7438e53933d47d53157ed6d96d864cb208597e62dce26235ace09d1063427fa2
- firmware unit suite: 131/131 passed
- board unit suite: 16/16 passed
- crypto unit suite: 4/4 passed
- the previously failing auto-lock test now passes with the initialized OLED harness
- companion test syntax and offline-fixture manifest checks passed

The first exact-head CI run exposed four stale MakerDAO Python tests that still attempted contract-data signing without AdvancedMode. The companion update makes those vectors exercise the generic blind-signing path while retaining their deterministic signature checks. Exact-head CI is rerunning with that pin.

## Release posture

This is a reviewable remediation PR, not release authorization. 7.14.2 remains NO-GO pending exact-head CI, the repeated frozen-head failure-class sweep with planted controls, independent approval, and the remaining hardware/storage gates. Nothing was signed, tagged, merged, or installed on hardware.