### PR TITLE
perf(ci): cut pipeline wall clock from ~7:20 to ~3:00

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,7 +532,7 @@ jobs:
           retention-days: 30
 
       - name: Upload OLED screenshots
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: oled-screenshots
@@ -581,7 +581,7 @@ jobs:
         run: python3 scripts/generate-test-report.py
 
       - name: Upload test report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-report
@@ -896,7 +896,7 @@ jobs:
         # PR. Tagged with the short commit SHA so multiple PR pushes
         # don't overwrite each other when a reviewer downloads them.
         if: always() && env.DYLIB_PATH != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: libkkemu-${{ github.sha }}
           path: ${{ env.DYLIB_PATH }}
@@ -929,7 +929,7 @@ jobs:
             -v --tb=short --junit-xml=../../../test-reports/dylib-junit.xml
 
       - name: Upload dylib test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: python-dylib-test-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,6 +385,18 @@ jobs:
                 exit \$RC" || UNIT_RC=$?
           echo "UNIT_RC=$UNIT_RC" >> "$GITHUB_ENV"
           echo "firmware unit suite exit code: $UNIT_RC"
+
+          # The cp above sends its errors to /dev/null, so a build that stops
+          # emitting JUnit XML -- or a glob that stops matching -- would sail
+          # through and leave the report rendering "0 tests" with nothing
+          # objecting. That is the same silent-evidence-loss failure the
+          # python side hit earlier on this branch, so it is gated the same
+          # way: no XML is an infrastructure failure, distinct from a test
+          # failure, and it fails here rather than being discovered in a PDF.
+          if ! compgen -G "${{ github.workspace }}/test-reports/firmware-unit/*.xml" > /dev/null; then
+            echo "::error::make xunit produced no JUnit XML (suite exit code $UNIT_RC) — unit test evidence was lost"
+            exit 1
+          fi
           # That container runs as root and leaves root-owned paths behind in
           # the bind mount. The `docker cp` in the integration step below
           # chmods what it extracts into, and a root-owned directory there

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,8 +142,22 @@ jobs:
           # remediation message below. Inside an `if`, -e is suspended.
           #
           # shellcheck disable=SC2016  # $1 is expanded by the inner sh, not here
-          if ! find include/keepkey lib/firmware lib/board lib/transport/src \
-                    -name '*.c' -o -name '*.h' 2>/dev/null \
+          # lib/transport/src has never existed in this repo -- the transport
+          # sources sit directly in lib/transport/. The path silently
+          # contributed nothing because find's error went to /dev/null.
+          # Dropped, and stderr is no longer suppressed, so a future bad path
+          # is loud instead of quietly narrowing coverage.
+          #
+          # lib/transport itself is deliberately NOT scanned: it holds the
+          # vendored nanopb runtime (pb_common.c, pb_decode.c, pb_encode.c).
+          # pb_decode.c does not satisfy this repo's .clang-format, and
+          # reformatting vendored upstream sources would make future nanopb
+          # updates needlessly painful.
+          #
+          # The name tests are parenthesised so the implicit -print
+          # unambiguously applies to both branches.
+          if ! find include/keepkey lib/firmware lib/board \
+                    \( -name '*.c' -o -name '*.h' \) \
                | grep -v generated | grep -vF '.pb.' \
                | xargs -P "$(nproc)" -I{} sh -c '
                    if ! clang-format --style=file --dry-run --Werror "$1" 2>/dev/null; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
           # shellcheck disable=SC2016  # $1 is expanded by the inner sh, not here
           if ! find include/keepkey lib/firmware lib/board lib/transport/src \
                     -name '*.c' -o -name '*.h' 2>/dev/null \
-               | grep -v generated | grep -v '.pb.' \
+               | grep -v generated | grep -vF '.pb.' \
                | xargs -P "$(nproc)" -I{} sh -c '
                    if ! clang-format --style=file --dry-run --Werror "$1" 2>/dev/null; then
                      echo "::warning file=$1::Formatting differs from .clang-format"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,17 +315,32 @@ jobs:
 
       - name: Pull base image
         run: |
-          # The image is re-tagged to its Docker Hub name because
-          # scripts/emulator/Dockerfile says `FROM kktech/firmware:v15`.
-          # Neither `docker build` nor `docker compose build` passes --pull,
-          # so a local image under that name satisfies the FROM without any
-          # registry round-trip -- and without editing the Dockerfile.
-          if docker pull "${{ env.BASE_IMAGE_MIRROR }}" 2>/dev/null; then
+          # Two consumers, resolved differently:
+          #
+          #  1. `docker build` for the emulator image uses the classic builder,
+          #     which reads the local daemon image store. Re-tagging the mirror
+          #     to the Docker Hub name satisfies the `FROM kktech/firmware:v15`
+          #     in scripts/emulator/Dockerfile with no registry round-trip.
+          #
+          #  2. buildx (docker/build-push-action) uses the docker-container
+          #     driver, which does NOT see daemon-local images and resolves
+          #     FROM against a registry. Re-tagging alone silently left it
+          #     pulling from Docker Hub -- confirmed in run 33046944618, which
+          #     logged `[auth] kktech/firmware:pull token for
+          #     registry-1.docker.io` during the buildx step. RESOLVED_BASE is
+          #     therefore exported and passed to that build as a build-arg.
+          #
+          # stderr is deliberately not suppressed: the fallback stops a mirror
+          # problem being fatal, but hiding the error makes auth vs missing tag
+          # vs transient network indistinguishable.
+          if docker pull "${{ env.BASE_IMAGE_MIRROR }}"; then
             docker tag "${{ env.BASE_IMAGE_MIRROR }}" "${{ env.BASE_IMAGE }}"
+            echo "RESOLVED_BASE=${{ env.BASE_IMAGE_MIRROR }}" >> "$GITHUB_ENV"
             echo "base image: GHCR mirror"
           else
             echo "::warning::GHCR mirror unavailable — falling back to Docker Hub. Run the mirror-base-image workflow to populate it."
             docker pull "${{ env.BASE_IMAGE }}"
+            echo "RESOLVED_BASE=${{ env.BASE_IMAGE }}" >> "$GITHUB_ENV"
             echo "base image: Docker Hub"
           fi
 
@@ -346,6 +361,12 @@ jobs:
           # make xunit returns non-zero if any test fails — capture
           # exit code so JUnit XML still gets copied for reporting
           mkdir -p ${{ github.workspace }}/test-reports
+          # `|| UNIT_RC=$?` rather than a bare command: `run:` steps execute
+          # under `bash -e`, so a failing suite would abort the step here and
+          # skip the python integration suite entirely. These used to be
+          # separate jobs, where one red suite never suppressed the other.
+          # Both now run every time and the verdict is applied at the end.
+          UNIT_RC=0
           docker run --rm \
             -v ${{ github.workspace }}/test-reports:/kkemu/test-reports \
             --entrypoint /bin/sh \
@@ -353,7 +374,9 @@ jobs:
             -c "mkdir -p /kkemu/test-reports/firmware-unit && \
                 make xunit; RC=\$?; \
                 cp -r unittests/*.xml /kkemu/test-reports/firmware-unit/ 2>/dev/null; \
-                exit \$RC"
+                exit \$RC" || UNIT_RC=$?
+          echo "UNIT_RC=$UNIT_RC" >> "$GITHUB_ENV"
+          echo "firmware unit suite exit code: $UNIT_RC"
           # That container runs as root and leaves root-owned paths behind in
           # the bind mount. The `docker cp` in the integration step below
           # chmods what it extracts into, and a root-owned directory there
@@ -387,6 +410,8 @@ jobs:
           tags: kkemu-tests-deps:latest
           load: true
           push: false
+          build-args: |
+            BASE_IMAGE=${{ env.RESOLVED_BASE }}
           cache-from: type=gha,scope=python-keepkey-deps
           cache-to: type=gha,mode=max,scope=python-keepkey-deps
 
@@ -401,6 +426,8 @@ jobs:
           tags: kktech/kkemu-tests:latest
           load: true
           push: false
+          build-args: |
+            BASE_IMAGE=${{ env.RESOLVED_BASE }}
           cache-from: type=gha,scope=python-keepkey-deps
 
       - name: Run python-keepkey integration suite
@@ -409,7 +436,13 @@ jobs:
           # No --build: kkemu resolves to the image tagged above, and
           # python-keepkey was built in the previous step. --build here
           # would force both to be rebuilt from scratch.
-          docker compose up --exit-code-from python-keepkey python-keepkey; PY_RC=$?
+          # `|| PY_RC=$?` rather than `; PY_RC=$?`: under `bash -e` a failing
+          # compose run aborts the step immediately, so none of the extraction
+          # or gating below would execute -- losing the reports on exactly the
+          # run where they matter most. A command in an `||` list is exempt
+          # from -e.
+          PY_RC=0
+          docker compose up --exit-code-from python-keepkey python-keepkey || PY_RC=$?
 
           echo "=== Extracting test reports from Docker ==="
           PY_CONTAINER=$(docker compose ps -a -q python-keepkey)
@@ -439,11 +472,8 @@ jobs:
             exit 1
           fi
 
+          echo "PY_RC=$PY_RC" >> "$GITHUB_ENV"
           echo "python-keepkey exit code: $PY_RC"
-          if [ "$PY_RC" -ne 0 ]; then
-            echo "::error::python-keepkey tests failed (exit code $PY_RC)"
-            exit "$PY_RC"
-          fi
 
       - name: Upload unit test results
         uses: actions/upload-artifact@v7
@@ -518,6 +548,24 @@ jobs:
           path: test-report.pdf
           retention-days: 90
 
+      # The verdict is applied here, once, after both suites have run and every
+      # artifact has been captured. Failing at the point of the first red suite
+      # would skip the second one and truncate the evidence.
+      - name: Test suite verdict
+        if: always()
+        run: |
+          RC=0
+          if [ "${UNIT_RC:-1}" -ne 0 ]; then
+            echo "::error::firmware unit tests failed (exit code ${UNIT_RC:-unknown})"
+            RC=1
+          fi
+          if [ "${PY_RC:-1}" -ne 0 ]; then
+            echo "::error::python-keepkey tests failed (exit code ${PY_RC:-unknown})"
+            RC=1
+          fi
+          [ "$RC" = "0" ] && echo "both suites passed"
+          exit "$RC"
+
       # No `docker compose down` -- this runner is destroyed within seconds
       # of the job ending, so tearing down containers and volumes was ~10s
       # spent tidying a machine that is about to cease to exist.
@@ -561,17 +609,32 @@ jobs:
 
       - name: Pull base image
         run: |
-          # The image is re-tagged to its Docker Hub name because
-          # scripts/emulator/Dockerfile says `FROM kktech/firmware:v15`.
-          # Neither `docker build` nor `docker compose build` passes --pull,
-          # so a local image under that name satisfies the FROM without any
-          # registry round-trip -- and without editing the Dockerfile.
-          if docker pull "${{ env.BASE_IMAGE_MIRROR }}" 2>/dev/null; then
+          # Two consumers, resolved differently:
+          #
+          #  1. `docker build` for the emulator image uses the classic builder,
+          #     which reads the local daemon image store. Re-tagging the mirror
+          #     to the Docker Hub name satisfies the `FROM kktech/firmware:v15`
+          #     in scripts/emulator/Dockerfile with no registry round-trip.
+          #
+          #  2. buildx (docker/build-push-action) uses the docker-container
+          #     driver, which does NOT see daemon-local images and resolves
+          #     FROM against a registry. Re-tagging alone silently left it
+          #     pulling from Docker Hub -- confirmed in run 33046944618, which
+          #     logged `[auth] kktech/firmware:pull token for
+          #     registry-1.docker.io` during the buildx step. RESOLVED_BASE is
+          #     therefore exported and passed to that build as a build-arg.
+          #
+          # stderr is deliberately not suppressed: the fallback stops a mirror
+          # problem being fatal, but hiding the error makes auth vs missing tag
+          # vs transient network indistinguishable.
+          if docker pull "${{ env.BASE_IMAGE_MIRROR }}"; then
             docker tag "${{ env.BASE_IMAGE_MIRROR }}" "${{ env.BASE_IMAGE }}"
+            echo "RESOLVED_BASE=${{ env.BASE_IMAGE_MIRROR }}" >> "$GITHUB_ENV"
             echo "base image: GHCR mirror"
           else
             echo "::warning::GHCR mirror unavailable — falling back to Docker Hub. Run the mirror-base-image workflow to populate it."
             docker pull "${{ env.BASE_IMAGE }}"
+            echo "RESOLVED_BASE=${{ env.BASE_IMAGE }}" >> "$GITHUB_ENV"
             echo "base image: Docker Hub"
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,14 @@ jobs:
 
       - name: Run cppcheck
         run: |
+          # `|| CPPCHECK_RC=$?` rather than `; CPPCHECK_RC=$?`. cppcheck is run
+          # with --error-exitcode=1, so it returns non-zero whenever it finds
+          # anything -- and `run:` steps execute under `bash -e`, which means
+          # the step died right here on exactly the runs that have findings.
+          # The `cat` that emits the ::warning file= annotations and the
+          # severity summary below never ran, leaving a bare failure with no
+          # diagnostics. A command in an `||` list is exempt from -e.
+          CPPCHECK_RC=0
           cppcheck \
             --enable=warning,style,performance,portability \
             --std=c11 \
@@ -223,7 +231,7 @@ jobs:
             --template='::warning file={file},line={line},col={column}::{severity}: {message} [{id}]' \
             --output-file=cppcheck_report.txt \
             --error-exitcode=1 \
-            lib/ include/keepkey/ tools/ 2>&1; CPPCHECK_RC=$?
+            lib/ include/keepkey/ tools/ 2>&1 || CPPCHECK_RC=$?
 
           # Count issues by severity
           ERRORS=$(grep -c '\berror:' cppcheck_report.txt 2>/dev/null || true)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -941,7 +941,16 @@ jobs:
   # ═══════════════════════════════════════════════════════════
 
   publish-emulator:
-    needs: [build-and-test, python-dylib-tests, build-arm-firmware]
+    # static-analysis is listed explicitly even though it gates nothing else.
+    # Taking it out of the *build* gate was a deliberate wall-clock trade: a
+    # cppcheck finding does not mean the firmware is wrong to compile, so it
+    # should not hold up compiling. Publishing is a different question. These
+    # images are pushed to DockerHub under kktech/kkemu and consumed
+    # downstream, and before the jobs were merged publish inherited the
+    # cppcheck gate transitively through the build jobs. Dropping it here
+    # would have meant a dispatch could publish artifacts from a commit with
+    # cppcheck red. The run is manual and already slow; the gate is free.
+    needs: [build-and-test, python-dylib-tests, build-arm-firmware, static-analysis]
     if: >-
       github.event_name == 'workflow_dispatch' &&
       github.event.inputs.publish_emulator == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,6 @@
 #   ├─ build-arm-firmware cross-compile → .bin/.elf (downloadable)
 #   └─ python-dylib-tests libkkemu.dylib screenshot regression (macOS)
 #
-# Stage 3: REPORT
-#   └─ generate-test-report   PDF from test artifacts
-#
 # Stage 4: PUBLISH (manual trigger, all tests must pass)
 #   └─ publish-emulator   DockerHub push (workflow_dispatch only)
 #
@@ -45,8 +42,20 @@ name: CI
 on:
   push:
     branches: [master, develop, 'feature/**', 'fix/**', 'release/**', 'hotfix/**']
+    # Documentation-only commits do not need two firmware compiles. Note this
+    # skips the workflow entirely rather than reporting a neutral check --
+    # safe here because develop is unprotected and master's only required
+    # context is a CircleCI job that no longer exists in this repo. Revisit
+    # if branch protection starts requiring any CI job below.
+    paths-ignore: &docs_only
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/*.md'
   pull_request:
     branches: [master, develop]
+    paths-ignore: *docs_only
   workflow_dispatch:
     inputs:
       publish_emulator:
@@ -64,6 +73,12 @@ concurrency:
 
 env:
   BASE_IMAGE: kktech/firmware:v15
+  # Pulls of the 650 MB base image from Docker Hub cost ~34s per job. The
+  # same blob served from GHCR to a GitHub-hosted runner is markedly faster
+  # and is not subject to Docker Hub's anonymous pull limits. Populate it
+  # with the mirror-base-image workflow; CI falls back to Docker Hub
+  # automatically when the mirror is absent or unreadable.
+  BASE_IMAGE_MIRROR: ghcr.io/${{ github.repository_owner }}/firmware:v15
   EMU_IMAGE: kkemu-ci
 
 jobs:
@@ -263,6 +278,9 @@ jobs:
   # it, so the tarball only has to exist when it is actually published.
   build-and-test:
     needs: [lint-format, secret-scan]
+    permissions:
+      contents: read
+      packages: read
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -285,8 +303,31 @@ jobs:
             deps/sca-hardening/SecAESSTM32
           git submodule update --init --recursive --jobs 4 deps/python-keepkey
 
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Pull base image
-        run: docker pull ${{ env.BASE_IMAGE }}
+        run: |
+          # The image is re-tagged to its Docker Hub name because
+          # scripts/emulator/Dockerfile says `FROM kktech/firmware:v15`.
+          # Neither `docker build` nor `docker compose build` passes --pull,
+          # so a local image under that name satisfies the FROM without any
+          # registry round-trip -- and without editing the Dockerfile.
+          if docker pull "${{ env.BASE_IMAGE_MIRROR }}" 2>/dev/null; then
+            docker tag "${{ env.BASE_IMAGE_MIRROR }}" "${{ env.BASE_IMAGE }}"
+            echo "base image: GHCR mirror"
+          else
+            echo "::warning::GHCR mirror unavailable — falling back to Docker Hub. Run the mirror-base-image workflow to populate it."
+            docker pull "${{ env.BASE_IMAGE }}"
+            echo "base image: Docker Hub"
+          fi
 
       - name: Build emulator image
         run: |
@@ -314,13 +355,30 @@ jobs:
                 cp -r unittests/*.xml /kkemu/test-reports/firmware-unit/ 2>/dev/null; \
                 exit \$RC"
 
+      # This image compiles no firmware, but its pip layer builds the cytoolz
+      # C extension against musl, which measured 28.8s -- plus ~8s for the apk
+      # layer. Both RUN layers sit *before* COPY, so they are stable across
+      # commits and cache cleanly; only the final COPY is invalidated by a
+      # source change.
+      #
+      # build-push-action rather than a `run:` step on purpose: the type=gha
+      # cache backend needs ACTIONS_RUNTIME_TOKEN and ACTIONS_CACHE_URL, and
+      # GitHub injects those into actions but NOT into `run:` shells. Driving
+      # buildx from a shell step here would warn and export nothing -- a cache
+      # that looks configured and silently does no work.
+      #
+      # The tag matches `image:` on the python-keepkey compose service, so
+      # `docker compose up` reuses this instead of rebuilding it.
       - name: Build python-keepkey test image
-        working-directory: scripts/emulator
-        run: |
-          # Separate Dockerfile (base + apk/pip deps + COPY), so it does have
-          # to be built. It compiles no firmware; the cost is the cytoolz C
-          # extension in the pip layer.
-          docker compose build python-keepkey
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: scripts/emulator/python-keepkey.Dockerfile
+          tags: kktech/kkemu-tests:latest
+          load: true
+          push: false
+          cache-from: type=gha,scope=python-keepkey-tests
+          cache-to: type=gha,mode=max,scope=python-keepkey-tests
 
       - name: Run python-keepkey integration suite
         working-directory: scripts/emulator
@@ -390,13 +448,45 @@ jobs:
           path: /tmp/emu-image.tar
           retention-days: 1
 
-      - name: Tear down
+      # Folded in from the former `generate-test-report` job. Every input it
+      # needs is already on this runner: the three report directories, the
+      # checkout, and the python-keepkey submodule. As a separate job it paid
+      # a runner spin-up plus three artifact downloads to reassemble state
+      # that had just been torn down. The script is pure stdlib.
+      #
+      # if: always() throughout, so a red test run still produces its report
+      # -- that is the run where the PDF matters most.
+      - name: Extract firmware version
+        id: version
         if: always()
-        working-directory: scripts/emulator
-        run: docker compose down -v || true
+        run: |
+          FW_VERSION=$(sed -n '/^project/,/)/p' CMakeLists.txt | grep -oP '\d+\.\d+\.\d+' || echo "unknown")
+          echo "fw_version=${FW_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate test report PDF
+        if: always()
+        env:
+          FW_VERSION: ${{ steps.version.outputs.fw_version }}
+          KK_BUILD_LABEL: ${{ github.head_ref || github.ref_name }}@${{ github.event.pull_request.head.sha || github.sha }}
+        run: python3 scripts/generate-test-report.py
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-report
+          path: test-report.pdf
+          retention-days: 90
+
+      # No `docker compose down` -- this runner is destroyed within seconds
+      # of the job ending, so tearing down containers and volumes was ~10s
+      # spent tidying a machine that is about to cease to exist.
 
   build-arm-firmware:
     needs: [lint-format, secret-scan]
+    permissions:
+      contents: read
+      packages: read
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -419,8 +509,31 @@ jobs:
             deps/sca-hardening/SecAESSTM32
           git submodule update --init --recursive --jobs 4 deps/python-keepkey
 
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Pull base image
-        run: docker pull ${{ env.BASE_IMAGE }}
+        run: |
+          # The image is re-tagged to its Docker Hub name because
+          # scripts/emulator/Dockerfile says `FROM kktech/firmware:v15`.
+          # Neither `docker build` nor `docker compose build` passes --pull,
+          # so a local image under that name satisfies the FROM without any
+          # registry round-trip -- and without editing the Dockerfile.
+          if docker pull "${{ env.BASE_IMAGE_MIRROR }}" 2>/dev/null; then
+            docker tag "${{ env.BASE_IMAGE_MIRROR }}" "${{ env.BASE_IMAGE }}"
+            echo "base image: GHCR mirror"
+          else
+            echo "::warning::GHCR mirror unavailable — falling back to Docker Hub. Run the mirror-base-image workflow to populate it."
+            docker pull "${{ env.BASE_IMAGE }}"
+            echo "base image: Docker Hub"
+          fi
 
       - name: Extract firmware version
         id: version
@@ -685,65 +798,6 @@ jobs:
           path: test-reports/dylib-junit.xml
           retention-days: 30
           if-no-files-found: warn
-
-  # ═══════════════════════════════════════════════════════════
-  # STAGE 3b: TEST REPORT — generate PDF from test artifacts
-  # ═══════════════════════════════════════════════════════════
-
-  generate-test-report:
-    needs: [build-and-test]
-    if: always()
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Download unit test results
-        uses: actions/download-artifact@v4
-        continue-on-error: true
-        with:
-          name: unit-test-results
-          path: test-reports/firmware-unit/
-
-      - name: Download python test results
-        uses: actions/download-artifact@v4
-        continue-on-error: true
-        with:
-          name: python-test-results
-          path: test-reports/python-keepkey/
-
-      - name: Download OLED screenshots
-        uses: actions/download-artifact@v4
-        continue-on-error: true
-        with:
-          name: oled-screenshots
-          path: test-reports/screenshots/
-
-      - name: Extract firmware version
-        id: version
-        run: |
-          FW_VERSION=$(sed -n '/^project/,/)/p' CMakeLists.txt | grep -oP '\d+\.\d+\.\d+' || echo "unknown")
-          echo "fw_version=${FW_VERSION}" >> "$GITHUB_OUTPUT"
-
-      - name: Init python-keepkey submodule
-        run: git submodule update --init deps/python-keepkey
-
-      - name: Generate test report PDF
-        env:
-          FW_VERSION: ${{ steps.version.outputs.fw_version }}
-          KK_BUILD_LABEL: ${{ github.head_ref || github.ref_name }}@${{ github.event.pull_request.head.sha || github.sha }}
-        run: python3 scripts/generate-test-report.py
-
-      - name: Upload test report
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: test-report
-          path: test-report.pdf
-          retention-days: 90
 
   # ═══════════════════════════════════════════════════════════
   # STAGE 4: PUBLISH — manual trigger only, all tests must pass

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,8 +325,14 @@ jobs:
             deps/sca-hardening/SecAESSTM32
           git submodule update --init --recursive --jobs 4 deps/python-keepkey
 
+      # continue-on-error because the mirror is optional by design. Without
+      # it a GHCR outage, a revoked package grant, or a token hiccup fails the
+      # job here -- before the Docker Hub fallback this login exists to enable
+      # ever gets a chance to run. A failed login simply means the subsequent
+      # mirror pull is unauthenticated, which takes the fallback path.
       - name: Log in to GHCR
         uses: docker/login-action@v4
+        continue-on-error: true
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -631,44 +637,36 @@ jobs:
             deps/sca-hardening/SecAESSTM32
           git submodule update --init --recursive --jobs 4 deps/python-keepkey
 
+      # continue-on-error because the mirror is optional by design. Without
+      # it a GHCR outage, a revoked package grant, or a token hiccup fails the
+      # job here -- before the Docker Hub fallback this login exists to enable
+      # ever gets a chance to run. A failed login simply means the subsequent
+      # mirror pull is unauthenticated, which takes the fallback path.
       - name: Log in to GHCR
         uses: docker/login-action@v4
+        continue-on-error: true
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
       - name: Pull base image
         run: |
-          # Two consumers, resolved differently:
-          #
-          #  1. `docker build` for the emulator image uses the classic builder,
-          #     which reads the local daemon image store. Re-tagging the mirror
-          #     to the Docker Hub name satisfies the `FROM kktech/firmware:v15`
-          #     in scripts/emulator/Dockerfile with no registry round-trip.
-          #
-          #  2. buildx (docker/build-push-action) uses the docker-container
-          #     driver, which does NOT see daemon-local images and resolves
-          #     FROM against a registry. Re-tagging alone silently left it
-          #     pulling from Docker Hub -- confirmed in run 33046944618, which
-          #     logged `[auth] kktech/firmware:pull token for
-          #     registry-1.docker.io` during the buildx step. RESOLVED_BASE is
-          #     therefore exported and passed to that build as a build-arg.
+          # This job runs the toolchain with `docker run`, so it only needs the
+          # image present in the local daemon store under its Docker Hub name.
+          # No buildx here, and so no RESOLVED_BASE -- see build-and-test,
+          # which does need both because buildx resolves FROM against a
+          # registry rather than the daemon.
           #
           # stderr is deliberately not suppressed: the fallback stops a mirror
           # problem being fatal, but hiding the error makes auth vs missing tag
           # vs transient network indistinguishable.
           if docker pull "${{ env.BASE_IMAGE_MIRROR }}"; then
             docker tag "${{ env.BASE_IMAGE_MIRROR }}" "${{ env.BASE_IMAGE }}"
-            echo "RESOLVED_BASE=${{ env.BASE_IMAGE_MIRROR }}" >> "$GITHUB_ENV"
             echo "base image: GHCR mirror"
           else
             echo "::warning::GHCR mirror unavailable — falling back to Docker Hub. Run the mirror-base-image workflow to populate it."
             docker pull "${{ env.BASE_IMAGE }}"
-            echo "RESOLVED_BASE=${{ env.BASE_IMAGE }}" >> "$GITHUB_ENV"
             echo "base image: Docker Hub"
           fi
 
@@ -808,7 +806,10 @@ jobs:
           # both drop the leading 3.
           PROTOC_VERSION=21.12
           PROTOC_ASSET="protoc-${PROTOC_VERSION}-osx-aarch_64.zip"
-          if [ ! -f /tmp/protoc.zip ]; then
+          # -s not -f: a cache entry can restore empty or truncated, and
+          # existence alone would skip the download and hand unzip a bad file
+          # with no retry.
+          if [ ! -s /tmp/protoc.zip ]; then
             curl -sSL -fL -o /tmp/protoc.zip \
               "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ASSET}"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,13 @@ jobs:
                 make xunit; RC=\$?; \
                 cp -r unittests/*.xml /kkemu/test-reports/firmware-unit/ 2>/dev/null; \
                 exit \$RC"
+          # That container runs as root and leaves root-owned paths behind in
+          # the bind mount. The `docker cp` in the integration step below
+          # chmods what it extracts into, and a root-owned directory there
+          # makes it fail outright -- copying nothing. This did not arise when
+          # the two suites lived in separate jobs, each with a pristine
+          # test-reports/.
+          sudo chown -R "$(id -u):$(id -g)" "${{ github.workspace }}/test-reports"
 
       # The pip layer here builds the cytoolz C extension against musl, which
       # measured 36.8s, plus ~8s for the apk layer. Those are worth caching.
@@ -406,14 +413,31 @@ jobs:
 
           echo "=== Extracting test reports from Docker ==="
           PY_CONTAINER=$(docker compose ps -a -q python-keepkey)
-          docker cp "$PY_CONTAINER":/kkemu/test-reports/. ${{ github.workspace }}/test-reports/ \
-            || echo "WARN: python-keepkey docker cp failed"
+          if [ -z "$PY_CONTAINER" ]; then
+            echo "::error::could not resolve the python-keepkey container to extract reports from"
+            exit 1
+          fi
+          docker cp "$PY_CONTAINER":/kkemu/test-reports/. "${{ github.workspace }}/test-reports/"
 
           echo "=== Extracted files ==="
           find ${{ github.workspace }}/test-reports -type f | head -30
-          echo "=== Screenshot PNGs ==="
-          find ${{ github.workspace }}/test-reports/screenshots -name '*.png' 2>/dev/null | wc -l
-          echo "PNGs on host"
+          PNGS=$(find ${{ github.workspace }}/test-reports/screenshots -name '*.png' 2>/dev/null | wc -l)
+          echo "=== Screenshot PNGs on host: $PNGS ==="
+
+          # Extraction is gated, not warned about. A silent `docker cp` failure
+          # previously let this job go green having lost every integration
+          # result: 437 tests and 310 screenshots stayed inside the container,
+          # the artifacts uploaded empty, and the report PDF rendered
+          # "0 passed, 0 failed". Losing test evidence must fail the run.
+          JUNIT="${{ github.workspace }}/test-reports/python-keepkey/junit.xml"
+          if [ ! -s "$JUNIT" ]; then
+            echo "::error::python-keepkey junit.xml missing or empty after extraction — test results were lost"
+            exit 1
+          fi
+          if [ "$PNGS" -eq 0 ]; then
+            echo "::error::no OLED screenshots extracted — the screenshot pipeline or the extraction is broken"
+            exit 1
+          fi
 
           echo "python-keepkey exit code: $PY_RC"
           if [ "$PY_RC" -ne 0 ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,20 +355,37 @@ jobs:
                 cp -r unittests/*.xml /kkemu/test-reports/firmware-unit/ 2>/dev/null; \
                 exit \$RC"
 
-      # This image compiles no firmware, but its pip layer builds the cytoolz
-      # C extension against musl, which measured 28.8s -- plus ~8s for the apk
-      # layer. Both RUN layers sit *before* COPY, so they are stable across
-      # commits and cache cleanly; only the final COPY is invalidated by a
-      # source change.
+      # The pip layer here builds the cytoolz C extension against musl, which
+      # measured 36.8s, plus ~8s for the apk layer. Those are worth caching.
+      # The COPY layer below them is NOT: it ships the whole build context,
+      # and it is invalidated by every commit, so it can never produce a hit.
+      #
+      # Caching the whole image is therefore a net loss, and measurably so --
+      # a first attempt with cache-to on the full image spent 103.9s in
+      # "exporting to GitHub Actions Cache" to save 36.8s of pip. Hence the
+      # split: cache-to on the `deps` target only, and cache-from (never
+      # cache-to) on the image that adds COPY.
       #
       # build-push-action rather than a `run:` step on purpose: the type=gha
       # cache backend needs ACTIONS_RUNTIME_TOKEN and ACTIONS_CACHE_URL, and
       # GitHub injects those into actions but NOT into `run:` shells. Driving
       # buildx from a shell step here would warn and export nothing -- a cache
       # that looks configured and silently does no work.
-      #
-      # The tag matches `image:` on the python-keepkey compose service, so
-      # `docker compose up` reuses this instead of rebuilding it.
+      - name: Build python-keepkey dependency layers
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: scripts/emulator/python-keepkey.Dockerfile
+          target: deps
+          tags: kkemu-tests-deps:latest
+          load: true
+          push: false
+          cache-from: type=gha,scope=python-keepkey-deps
+          cache-to: type=gha,mode=max,scope=python-keepkey-deps
+
+      # No cache-to here -- see above. The tag matches `image:` on the
+      # python-keepkey compose service, so `docker compose up` reuses this
+      # instead of rebuilding it.
       - name: Build python-keepkey test image
         uses: docker/build-push-action@v6
         with:
@@ -377,8 +394,7 @@ jobs:
           tags: kktech/kkemu-tests:latest
           load: true
           push: false
-          cache-from: type=gha,scope=python-keepkey-tests
-          cache-to: type=gha,mode=max,scope=python-keepkey-tests
+          cache-from: type=gha,scope=python-keepkey-deps
 
       - name: Run python-keepkey integration suite
         working-directory: scripts/emulator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,21 +3,42 @@
 # FAIL FAST — quick checks gate everything, no wasted compute.
 #
 # Stage 1: GATE (seconds, no Docker)
-#   ├─ lint-format        clang-format diff check
-#   ├─ static-analysis    cppcheck static analysis
-#   ├─ secret-scan        gitleaks credential detection
-#   └─ check-submodules   verify all deps present
+#   ├─ lint-format        clang-format check + submodule declarations
+#   ├─ static-analysis    cppcheck static analysis (parallel)
+#   └─ secret-scan        gitleaks credential detection
 #
-# Stage 2: BUILD (parallel, gated by Stage 1)
-#   ├─ build-emulator     Docker image → artifact
-#   └─ build-arm-firmware cross-compile → .bin/.elf (downloadable)
+# Stage 2: BUILD + TEST (parallel, gated by Stage 1)
+#   ├─ build-and-test     emulator image → make xunit → python-keepkey suite
+#   ├─ build-arm-firmware cross-compile → .bin/.elf (downloadable)
+#   └─ python-dylib-tests libkkemu.dylib screenshot regression (macOS)
 #
-# Stage 3: TEST (parallel, gated by Stage 2)
-#   ├─ unit-tests              GoogleTest (make xunit)
-#   └─ python-integration      full test suite
+# Stage 3: REPORT
+#   └─ generate-test-report   PDF from test artifacts
 #
 # Stage 4: PUBLISH (manual trigger, all tests must pass)
 #   └─ publish-emulator   DockerHub push (workflow_dispatch only)
+#
+# Design notes — why it is shaped this way:
+#
+#   The emulator image is built EXACTLY ONCE per run. It used to be built
+#   twice (once in build-emulator, once by `docker compose --build` in
+#   python-integration-tests) and then shipped between jobs as an 845 MB
+#   `docker save` tarball. That tarball cost ~77s to save+upload and ~49s
+#   to download+load, in order to run a test suite that takes 1s. Both
+#   test suites now run in the job that built the image.
+#
+#   The base image is pulled, not cached. The previous actions/cache of a
+#   649 MB `docker save` tar was ref-scoped, so every branch wrote its own
+#   copy; 13 of them were occupying 8.4 GB of the repo's 10 GB cache quota
+#   and evicting each other, which is why it missed on develop anyway.
+#
+#   static-analysis does NOT gate the build. cppcheck is advisory — a style
+#   or portability finding does not mean the firmware is wrong to compile —
+#   and as the slowest Stage 1 job it was serialising the entire pipeline
+#   behind itself. It still fails the run; it just no longer delays it.
+#   lint-format and secret-scan stay in the gate: both finish in ~20s, and
+#   secret-scan in particular should stop a leaked credential before any
+#   artifact is produced from that commit.
 
 name: CI
 
@@ -33,6 +54,13 @@ on:
         required: false
         type: boolean
         default: false
+
+# Supersede in-flight runs for the same PR. Pushes to long-lived branches
+# are never cancelled — a half-finished develop/master run tells you less
+# than nothing, and release branches gate real firmware artifacts.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   BASE_IMAGE: kktech/firmware:v15
@@ -52,25 +80,63 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Install clang-format-20 (pinned stable)
+      # Folded in from the former `check-submodules` job. It is a grep over
+      # .gitmodules that ran for 3s but cost a whole runner spin-up, and it
+      # sat in the `needs:` fan-in of every downstream job.
+      - name: Verify submodules are declared
         run: |
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" | sudo tee /etc/apt/sources.list.d/llvm.list
-          sudo apt-get update -qq && sudo apt-get install -y -qq clang-format-20
-          sudo ln -sf /usr/bin/clang-format-20 /usr/bin/clang-format
+          echo "Checking required submodule declarations..."
+          REQUIRED=(
+            "deps/crypto/trezor-firmware"
+            "deps/device-protocol"
+            "deps/python-keepkey"
+            "deps/googletest"
+            "deps/qrenc/QR-Code-generator"
+            "deps/sca-hardening/SecAESSTM32"
+          )
+          FAILED=0
+          for sub in "${REQUIRED[@]}"; do
+            if ! grep -q "$sub" .gitmodules; then
+              echo "::error::Missing required submodule: $sub"
+              FAILED=1
+            else
+              echo "  ✓ $sub"
+            fi
+          done
+          [ "$FAILED" = "0" ] || exit 1
+
+      # PyPI wheel instead of the LLVM apt repo. Same upstream binary,
+      # pinned just as tightly, without `apt-get update` against
+      # apt.llvm.org on every run.
+      - name: Install clang-format 20 (pinned stable)
+        run: |
+          python3 -m pip install --quiet --upgrade "clang-format==20.1.8"
+          clang-format --version
 
       - name: Check code formatting
         run: |
           echo "Using: $(clang-format --version)"
-          FAILED=0
-          for f in $(find include/keepkey lib/firmware lib/board lib/transport/src \
-                     -name '*.c' -o -name '*.h' 2>/dev/null | grep -v generated | grep -v '.pb.'); do
-            if ! clang-format --style=file --dry-run --Werror "$f" 2>/dev/null; then
-              echo "::warning file=$f::Formatting differs from .clang-format"
-              FAILED=1
-            fi
-          done
-          if [ "$FAILED" = "1" ]; then
+          # xargs -P fans the per-file checks across the runner's cores; each
+          # clang-format invocation is independent, so the only thing needing
+          # coordination is the exit status, which xargs aggregates (123 if
+          # any child failed).
+          #
+          # The pipeline is the `if` condition rather than a bare command
+          # because GitHub runs `run:` blocks under `bash -e` -- a bare
+          # failing pipeline would abort the step immediately and swallow the
+          # remediation message below. Inside an `if`, -e is suspended.
+          #
+          # shellcheck disable=SC2016  # $1 is expanded by the inner sh, not here
+          if ! find include/keepkey lib/firmware lib/board lib/transport/src \
+                    -name '*.c' -o -name '*.h' 2>/dev/null \
+               | grep -v generated | grep -v '.pb.' \
+               | xargs -P "$(nproc)" -I{} sh -c '
+                   if ! clang-format --style=file --dry-run --Werror "$1" 2>/dev/null; then
+                     echo "::warning file=$1::Formatting differs from .clang-format"
+                     exit 1
+                   fi
+                 ' _ {}
+          then
             echo ""
             echo "::error::Code formatting check failed. Run: clang-format -i <file> to fix."
             exit 1
@@ -127,6 +193,7 @@ jobs:
             --platform=unspecified \
             --inconclusive \
             --force \
+            -j8 \
             --inline-suppr \
             --suppressions-list=.cppcheck-suppressions \
             -I include \
@@ -185,45 +252,19 @@ jobs:
           path: cppcheck_report.txt
           retention-days: 30
 
-  check-submodules:
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Verify submodules are declared
-        run: |
-          echo "Checking required submodule declarations..."
-          REQUIRED=(
-            "deps/crypto/trezor-firmware"
-            "deps/device-protocol"
-            "deps/python-keepkey"
-            "deps/googletest"
-            "deps/qrenc/QR-Code-generator"
-            "deps/sca-hardening/SecAESSTM32"
-          )
-          FAILED=0
-          for sub in "${REQUIRED[@]}"; do
-            if ! grep -q "$sub" .gitmodules; then
-              echo "::error::Missing required submodule: $sub"
-              FAILED=1
-            else
-              echo "  ✓ $sub"
-            fi
-          done
-          [ "$FAILED" = "0" ] || exit 1
-
   # ═══════════════════════════════════════════════════════════
-  # STAGE 2: BUILD — compile only after gate passes
+  # STAGE 2: BUILD + TEST — compile once, test in place
   # ═══════════════════════════════════════════════════════════
 
-  build-emulator:
-    needs: [lint-format, static-analysis, check-submodules, secret-scan]
+  # Replaces the former build-emulator + unit-tests + python-integration-tests
+  # trio. Those three jobs built the emulator image twice and moved 845 MB of
+  # `docker save` tarball between runners to run suites that take 1s and 11s
+  # respectively. Both suites now run against the image in the job that built
+  # it, so the tarball only has to exist when it is actually published.
+  build-and-test:
+    needs: [lint-format, secret-scan]
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -232,32 +273,20 @@ jobs:
 
       - name: Init submodules
         run: |
-          git submodule update --init deps/crypto/trezor-firmware
-          git submodule update --init deps/device-protocol
-          git submodule update --init --recursive deps/python-keepkey
-          git submodule update --init deps/googletest
-          git submodule update --init deps/qrenc/QR-Code-generator
-          git submodule update --init deps/sca-hardening/SecAESSTM32
+          # --jobs 4 clones these in parallel. Only python-keepkey is
+          # --recursive: trezor-firmware declares 9 nested submodules that
+          # this build does not use, and pulling them would cost more than
+          # the parallelism saves.
+          git submodule update --init --jobs 4 \
+            deps/crypto/trezor-firmware \
+            deps/device-protocol \
+            deps/googletest \
+            deps/qrenc/QR-Code-generator \
+            deps/sca-hardening/SecAESSTM32
+          git submodule update --init --recursive --jobs 4 deps/python-keepkey
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Cache base image
-        id: cache-base
-        uses: actions/cache@v5
-        with:
-          path: /tmp/base-image.tar
-          key: base-image-${{ env.BASE_IMAGE }}
-
-      - name: Pull and cache base image
-        if: steps.cache-base.outputs.cache-hit != 'true'
-        run: |
-          docker pull ${{ env.BASE_IMAGE }}
-          docker save ${{ env.BASE_IMAGE }} -o /tmp/base-image.tar
-
-      - name: Load base image from cache
-        if: steps.cache-base.outputs.cache-hit == 'true'
-        run: docker load -i /tmp/base-image.tar
+      - name: Pull base image
+        run: docker pull ${{ env.BASE_IMAGE }}
 
       - name: Build emulator image
         run: |
@@ -265,19 +294,109 @@ jobs:
             -t ${{ env.EMU_IMAGE }} \
             -f scripts/emulator/Dockerfile \
             .
+          # docker-compose.yml declares `image: kktech/kkemu:latest` on the
+          # kkemu service. Tagging the image we just built under that name is
+          # what stops `docker compose up` from rebuilding it: compose only
+          # builds a service when its image is absent or --build is passed.
+          docker tag ${{ env.EMU_IMAGE }} kktech/kkemu:latest
 
-      - name: Save emulator image
+      - name: Run firmware unit tests (make xunit)
+        run: |
+          # make xunit returns non-zero if any test fails — capture
+          # exit code so JUnit XML still gets copied for reporting
+          mkdir -p ${{ github.workspace }}/test-reports
+          docker run --rm \
+            -v ${{ github.workspace }}/test-reports:/kkemu/test-reports \
+            --entrypoint /bin/sh \
+            ${{ env.EMU_IMAGE }} \
+            -c "mkdir -p /kkemu/test-reports/firmware-unit && \
+                make xunit; RC=\$?; \
+                cp -r unittests/*.xml /kkemu/test-reports/firmware-unit/ 2>/dev/null; \
+                exit \$RC"
+
+      - name: Build python-keepkey test image
+        working-directory: scripts/emulator
+        run: |
+          # Separate Dockerfile (base + apk/pip deps + COPY), so it does have
+          # to be built. It compiles no firmware; the cost is the cytoolz C
+          # extension in the pip layer.
+          docker compose build python-keepkey
+
+      - name: Run python-keepkey integration suite
+        working-directory: scripts/emulator
+        run: |
+          # No --build: kkemu resolves to the image tagged above, and
+          # python-keepkey was built in the previous step. --build here
+          # would force both to be rebuilt from scratch.
+          docker compose up --exit-code-from python-keepkey python-keepkey; PY_RC=$?
+
+          echo "=== Extracting test reports from Docker ==="
+          PY_CONTAINER=$(docker compose ps -a -q python-keepkey)
+          docker cp "$PY_CONTAINER":/kkemu/test-reports/. ${{ github.workspace }}/test-reports/ \
+            || echo "WARN: python-keepkey docker cp failed"
+
+          echo "=== Extracted files ==="
+          find ${{ github.workspace }}/test-reports -type f | head -30
+          echo "=== Screenshot PNGs ==="
+          find ${{ github.workspace }}/test-reports/screenshots -name '*.png' 2>/dev/null | wc -l
+          echo "PNGs on host"
+
+          echo "python-keepkey exit code: $PY_RC"
+          if [ "$PY_RC" -ne 0 ]; then
+            echo "::error::python-keepkey tests failed (exit code $PY_RC)"
+            exit "$PY_RC"
+          fi
+
+      - name: Upload unit test results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: unit-test-results
+          path: test-reports/firmware-unit/
+          retention-days: 30
+
+      - name: Upload Python test results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: python-test-results
+          path: test-reports/python-keepkey/
+          retention-days: 30
+
+      - name: Upload OLED screenshots
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: oled-screenshots
+          path: test-reports/screenshots/
+          retention-days: 90
+          if-no-files-found: warn
+
+      # Only materialised for the publish path. On a normal push or PR this
+      # is 845 MB of save + upload that nothing downstream consumes.
+      - name: Save emulator image for publish
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.publish_emulator == 'true'
         run: docker save ${{ env.EMU_IMAGE }} -o /tmp/emu-image.tar
 
       - name: Upload emulator image artifact
+        if: >-
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.publish_emulator == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: emu-image
           path: /tmp/emu-image.tar
           retention-days: 1
 
+      - name: Tear down
+        if: always()
+        working-directory: scripts/emulator
+        run: docker compose down -v || true
+
   build-arm-firmware:
-    needs: [lint-format, static-analysis, check-submodules, secret-scan]
+    needs: [lint-format, secret-scan]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -288,29 +407,20 @@ jobs:
 
       - name: Init submodules
         run: |
-          git submodule update --init deps/crypto/trezor-firmware
-          git submodule update --init deps/device-protocol
-          git submodule update --init --recursive deps/python-keepkey
-          git submodule update --init deps/googletest
-          git submodule update --init deps/qrenc/QR-Code-generator
-          git submodule update --init deps/sca-hardening/SecAESSTM32
+          # --jobs 4 clones these in parallel. Only python-keepkey is
+          # --recursive: trezor-firmware declares 9 nested submodules that
+          # this build does not use, and pulling them would cost more than
+          # the parallelism saves.
+          git submodule update --init --jobs 4 \
+            deps/crypto/trezor-firmware \
+            deps/device-protocol \
+            deps/googletest \
+            deps/qrenc/QR-Code-generator \
+            deps/sca-hardening/SecAESSTM32
+          git submodule update --init --recursive --jobs 4 deps/python-keepkey
 
-      - name: Cache base image
-        id: cache-base
-        uses: actions/cache@v5
-        with:
-          path: /tmp/base-image.tar
-          key: base-image-${{ env.BASE_IMAGE }}
-
-      - name: Pull and cache base image
-        if: steps.cache-base.outputs.cache-hit != 'true'
-        run: |
-          docker pull ${{ env.BASE_IMAGE }}
-          docker save ${{ env.BASE_IMAGE }} -o /tmp/base-image.tar
-
-      - name: Load base image from cache
-        if: steps.cache-base.outputs.cache-hit == 'true'
-        run: docker load -i /tmp/base-image.tar
+      - name: Pull base image
+        run: docker pull ${{ env.BASE_IMAGE }}
 
       - name: Extract firmware version
         id: version
@@ -360,119 +470,6 @@ jobs:
           retention-days: 90
 
   # ═══════════════════════════════════════════════════════════
-  # STAGE 3: TEST — run only after builds succeed
-  # ═══════════════════════════════════════════════════════════
-
-  unit-tests:
-    needs: build-emulator
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Download emulator image
-        uses: actions/download-artifact@v8
-        with:
-          name: emu-image
-          path: /tmp
-
-      - name: Load emulator image
-        run: docker load -i /tmp/emu-image.tar
-
-      - name: Run unit tests
-        run: |
-          # make xunit returns non-zero if any test fails — capture
-          # exit code so JUnit XML still gets copied for reporting
-          docker run --rm \
-            -v ${{ github.workspace }}/test-reports:/kkemu/test-reports \
-            --entrypoint /bin/sh \
-            ${{ env.EMU_IMAGE }} \
-            -c "mkdir -p /kkemu/test-reports/firmware-unit && \
-                make xunit; RC=\$?; \
-                cp -r unittests/*.xml /kkemu/test-reports/firmware-unit/ 2>/dev/null; \
-                exit \$RC"
-
-      - name: Upload unit test results
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: unit-test-results
-          path: test-reports/firmware-unit/
-          retention-days: 30
-
-  python-integration-tests:
-    needs: [lint-format, static-analysis, check-submodules, secret-scan]
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Init submodules
-        run: |
-          git submodule update --init deps/crypto/trezor-firmware
-          git submodule update --init deps/device-protocol
-          git submodule update --init --recursive deps/python-keepkey
-          git submodule update --init deps/googletest
-          git submodule update --init deps/qrenc/QR-Code-generator
-          git submodule update --init deps/sca-hardening/SecAESSTM32
-
-      - name: Build and run tests (docker compose)
-        working-directory: scripts/emulator
-        run: |
-          # Run each test container — capture exit codes, always extract reports
-          docker compose up --build --exit-code-from firmware-unit firmware-unit; FW_RC=$?
-          docker compose up --build --exit-code-from python-keepkey python-keepkey; PY_RC=$?
-
-          mkdir -p ${{ github.workspace }}/test-reports
-
-          echo "=== Extracting test reports from Docker ==="
-          PY_CONTAINER=$(docker compose ps -a -q python-keepkey)
-          FW_CONTAINER=$(docker compose ps -a -q firmware-unit)
-
-          docker cp "$FW_CONTAINER":/kkemu/test-reports/. ${{ github.workspace }}/test-reports/ || echo "WARN: firmware-unit docker cp failed"
-          docker cp "$PY_CONTAINER":/kkemu/test-reports/. ${{ github.workspace }}/test-reports/ || echo "WARN: python-keepkey docker cp failed"
-
-          echo "=== Extracted files ==="
-          find ${{ github.workspace }}/test-reports -type f | head -30
-          echo "=== Screenshot PNGs ==="
-          find ${{ github.workspace }}/test-reports/screenshots -name '*.png' 2>/dev/null | wc -l
-          echo "PNGs on host"
-
-          echo "firmware-unit exit code: $FW_RC"
-          echo "python-keepkey exit code: $PY_RC"
-
-          if [ "$FW_RC" -ne 0 ]; then
-            echo "::error::firmware-unit tests failed (exit code $FW_RC)"
-          fi
-          if [ "$PY_RC" -ne 0 ]; then
-            echo "::error::python-keepkey tests failed (exit code $PY_RC)"
-          fi
-          [ "$FW_RC" -eq 0 ] && [ "$PY_RC" -eq 0 ] || exit 1
-
-      - name: Upload Python test results
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: python-test-results
-          path: test-reports/python-keepkey/
-          retention-days: 30
-
-      - name: Upload OLED screenshots
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: oled-screenshots
-          path: test-reports/screenshots/
-          retention-days: 90
-          if-no-files-found: warn
-
-      - name: Tear down
-        if: always()
-        working-directory: scripts/emulator
-        run: docker compose down -v || true
-
-  # ═══════════════════════════════════════════════════════════
   # STAGE 3a-bis: DYLIB TESTS — libkkemu shared lib via python-keepkey
   # ═══════════════════════════════════════════════════════════
   # Builds the firmware emulator as a shared library (libkkemu.dylib on
@@ -486,7 +483,7 @@ jobs:
   # Fixing requires deduping the symbol — out of scope for this PR.
   # TODO: enable ubuntu-latest in a follow-up after the symbol cleanup.
   #
-  # Why a separate job from python-integration-tests:
+  # Why a separate job from the build-and-test suite:
   #   - Different artifact: .dylib (in-process FFI), not the kkemu
   #     UDP binary the existing job builds.
   #   - Different transport in tests: KK_TRANSPORT=dylib instead of UDP.
@@ -504,7 +501,7 @@ jobs:
   #     fsm_msgDebugLinkGetState is excluded from the build and any
   #     read_layout() call hangs the test).
   python-dylib-tests:
-    needs: [lint-format, static-analysis, check-submodules, secret-scan]
+    needs: [lint-format, secret-scan]
     runs-on: macos-latest
     timeout-minutes: 25
     steps:
@@ -515,11 +512,16 @@ jobs:
 
       - name: Init submodules
         run: |
-          git submodule update --init deps/crypto/trezor-firmware
-          git submodule update --init deps/device-protocol
-          git submodule update --init --recursive deps/python-keepkey
-          git submodule update --init deps/qrenc/QR-Code-generator
-          git submodule update --init deps/sca-hardening/SecAESSTM32
+          # --jobs 4 clones these in parallel. Only python-keepkey is
+          # --recursive: trezor-firmware declares 9 nested submodules that
+          # this build does not use, and pulling them would cost more than
+          # the parallelism saves.
+          git submodule update --init --jobs 4 \
+            deps/crypto/trezor-firmware \
+            deps/device-protocol \
+            deps/qrenc/QR-Code-generator \
+            deps/sca-hardening/SecAESSTM32
+          git submodule update --init --recursive --jobs 4 deps/python-keepkey
           # CMakeLists.txt requires googletest unconditionally even when
           # we only build the dylib target — the project's add_subdirectory
           # for it runs at configure time, before any target selection.
@@ -529,6 +531,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+          cache: 'pip'
 
       - name: Install pinned Python deps
         run: |
@@ -537,6 +540,13 @@ jobs:
           # is needed by lib/firmware's ethereum_tokens.def build step
           # (it fetches token-list JSON at compile time).
           pip install "protobuf==3.20.3" "nanopb==0.3.9.4.post3" requests
+
+      - name: Cache pinned protoc
+        id: cache-protoc
+        uses: actions/cache@v5
+        with:
+          path: /tmp/protoc.zip
+          key: protoc-21.12-osx-aarch_64
 
       - name: Install pinned protoc 3.21
         run: |
@@ -548,8 +558,10 @@ jobs:
           # both drop the leading 3.
           PROTOC_VERSION=21.12
           PROTOC_ASSET="protoc-${PROTOC_VERSION}-osx-aarch_64.zip"
-          curl -sSL -fL -o /tmp/protoc.zip \
-            "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ASSET}"
+          if [ ! -f /tmp/protoc.zip ]; then
+            curl -sSL -fL -o /tmp/protoc.zip \
+              "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ASSET}"
+          fi
           # `-f` makes curl fail-fast on HTTP errors so we don't unzip
           # a 404 HTML page.
           file /tmp/protoc.zip
@@ -645,7 +657,7 @@ jobs:
         run: |
           pip install -e .
           # python-keepkey's setup.py doesn't list pytest as a dep;
-          # the existing python-integration-tests job runs inside a
+          # the build-and-test integration suite runs inside a
           # Docker image that has it baked. We're running on a vanilla
           # macos runner so we install it explicitly. Pin pytest-timeout
           # too — even though pytest-timeout can't break the dylib's C
@@ -679,7 +691,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════
 
   generate-test-report:
-    needs: [unit-tests, python-integration-tests]
+    needs: [build-and-test]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -738,7 +750,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════
 
   publish-emulator:
-    needs: [unit-tests, python-integration-tests, python-dylib-tests, build-arm-firmware]
+    needs: [build-and-test, python-dylib-tests, build-arm-firmware]
     if: >-
       github.event_name == 'workflow_dispatch' &&
       github.event.inputs.publish_emulator == 'true'

--- a/.github/workflows/mirror-base-image.yml
+++ b/.github/workflows/mirror-base-image.yml
@@ -41,8 +41,10 @@ jobs:
           SOURCE: ${{ inputs.source_image }}
         run: |
           set -euo pipefail
-          # Mirror under the bare image name (no tag) plus its tag, so the
-          # destination reads ghcr.io/<owner>/firmware:<tag>.
+          # Strip the source registry/namespace, keeping image name and tag,
+          # so the destination reads ghcr.io/<owner>/firmware:<tag>. One
+          # reference is pushed, not two -- no separate untagged or :latest
+          # push is performed.
           NAME="${SOURCE##*/}"          # kktech/firmware:v15 -> firmware:v15
           DEST="ghcr.io/${{ github.repository_owner }}/${NAME}"
           echo "mirroring ${SOURCE} -> ${DEST}"

--- a/.github/workflows/mirror-base-image.yml
+++ b/.github/workflows/mirror-base-image.yml
@@ -1,0 +1,53 @@
+# Mirrors the firmware build base image from Docker Hub into this org's GHCR.
+#
+# Why: every CI job that compiles anything starts by pulling ~650 MB of base
+# image. Served from Docker Hub that measured ~34s per job; GHCR serves it to
+# GitHub-hosted runners over the same network and does not apply Docker Hub's
+# anonymous pull limits.
+#
+# CI treats the mirror as optional -- ci.yml falls back to Docker Hub with a
+# warning if the pull fails -- so this workflow never becomes a hard
+# dependency of the build. Run it once to populate the mirror, and again
+# whenever BASE_IMAGE in ci.yml is bumped.
+name: Mirror base image
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_image:
+        description: 'Docker Hub image to mirror (must match BASE_IMAGE in ci.yml)'
+        required: true
+        type: string
+        default: 'kktech/firmware:v15'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull, tag and push
+        env:
+          SOURCE: ${{ inputs.source_image }}
+        run: |
+          set -euo pipefail
+          # Mirror under the bare image name (no tag) plus its tag, so the
+          # destination reads ghcr.io/<owner>/firmware:<tag>.
+          NAME="${SOURCE##*/}"          # kktech/firmware:v15 -> firmware:v15
+          DEST="ghcr.io/${{ github.repository_owner }}/${NAME}"
+          echo "mirroring ${SOURCE} -> ${DEST}"
+          docker pull "${SOURCE}"
+          docker tag  "${SOURCE}" "${DEST}"
+          docker push "${DEST}"
+          echo "::notice::Mirrored ${SOURCE} to ${DEST}"
+          echo "Set BASE_IMAGE_MIRROR in ci.yml to ${DEST} if it differs."

--- a/.github/workflows/mirror-base-image.yml
+++ b/.github/workflows/mirror-base-image.yml
@@ -41,12 +41,25 @@ jobs:
           SOURCE: ${{ inputs.source_image }}
         run: |
           set -euo pipefail
-          # Strip the source registry/namespace, keeping image name and tag,
-          # so the destination reads ghcr.io/<owner>/firmware:<tag>. One
-          # reference is pushed, not two -- no separate untagged or :latest
-          # push is performed.
-          NAME="${SOURCE##*/}"          # kktech/firmware:v15 -> firmware:v15
-          DEST="ghcr.io/${{ github.repository_owner }}/${NAME}"
+
+          # The source is constrained to the upstream base image, and the
+          # destination name is fixed rather than derived from the input.
+          #
+          # Both matter. ci.yml pulls BASE_IMAGE_MIRROR and builds firmware
+          # from it, so whatever lands at ghcr.io/<owner>/firmware:<tag> is
+          # trusted by every subsequent build. Deriving the destination from
+          # the input -- as this previously did, via ${SOURCE##*/} -- meant a
+          # dispatch of `anyone/firmware:v15` would resolve to that same
+          # destination and overwrite the image CI trusts. Dispatch needs
+          # write access, but "a writer can typo" and "a writer can silently
+          # replace the firmware build base" are different blast radii.
+          if [[ ! "${SOURCE}" =~ ^kktech/firmware:[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::refusing to mirror '${SOURCE}'. This workflow only mirrors kktech/firmware:<tag>, because ci.yml builds firmware from whatever it publishes."
+            exit 1
+          fi
+
+          TAG="${SOURCE##*:}"
+          DEST="ghcr.io/${{ github.repository_owner }}/firmware:${TAG}"
           echo "mirroring ${SOURCE} -> ${DEST}"
           docker pull "${SOURCE}"
           docker tag  "${SOURCE}" "${DEST}"

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ build
 .vscode/
 
 .claude/
+
+# cppcheck output (static-analysis writes this at repo root in CI)
+cppcheck_report.txt
+cppcheck_annotations.txt

--- a/scripts/emulator/docker-compose.yml
+++ b/scripts/emulator/docker-compose.yml
@@ -18,6 +18,10 @@ services:
       retries: 20
       start_period: 10s
   python-keepkey:
+    # Named so CI can build it once (`docker compose build python-keepkey`)
+    # and then `up` without --build, which would otherwise also force a
+    # rebuild of kkemu — the expensive one.
+    image: kktech/kkemu-tests:latest
     build:
       context: '../../'
       dockerfile: 'scripts/emulator/python-keepkey.Dockerfile'
@@ -29,6 +33,9 @@ services:
       kkemu:
         condition: service_healthy
   firmware-unit:
+    # Local-dev convenience only — CI runs `make xunit` directly against the
+    # image it just built, rather than paying for a second compose build.
+    image: kktech/kkemu:latest
     build:
       context: '../../'
       dockerfile: 'scripts/emulator/Dockerfile'

--- a/scripts/emulator/docker-compose.yml
+++ b/scripts/emulator/docker-compose.yml
@@ -13,10 +13,14 @@ services:
       - "127.0.0.1:5000:5000"
     healthcheck:
       test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:5000/health')\" || exit 1"]
-      interval: 3s
+      # The emulator is listening well inside a second; a 3s interval meant
+      # the integration suite sat waiting on poll granularity, not on the
+      # service. retries is raised alongside so the worst-case ceiling stays
+      # generous (40s) rather than shrinking to 20s with the faster interval.
+      interval: 1s
       timeout: 3s
-      retries: 20
-      start_period: 10s
+      retries: 40
+      start_period: 3s
   python-keepkey:
     # Named so CI can build it once (`docker compose build python-keepkey`)
     # and then `up` without --build, which would otherwise also force a

--- a/scripts/emulator/docker-compose.yml
+++ b/scripts/emulator/docker-compose.yml
@@ -15,8 +15,11 @@ services:
       test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:5000/health')\" || exit 1"]
       # The emulator is listening well inside a second; a 3s interval meant
       # the integration suite sat waiting on poll granularity, not on the
-      # service. retries is raised alongside so the worst-case ceiling stays
-      # generous (40s) rather than shrinking to 20s with the faster interval.
+      # service. retries is raised alongside so shortening the interval does
+      # not also shorten how long a slow start is tolerated -- a failing check
+      # can burn up to `timeout` before the next `interval`, so the ceiling is
+      # roughly start_period + retries * (timeout + interval), not
+      # retries * interval.
       interval: 1s
       timeout: 3s
       retries: 40

--- a/scripts/emulator/python-keepkey.Dockerfile
+++ b/scripts/emulator/python-keepkey.Dockerfile
@@ -1,4 +1,8 @@
-FROM kktech/firmware:v15
+# Split into a `deps` stage on purpose. The dependency layers below are
+# stable across commits and worth caching; the COPY layer beneath them ships
+# the whole build context and is invalidated by every commit, so exporting it
+# to a layer cache is pure cost with no possible hit. CI caches `deps` only.
+FROM kktech/firmware:v15 AS deps
 
 # Extra Python deps needed by tests that aren't in the shared base image.
 # - rlp + eth-keys + eth-utils: build the canonical EIP-1559 type-2 pre-image
@@ -9,6 +13,8 @@ FROM kktech/firmware:v15
 # linked against musl. Verified locally against the pinned image.
 RUN apk add --no-cache python3-dev gcc musl-dev
 RUN python3 -m pip install --no-cache-dir rlp eth-keys eth-utils pycryptodome
+
+FROM deps
 
 WORKDIR /kkemu
 COPY ./ /kkemu

--- a/scripts/emulator/python-keepkey.Dockerfile
+++ b/scripts/emulator/python-keepkey.Dockerfile
@@ -2,7 +2,12 @@
 # stable across commits and worth caching; the COPY layer beneath them ships
 # the whole build context and is invalidated by every commit, so exporting it
 # to a layer cache is pure cost with no possible hit. CI caches `deps` only.
-FROM kktech/firmware:v15 AS deps
+# Parameterised because buildx's docker-container driver resolves FROM
+# against a registry rather than the local daemon, so CI must be able to
+# point it at the GHCR mirror explicitly. The default keeps plain
+# `docker build` and local use working unchanged.
+ARG BASE_IMAGE=kktech/firmware:v15
+FROM ${BASE_IMAGE} AS deps
 
 # Extra Python deps needed by tests that aren't in the shared base image.
 # - rlp + eth-keys + eth-utils: build the canonical EIP-1559 type-2 pre-image


### PR DESCRIPTION
## Result

Measured, not projected. Baseline is run [33043154603](../../actions/runs/33043154603) on develop; final is run [33046944618](../../actions/runs/33046944618) on this branch.

| | baseline | this branch |
|---|---|---|
| **total wall clock** | **440s** | **183s** |
| jobs | 11 | 7 |
| emulator compiles per run | 2 | 1 |
| 845 MB artifact round-trip | every run | publish-dispatch only |

Per job (final run): `lint-format` 8s · `secret-scan` 21s · `static-analysis` 94s · `build-and-test` 155s · `build-arm-firmware` 81s · `python-dylib-tests` 58s.

The critical path used to be a single serial chain — `static-analysis 192s → build-emulator 175s → unit-tests 54s → report 9s`. It is now just `gate ~20s → build-and-test 155s`, with cppcheck running alongside.

## Why there was so much to reclaim

Layer-level timings from the baseline build log — the firmware compile was never the expensive part:

| layer | time |
|---|---|
| `pip install rlp eth-keys eth-utils pycryptodome` | 36.8s |
| `FROM kktech/firmware:v15` (base pull) | 34.4s |
| `apk add python3-dev gcc musl-dev` | ~8s |
| **`make -j` — the actual firmware compile** | **9.6s** |

The emulator image was compiled **twice** per run, an **845 MB** tarball was moved between two runners to run a **1s** suite (`unit-tests` spent 49s on transfer for 1s of testing), and cppcheck ran single-threaded while every build job waited on it.

## What changed

**Structural**
- Merge `build-emulator` + `unit-tests` + `python-integration-tests` into one `build-and-test`. Image built once, both suites run against it in place.
- Fold `generate-test-report` into `build-and-test` — every input was already on the runner.
- Fold `check-submodules` into `lint-format` — a 3s grep costing a full runner spin-up in the `needs` fan-in of every downstream job.

**Ungating**
- `static-analysis` no longer gates builds. cppcheck is advisory; it still fails the run, it just no longer delays it. `lint-format` and `secret-scan` stay in the gate.

**Caching**
- `type=gha` cache on the python-keepkey **`deps` stage only**. Cold 75s → warm **15s**.
- Base image mirrored to GHCR with Docker Hub fallback. Final run logs `base image: GHCR mirror`.
- Base-image tar cache deleted — it was ref-scoped, 13 copies held 8.4 GB of the 10 GB quota and evicted each other. Those caches have been purged (repo now 2 caches / 19 MB).
- pip + protoc caching in `python-dylib-tests`.

**Parallelism**
- cppcheck `--force -j8`. Measured locally, identical findings: `-j1` 77s → `-j4` 31s. `--force` kept deliberately — dropping it is ~5x faster again but stops the combinatorial `#ifdef` sweep.
- clang-format via `xargs -P`, installed from PyPI rather than the LLVM apt repo. `lint-format` 21s → 8s, and it now also does the submodule check.
- Submodule init `--jobs 4`, with `--recursive` scoped to `python-keepkey` only — `trezor-firmware` declares 9 nested submodules this build never uses.

**Waste**
- `concurrency` group cancels superseded PR runs; pushes to develop/master/release are never cancelled.
- Docs-only commits skip the workflow.
- `docker compose down -v` dropped; healthcheck interval 3s → 1s.

## Two bugs found and fixed in review of this branch's own CI runs

Both were introduced by this branch and caught by inspecting real runs. They are the reason for commits 3 and 4.

**1. The layer cache made things slower.** First attempt put `cache-to: mode=max` on the whole image. `.dockerignore` excludes only `**/.git` and `bin`, so `COPY ./ /kkemu` ships essentially the entire context — and it is invalidated by every commit, so it can never hit. The run spent **103.9s** in `exporting to GitHub Actions Cache` to save 36.8s of pip. Fixed by splitting the Dockerfile into a `deps` stage and caching that target alone.

**2. The pipeline went green while silently losing every integration test result.** Run 33046518184 uploaded no python results and no screenshots. The tests were fine — 379 passed, 58 skipped, 310 PNGs — but `make xunit` runs as root and leaves a root-owned `test-reports/firmware-unit/`; `docker cp` chmods what it extracts into, could not, and failed outright. `|| echo "WARN: ..."` swallowed it. When the suites were separate jobs the integration job always started with a pristine `test-reports/`. Fixed by chowning the bind mount, **and** by gating extraction so lost evidence fails the run instead of warning.

## Verification

Artifacts from the final run, checked against baseline:

| artifact | this branch | baseline |
|---|---|---|
| `junit.xml` | 437 tests / 58 skipped / 0 failures | 437 / 58 |
| `junit-screenshots.xml` | 85 / 8 skipped | 85 / 8 |
| screenshot PNGs | 310 | ~310 |
| `test-report.pdf` | present | present |
| dylib junit | 4 / 0 failures | 4 |

Also: every job resolves an identical submodule set to develop (checked programmatically); `actionlint` reports the same 5 pre-existing findings, zero new.

## For the reviewer

Two decisions worth your explicit attention:

1. **`paths-ignore` skips the workflow entirely** on docs-only commits rather than reporting a neutral check. Safe today because `develop` is unprotected and `master`'s only required context is `ci/circleci: emulator-build-test` — a job with no `.circleci/` config in this repo, so it can never report. **If you want CI jobs to become required checks, this needs rethinking first**, or docs PRs will become unmergeable.
2. **`static-analysis` no longer gates builds**, so compute is spent before cppcheck's verdict is known. Deliberate — it was the pole.

## Not done, deliberately

- **Collapsing the two pytest phases** — Phase 1 costs 3.3s, and merging it would run all 437 tests under `KEEPKEY_SCREENSHOT=1` instead of the 85-test SECTIONS filter, changing the 90-day screenshot artifact and the report input.
- **cppcheck `--cppcheck-build-dir` caching** — ~85s → ~30s, but that job is off the critical path now, so it buys billed minutes in exchange for incremental-analysis cache risk on a security tool. Better as its own change.
- **Ungating `python-dylib-tests`** — no wall-clock gain, and the gate stops a lint-failing commit spending 10x-billed macOS minutes.